### PR TITLE
chore(renovate): set minimumReleaseAge to 7 days

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "minimumReleaseAge": "7 days",
   "pep621": {
     "enabled": true
   }


### PR DESCRIPTION
## Summary

- Adds `minimumReleaseAge: "7 days"` to `renovate.json` so Renovate will wait 7 days after a package is published before opening a PR, reducing exposure to yanked or malicious releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)