### PR TITLE
chore(renovate): enable docker:pinDigests preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":semanticCommits"
+    ":semanticCommits",
+    "docker:pinDigests"
   ],
   "minimumReleaseAge": "7 days",
   "pep621": {


### PR DESCRIPTION
## What

Adds the `docker:pinDigests` preset to `renovate.json`.

## Why

`Dockerfile.laps` and `Dockerfile.pi` already pin their base images to digests (`ghcr.io/astral-sh/uv` builder and the `python` runtime). This preset tells Renovate to **maintain and update those digests** going forward, while preserving the human-readable tag — images stay in the `image:tag@sha256:…` form so it's always clear what each image is.

`race-monitor-py` was intentionally left out: it has no Dockerfiles, compose files, or container images, so the preset has nothing to act on there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)