### PR TITLE
ci: self-heal stale PR images on weekly cleanup

### DIFF
--- a/.github/workflows/package-cleanup.yml
+++ b/.github/workflows/package-cleanup.yml
@@ -32,7 +32,7 @@ jobs:
             echo "No image found for ${{ matrix.package }} pr-${{ github.event.pull_request.number }}, skipping"
           fi
 
-  cleanup-untagged:
+  cleanup-scheduled:
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
     permissions:
@@ -50,4 +50,25 @@ jobs:
           while read version_id; do
             gh api --method DELETE /orgs/wot-lemons/packages/container/${{ matrix.package }}/versions/$version_id
             echo "Deleted untagged ${{ matrix.package }} version $version_id"
+          done
+
+      - name: Delete ${{ matrix.package }} PR images for closed PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Self-heal: prune pr-* images whose PR is no longer open. The
+          # cleanup-pr job only catches a clean "closed" event for a single PR
+          # number; superseded/autoclosed bot PRs can slip through, so sweep
+          # them here on the weekly schedule.
+          gh api /orgs/wot-lemons/packages/container/${{ matrix.package }}/versions --paginate \
+            --jq '.[] | select(.metadata.container.tags[]? | startswith("pr-")) | "\(.id) \(.metadata.container.tags[] | select(startswith("pr-")))"' | \
+          while read version_id tag; do
+            pr_number="${tag#pr-}"
+            state=$(gh api /repos/${{ github.repository }}/pulls/"$pr_number" --jq '.state' 2>/dev/null || echo "")
+            if [ "$state" = "closed" ]; then
+              gh api --method DELETE /orgs/wot-lemons/packages/container/${{ matrix.package }}/versions/"$version_id"
+              echo "Deleted ${{ matrix.package }} $tag (PR #$pr_number closed)"
+            else
+              echo "Keeping ${{ matrix.package }} $tag (PR #$pr_number state=${state:-unknown})"
+            fi
           done


### PR DESCRIPTION
## Summary

The `cleanup-pr` job only fires on a clean `pull_request: closed` event for a single PR number, so superseded/autoclosed bot PRs can leave their `pr-*` images behind in GHCR. This adds a scheduled step that prunes any `pr-*` image whose PR is no longer open, making cleanup self-healing.

## Changes

- Add a weekly scheduled step that deletes `pr-*` images for any PR that is closed (open PRs are kept).
- Rename the scheduled job `cleanup-untagged` → `cleanup-scheduled` to reflect its broader scope.

## Context

Found 11 orphaned `pr-*` images across `lemongrass-pi`/`lemongrass-laps` from closed/autoclosed Renovate PRs (pr-36/46/58/61/62/64) that the close-triggered job never caught. Those have already been pruned manually; this prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)