### PR TITLE
chore(renovate): use :semanticCommits preset instead of invalid :conventionalCommits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":conventionalCommits"
+    ":semanticCommits"
   ],
   "minimumReleaseAge": "7 days",
   "pep621": {


### PR DESCRIPTION
## What

Replaces the non-existent `:conventionalCommits` preset with `:semanticCommits` in `renovate.json`.

## Why

Renovate has no `:conventionalCommits` preset, so preset resolution fails at runtime and Renovate stops opening PRs. The local config validator only checks structure (not preset resolution), so it reports success despite the broken preset.

`:semanticCommits` sets `semanticCommits: "enabled"`, producing the intended conventional-commit-style messages (e.g. `chore(deps): ...`).

Same fix as WOT-Lemons/race-monitor-py#22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)