### PR TITLE
build(docker): shrink images with multi-stage builds and slim runtime

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,29 @@
+# Version control
+.git
+.gitignore
+
+# Python
+.venv
+__pycache__
+*.pyc
+.pytest_cache
+.python-version
+
+# Build artifacts
+dist
+build
+*.egg-info
+
+# Local env / secrets
+.env
+.env.sample
+
+# Editor / tooling
+.claude
+.github
+docs
+images
+tests
+*.md
+*.txt
+LICENSE

--- a/.github/workflows/docker-build-laps.yml
+++ b/.github/workflows/docker-build-laps.yml
@@ -8,7 +8,7 @@ on:
       - 'v*'
     paths:
       - Dockerfile.laps
-      - race-requirements.txt
+      - .dockerignore
       - pyproject.toml
       - uv.lock
       - laps.py
@@ -18,7 +18,7 @@ on:
       - main
     paths:
       - Dockerfile.laps
-      - race-requirements.txt
+      - .dockerignore
       - pyproject.toml
       - uv.lock
       - laps.py

--- a/.github/workflows/docker-build-pi.yml
+++ b/.github/workflows/docker-build-pi.yml
@@ -8,7 +8,7 @@ on:
       - 'v*'
     paths:
       - Dockerfile.pi
-      - pi-requirements.txt
+      - .dockerignore
       - pyproject.toml
       - uv.lock
       - telem.py
@@ -19,7 +19,7 @@ on:
       - main
     paths:
       - Dockerfile.pi
-      - pi-requirements.txt
+      - .dockerignore
       - pyproject.toml
       - uv.lock
       - telem.py

--- a/Dockerfile.laps
+++ b/Dockerfile.laps
@@ -1,7 +1,12 @@
-FROM ghcr.io/astral-sh/uv:0.11.13-python3.14-trixie@sha256:e334c2bc6bef0aa02f86062d067982439dc834404e47a078e4e23af414bae3cf
+FROM ghcr.io/astral-sh/uv:0.11.16-python3.14-trixie@sha256:244c325aaa0c2474445996cdac081cd3af9bab8fbd31a27577cb27e80c682daa AS builder
 WORKDIR /app
+ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 COPY pyproject.toml uv.lock ./
-RUN uv sync --frozen --no-dev --group race
+RUN uv sync --frozen --no-dev --no-install-project --group race
+
+FROM python:3.14-slim-trixie@sha256:7d8de339aa8619f9b25e7d474d687ae4f6ef9704adad90a136af0f485adeccb7
+WORKDIR /app
+COPY --from=builder /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
 COPY laps.py .
 ENTRYPOINT ["python", "laps.py"]

--- a/Dockerfile.pi
+++ b/Dockerfile.pi
@@ -1,6 +1,11 @@
-FROM ghcr.io/astral-sh/uv:0.11.13-python3.14-trixie@sha256:8cc52137ffba0e08e8519f299e85c0ec4ed6c2ff8476e740bf32686bcb530fbd
+FROM ghcr.io/astral-sh/uv:0.11.16-python3.14-trixie@sha256:a03e6e1ff78b8748b97e2d4fa5861a51828076a2e41978835fe1119027c40a15 AS builder
 WORKDIR /app
+ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 COPY pyproject.toml uv.lock ./
-RUN uv sync --frozen --no-dev --group pi
+RUN uv sync --frozen --no-dev --no-install-project --group pi
+
+FROM python:3.14-slim-trixie@sha256:4701f9885ba369bf50a80ae4b5e1f637be3aa961dbb9b676d295e98fb2c01075
+WORKDIR /app
+COPY --from=builder /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
 COPY telem.py pisugar-monitor.py ./


### PR DESCRIPTION
## Summary
Optimizes the `laps` and `pi` Docker images using multi-stage builds. The venv is built in the `uv` image, then only `.venv` is copied into a `python:3.14-slim-trixie` runtime stage — dropping the `uv` binary and all of trixie's build/dev tooling from the shipped images.

uv is only a build-time tool here (the entrypoint runs `python` against the venv directly, never `uv run`), so it doesn't belong in the runtime layer. The `uv:python3.14-trixie` image is just the official `python:3.14-trixie` with uv added, so the venv is ABI-compatible with `python:3.14-slim-trixie`.

### Size results (true on-disk rootfs)
| Image | Before | After |
|---|---|---|
| laps | 1.31 GB | **319 MB** |
| pi | ~1.2 GB | **173 MB** |

Verified both images import their deps cleanly in the slim runtime (no missing shared libs), on each target arch.

## Also included
- **Pin runtime bases to per-arch SHA digests** (amd64 for `laps`, arm64 for `pi`), matching the existing uv base pinning convention. The pinned `python:3.14-slim-trixie` digests are ~11 days old, within the renovate `minimumReleaseAge` (7 days) window.
- **Bump uv** builder image `0.11.13` → `0.11.16` (newest release within the 7-day window).
- Add a `.dockerignore` to keep the build context small.
- Fix stale build-trigger path filters in the docker workflows: the removed `*-requirements.txt` paths (migrated to uv) are replaced with `.dockerignore`.

## Rollout
Deployments track `:latest`, so merging to main rebuilds and pushes the smaller `:latest` images automatically; deployments then pull + restart to pick them up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)