### PR TITLE
feat(laps): add class tag and class_position field to influx lap writes

### DIFF
--- a/.github/workflows/python-syntax.yml
+++ b/.github/workflows/python-syntax.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Check syntax and style
-        run: uv run --with flake8 flake8 .
+        run: uv run --with ruff ruff check .

--- a/laps.py
+++ b/laps.py
@@ -264,17 +264,27 @@ def old_race(ctx, opts):
     competitor_details = {}
     competitor_missing = True
 
-    # Send request for all session_ids from a race, including lap times
     for session_id in session_ids_for_race:
         logging.debug("Getting session details for %s including lap times.", session_id)
         session_details = ctx.client.results.session_details(session_id, include_lap_times=True)
-        sorted_competitors = session_details['Session']['SortedCompetitors'].copy()
+        sorted_competitors = [dict(c) for c in session_details['Session']['SortedCompetitors']]
 
+        session_laps = []
         for competitor in sorted_competitors:
             if competitor['Number'] == ctx.car_number:
                 competitor_missing = False
                 competitor_details = competitor
-                laps = laps + competitor['LapTimes'].copy()
+                session_laps = competitor['LapTimes'].copy()
+                laps = laps + [dict(lap) for lap in session_laps]
+
+        if opts.network_mode and session_laps:
+            flag_map = {0: "Green", 1: "Yellow", -1: "Finish"}
+            influx_laps = [
+                {**lap, 'FlagStatus': flag_map.get(lap['FlagStatus'], str(lap['FlagStatus']))}
+                for lap in session_laps
+            ]
+            class_name, class_positions = _resolve_class_historical(ctx.car_number, session_details)
+            push_influx(ctx, influx_laps, False, class_name=class_name, class_positions=class_positions)
 
     if competitor_missing:
         logging.info('Car %s not found', ctx.car_number)
@@ -282,7 +292,6 @@ def old_race(ctx, opts):
 
     print_rankings(sorted_competitors, False, opts.selected_class)
 
-    # Print competitor detail block
     print(
         f"Team: {competitor_details['FirstName']:<6}\t"
         f"Car Number: {competitor_details['Number']:<4}\t"
@@ -306,12 +315,10 @@ def old_race(ctx, opts):
         elif lap['FlagStatus'] == -1:
             lap['FlagStatus'] = "Finish"
 
-    # Create pandas dataframe and print without index to remove row numbers
     lap_time_df = pandas.json_normalize(laps)
     print(lap_time_df.to_string(index=False))
     print(UNDERLINE)
 
-    # Remove competitors (LOSERS) with no position
     for competitor in sorted_competitors:
         for key, value in competitor.items():
             try:
@@ -320,12 +327,8 @@ def old_race(ctx, opts):
             except ValueError:
                 value = None
 
-    if opts.network_mode:
-        push_influx(ctx, laps, False)
-
     if opts.save_file:
-        # Create filename and call function to write to CSV
-        filename = f"{competitor_details['Name']}-{ctx.race_id}-results"
+        filename = f"{competitor_details['FirstName']}-{ctx.race_id}-results"
         write_csv(filename, laps)
 
 

--- a/laps.py
+++ b/laps.py
@@ -514,6 +514,43 @@ def _resolve_class_historical(car_number, session_details):
     return class_name, class_positions
 
 
+def _resolve_class_live(client, race_id, car_number):
+    """Return (class_name, class_position) for the tracked car using current session state."""
+    response = client.live.get_session(race_id)
+    session = response['Session']
+    classes = session['Classes']
+    competitors = session['Competitors']
+
+    tracked = None
+    for competitor in competitors.values():
+        if competitor['Number'] == car_number:
+            tracked = competitor
+            break
+
+    if tracked is None:
+        return None, None
+
+    class_id = tracked['ClassID']
+    class_name = classes.get(class_id, {}).get('Description', class_id).replace(' ', '_')
+
+    try:
+        tracked_pos = int(tracked['Position'])
+    except (ValueError, TypeError):
+        return class_name, None
+
+    class_position = 1
+    for competitor in competitors.values():
+        if competitor['Number'] == car_number or competitor['ClassID'] != class_id:
+            continue
+        try:
+            if int(competitor['Position']) < tracked_pos:
+                class_position += 1
+        except (ValueError, TypeError):
+            pass
+
+    return class_name, class_position
+
+
 if __name__ == '__main__':
     try:
         main()

--- a/laps.py
+++ b/laps.py
@@ -425,7 +425,7 @@ def refresh_competitor(ctx):
     return laps
 
 
-def push_influx(ctx, laps, monitor_mode):
+def push_influx(ctx, laps, monitor_mode, class_name=None, class_positions=None):
     """Push lap data to InfluxDB."""
     logging.debug("Entering network mode.")
     logging.debug("Start epoch in seconds: %s", ctx.start_epoc)
@@ -436,28 +436,31 @@ def push_influx(ctx, laps, monitor_mode):
         logging.info("Writing laps to influx...")
 
     current_driver = "Driver" + str(ctx.car_number)
+    tag_str = f"class={class_name},driver={current_driver}" if class_name else f"driver={current_driver}"
 
-    # TODO: Concat driver from args
     write_success = True
     for lap in laps:
-        # Convert HH:MM:SS.MS to get time lap completed
         h, m, s = lap['TotalTime'].split(':')
         s, ms = s.split('.')
         lap_finish_ms = int(h) * 3600000 + int(m) * 60000 + int(s) * 1000 + int(ms)
         time_lap_completed_ms = start_epoc_ms + lap_finish_ms
         lap_timestamp = str(time_lap_completed_ms).replace(".", '')
 
-        # Convert lap time to milliseconds
         h, m, s = lap['LapTime'].split(':')
         s, ms = s.split('.')
         lap_time_ms = int(h) * 3600000 + int(m) * 60000 + int(s) * 1000 + int(ms)
 
-        data = [
-            f"laps{ctx.race_id},driver={current_driver} "
-            f"lap_no={lap['Lap']},lap_time={lap_time_ms},"
-            f"position={lap['Position']},flag_status=\"{lap['FlagStatus']}\" "
-            f"{lap_timestamp}"
-        ]
+        lap_num = int(lap['Lap'])
+        field_str = (
+            f"lap_no={lap_num},lap_time={lap_time_ms},"
+            f"position={lap['Position']},flag_status=\"{lap['FlagStatus']}\""
+        )
+        if class_positions is not None:
+            class_pos = class_positions.get(lap_num)
+            if class_pos is not None:
+                field_str += f",class_position={class_pos}"
+
+        data = [f"laps{ctx.race_id},{tag_str} {field_str} {lap_timestamp}"]
         logging.debug(data)
         try:
             ctx.write_api.write(bucket='laps_252/autogen', record=data, write_precision='ms')

--- a/laps.py
+++ b/laps.py
@@ -238,7 +238,12 @@ def live_race(ctx, opts):
     print(UNDERLINE)
 
     if opts.network_mode:
-        push_influx(ctx, laps, False)
+        class_name, class_position = _resolve_class_live(ctx.client, ctx.race_id, ctx.car_number)
+        class_positions = (
+            {int(lap['Lap']): class_position for lap in laps}
+            if class_position is not None else None
+        )
+        push_influx(ctx, laps, False, class_name=class_name, class_positions=class_positions)
 
     if opts.save_file:
         # Create filename and call function to write to CSV
@@ -411,7 +416,11 @@ def monitor_routine(ctx, laps, opts, _stop_event=None):
             print(current_competitor_lap_time_df.to_string(index=False, header=False))
             laps.append(current_competitor_lap_times[-1])
             if opts.network_mode:
-                push_influx(ctx, current_competitor_lap_times, True)
+                class_name, class_position = _resolve_class_live(
+                    ctx.client, ctx.race_id, ctx.car_number)
+                new_lap_num = int(current_competitor_lap_times[-1]['Lap'])
+                class_positions = {new_lap_num: class_position} if class_position is not None else None
+                push_influx(ctx, current_competitor_lap_times, True, class_name=class_name, class_positions=class_positions)
 
 
 def refresh_competitor(ctx):

--- a/laps.py
+++ b/laps.py
@@ -240,7 +240,7 @@ def live_race(ctx, opts):
     if opts.network_mode:
         class_name, class_position = _resolve_class_live(ctx.client, ctx.race_id, ctx.car_number)
         class_positions = (
-            {int(lap['Lap']): class_position for lap in laps}
+            {int(laps[-1]['Lap']): class_position}
             if class_position is not None else None
         )
         push_influx(ctx, laps, False, class_name=class_name, class_positions=class_positions)
@@ -424,7 +424,7 @@ def monitor_routine(ctx, laps, opts, _stop_event=None):
                 class_positions = (
                     {new_lap_num: class_position} if class_position is not None else None)
                 push_influx(
-                    ctx, current_competitor_lap_times, True,
+                    ctx, [current_competitor_lap_times[-1]], True,
                     class_name=class_name, class_positions=class_positions)
 
 
@@ -519,24 +519,26 @@ def _resolve_class_historical(car_number, session_details):
     class_name = (
         categories.get(tracked_category, {})
         .get('Name', tracked_category)
-        .replace(' ', '_')
+        .replace(' ', '_').replace(',', '').replace('=', '')
     )
 
-    class_positions = {}
-    for lap_num, tracked_pos in tracked_laps.items():
-        class_pos = 1
-        for competitor in competitors:
-            if competitor['Number'] == car_number or competitor['Category'] != tracked_category:
-                continue
-            for lap in competitor['LapTimes']:
-                try:
-                    if int(lap['Lap']) == lap_num:
-                        if int(lap['Position']) < tracked_pos:
-                            class_pos += 1
-                        break
-                except (ValueError, TypeError):
-                    pass
-        class_positions[lap_num] = class_pos
+    class_lap_positions = {}
+    for competitor in competitors:
+        if competitor['Number'] == car_number or competitor['Category'] != tracked_category:
+            continue
+        for lap in competitor['LapTimes']:
+            try:
+                lap_num = int(lap['Lap'])
+                if lap_num not in class_lap_positions:
+                    class_lap_positions[lap_num] = []
+                class_lap_positions[lap_num].append(int(lap['Position']))
+            except (ValueError, TypeError):
+                pass
+
+    class_positions = {
+        lap_num: 1 + sum(1 for pos in class_lap_positions.get(lap_num, []) if pos < tracked_pos)
+        for lap_num, tracked_pos in tracked_laps.items()
+    }
 
     return class_name, class_positions
 
@@ -544,6 +546,8 @@ def _resolve_class_historical(car_number, session_details):
 def _resolve_class_live(client, race_id, car_number):
     """Return (class_name, class_position) for the tracked car using current session state."""
     response = client.live.get_session(race_id)
+    if not response['Successful']:
+        return None, None
     session = response['Session']
     classes = session['Classes']
     competitors = session['Competitors']
@@ -558,7 +562,10 @@ def _resolve_class_live(client, race_id, car_number):
         return None, None
 
     class_id = tracked['ClassID']
-    class_name = classes.get(class_id, {}).get('Description', class_id).replace(' ', '_')
+    class_name = (
+        classes.get(class_id, {}).get('Description', class_id)
+        .replace(' ', '_').replace(',', '').replace('=', '')
+    )
 
     try:
         tracked_pos = int(tracked['Position'])

--- a/laps.py
+++ b/laps.py
@@ -289,7 +289,9 @@ def old_race(ctx, opts):
                 for lap in session_laps
             ]
             class_name, class_positions = _resolve_class_historical(ctx.car_number, session_details)
-            push_influx(ctx, influx_laps, False, class_name=class_name, class_positions=class_positions)
+            push_influx(
+                ctx, influx_laps, False,
+                class_name=class_name, class_positions=class_positions)
 
     if competitor_missing:
         logging.info('Car %s not found', ctx.car_number)
@@ -419,8 +421,11 @@ def monitor_routine(ctx, laps, opts, _stop_event=None):
                 class_name, class_position = _resolve_class_live(
                     ctx.client, ctx.race_id, ctx.car_number)
                 new_lap_num = int(current_competitor_lap_times[-1]['Lap'])
-                class_positions = {new_lap_num: class_position} if class_position is not None else None
-                push_influx(ctx, current_competitor_lap_times, True, class_name=class_name, class_positions=class_positions)
+                class_positions = (
+                    {new_lap_num: class_position} if class_position is not None else None)
+                push_influx(
+                    ctx, current_competitor_lap_times, True,
+                    class_name=class_name, class_positions=class_positions)
 
 
 def refresh_competitor(ctx):
@@ -448,7 +453,10 @@ def push_influx(ctx, laps, monitor_mode, class_name=None, class_positions=None):
         logging.info("Writing laps to influx...")
 
     current_driver = "Driver" + str(ctx.car_number)
-    tag_str = f"class={class_name},driver={current_driver}" if class_name else f"driver={current_driver}"
+    tag_str = (
+        f"class={class_name},driver={current_driver}"
+        if class_name else f"driver={current_driver}"
+    )
 
     write_success = True
     for lap in laps:
@@ -508,7 +516,11 @@ def _resolve_class_historical(car_number, session_details):
     if tracked_category is None:
         return None, {}
 
-    class_name = categories.get(tracked_category, {}).get('Name', tracked_category).replace(' ', '_')
+    class_name = (
+        categories.get(tracked_category, {})
+        .get('Name', tracked_category)
+        .replace(' ', '_')
+    )
 
     class_positions = {}
     for lap_num, tracked_pos in tracked_laps.items():

--- a/laps.py
+++ b/laps.py
@@ -13,6 +13,7 @@ import argparse
 import csv
 import logging
 import os
+from collections import defaultdict
 import sys
 import threading
 import time
@@ -237,7 +238,7 @@ def live_race(ctx, opts):
     print(lap_time_df.to_string(index=False))
     print(UNDERLINE)
 
-    if opts.network_mode:
+    if opts.network_mode and laps:
         class_name, class_position = _resolve_class_live(ctx.client, ctx.race_id, ctx.car_number)
         class_positions = (
             {int(laps[-1]['Lap']): class_position}
@@ -522,16 +523,13 @@ def _resolve_class_historical(car_number, session_details):
         .replace(' ', '_').replace(',', '').replace('=', '')
     )
 
-    class_lap_positions = {}
+    class_lap_positions = defaultdict(list)
     for competitor in competitors:
         if competitor['Number'] == car_number or competitor['Category'] != tracked_category:
             continue
         for lap in competitor['LapTimes']:
             try:
-                lap_num = int(lap['Lap'])
-                if lap_num not in class_lap_positions:
-                    class_lap_positions[lap_num] = []
-                class_lap_positions[lap_num].append(int(lap['Position']))
+                class_lap_positions[int(lap['Lap'])].append(int(lap['Position']))
             except (ValueError, TypeError):
                 pass
 

--- a/laps.py
+++ b/laps.py
@@ -472,6 +472,48 @@ def push_influx(ctx, laps, monitor_mode):
     print(UNDERLINE)
 
 
+def _resolve_class_historical(car_number, session_details):
+    """Return (class_name, {lap_num: class_position}) for the tracked car."""
+    session = session_details['Session']
+    competitors = session['SortedCompetitors']
+    categories = session['Categories']
+
+    tracked_category = None
+    tracked_laps = {}
+    for competitor in competitors:
+        if competitor['Number'] == car_number:
+            tracked_category = competitor['Category']
+            for lap in competitor['LapTimes']:
+                try:
+                    tracked_laps[int(lap['Lap'])] = int(lap['Position'])
+                except (ValueError, TypeError):
+                    pass
+            break
+
+    if tracked_category is None:
+        return None, {}
+
+    class_name = categories.get(tracked_category, {}).get('Name', tracked_category).replace(' ', '_')
+
+    class_positions = {}
+    for lap_num, tracked_pos in tracked_laps.items():
+        class_pos = 1
+        for competitor in competitors:
+            if competitor['Number'] == car_number or competitor['Category'] != tracked_category:
+                continue
+            for lap in competitor['LapTimes']:
+                try:
+                    if int(lap['Lap']) == lap_num:
+                        if int(lap['Position']) < tracked_pos:
+                            class_pos += 1
+                        break
+                except (ValueError, TypeError):
+                    pass
+        class_positions[lap_num] = class_pos
+
+    return class_name, class_positions
+
+
 if __name__ == '__main__':
     try:
         main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,4 @@ dependencies = [
 [dependency-groups]
 pi = ["obd~=0.7"]
 race = ["pandas~=2.3"]
+dev = ["pytest>=8"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,10 @@ dependencies = [
     "race-monitor>=0.5.1,<1",
 ]
 
+[tool.ruff]
+line-length = 100
+exclude = [".git", "__pycache__", "build", "dist", ".venv"]
+
 [dependency-groups]
 pi = ["obd~=0.7"]
 race = ["pandas~=2.3"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 requires-python = ">=3.14"
 dependencies = [
     "influxdb-client~=1.47",
-    "race-monitor>=0.3,<1",
+    "race-monitor>=0.5.1,<1",
 ]
 
 [dependency-groups]

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -218,3 +218,43 @@ class TestResolveClassLive:
         class_name, class_pos = _mod._resolve_class_live(client, '999', '99')
         assert class_name is None
         assert class_pos is None
+
+
+class TestPushInfluxClassInfo:
+    def _laps(self):
+        return [{'Lap': '1', 'LapTime': '0:01:30.000', 'Position': '3',
+                 'FlagStatus': 'Green', 'TotalTime': '0:01:30.000'}]
+
+    def _ctx(self):
+        write_api = MagicMock()
+        ctx = _mod.RaceContext('999', '42', MagicMock(), write_api, 0)
+        return ctx, write_api
+
+    def _record(self, write_api):
+        return write_api.write.call_args[1]['record'][0]
+
+    def test_includes_class_tag_when_provided(self):
+        ctx, write_api = self._ctx()
+        _mod.push_influx(ctx, self._laps(), False, class_name='A', class_positions={1: 2})
+        assert 'class=A' in self._record(write_api)
+
+    def test_class_tag_before_driver_tag(self):
+        ctx, write_api = self._ctx()
+        _mod.push_influx(ctx, self._laps(), False, class_name='A', class_positions={1: 1})
+        record = self._record(write_api)
+        assert record.index('class=') < record.index('driver=')
+
+    def test_includes_class_position_field_when_provided(self):
+        ctx, write_api = self._ctx()
+        _mod.push_influx(ctx, self._laps(), False, class_name='A', class_positions={1: 2})
+        assert 'class_position=2' in self._record(write_api)
+
+    def test_omits_class_tag_when_not_provided(self):
+        ctx, write_api = self._ctx()
+        _mod.push_influx(ctx, self._laps(), False)
+        assert 'class=' not in self._record(write_api)
+
+    def test_omits_class_position_when_not_provided(self):
+        ctx, write_api = self._ctx()
+        _mod.push_influx(ctx, self._laps(), False)
+        assert 'class_position' not in self._record(write_api)

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -312,7 +312,9 @@ class TestOldRaceClassWiring:
         opts = _mod.RaceOptions(network_mode=True)
         ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
         ctx.client.results.session_details.return_value = self._session_details()
-        with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})) as mock_resolve:
+        with patch.object(
+            _mod, '_resolve_class_historical', return_value=('A', {1: 1})
+        ) as mock_resolve:
             with patch.object(_mod, 'push_influx'):
                 with patch.object(_mod, 'print_rankings'):
                     _mod.old_race(ctx, opts)

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -317,3 +317,66 @@ class TestOldRaceClassWiring:
             with patch.object(_mod, 'print_rankings'):
                 _mod.old_race(ctx, opts)
         mock_resolve.assert_not_called()
+
+
+class TestLiveClassWiring:
+    def _make_ctx(self):
+        write_api = MagicMock()
+        ctx = _mod.RaceContext('999', '42', MagicMock(), write_api, 0)
+        ctx.client.live.get_racer.return_value = {
+            'Successful': True,
+            'Details': {
+                'Competitor': {
+                    'RacerID': 'r1', 'Number': '42', 'ClassID': 'A',
+                    'Position': '3', 'Laps': '1', 'TotalTime': '0:01:30.000',
+                    'BestPosition': '3', 'BestLap': '1', 'BestLapTime': '0:01:30.000',
+                    'LastLapTime': '0:01:30.000', 'Transponder': '',
+                    'FirstName': 'Jane', 'LastName': 'Doe',
+                    'Nationality': '', 'AdditionalData': '',
+                },
+                'Laps': [
+                    {'Lap': '1', 'LapTime': '0:01:30.000', 'Position': '3',
+                     'FlagStatus': '0', 'TotalTime': '0:01:30.000'},
+                ],
+            },
+        }
+        return ctx
+
+    def test_live_race_calls_resolve_class_live(self):
+        ctx = self._make_ctx()
+        opts = _mod.RaceOptions(network_mode=True)
+        with patch.object(_mod, '_resolve_class_live', return_value=('A', 1)) as mock_resolve:
+            with patch.object(_mod, 'push_influx'):
+                with patch.object(_mod, 'print_rankings'):
+                    _mod.live_race(ctx, opts)
+        mock_resolve.assert_called_once_with(ctx.client, ctx.race_id, ctx.car_number)
+
+    def test_live_race_passes_class_name_to_push_influx(self):
+        ctx = self._make_ctx()
+        opts = _mod.RaceOptions(network_mode=True)
+        with patch.object(_mod, '_resolve_class_live', return_value=('A', 2)):
+            with patch.object(_mod, 'push_influx') as mock_push:
+                with patch.object(_mod, 'print_rankings'):
+                    _mod.live_race(ctx, opts)
+        _, kwargs = mock_push.call_args
+        assert kwargs.get('class_name') == 'A'
+
+    def test_monitor_routine_calls_resolve_class_live_on_new_lap(self):
+        ctx = self._make_ctx()
+        opts = _mod.RaceOptions(network_mode=True, interval=30)
+        existing_laps = [
+            {'Lap': '1', 'LapTime': '0:01:30.000', 'Position': '3',
+             'FlagStatus': '0', 'TotalTime': '0:01:30.000'},
+        ]
+        new_laps = existing_laps + [
+            {'Lap': '2', 'LapTime': '0:01:31.000', 'Position': '3',
+             'FlagStatus': '0', 'TotalTime': '0:03:01.000'},
+        ]
+        # wait() returns False first (enter loop body), then True (stop)
+        mock_stop = MagicMock()
+        mock_stop.wait.side_effect = [False, True]
+        with patch.object(_mod, 'refresh_competitor', return_value=new_laps):
+            with patch.object(_mod, '_resolve_class_live', return_value=('A', 1)) as mock_resolve:
+                with patch.object(_mod, 'push_influx'):
+                    _mod.monitor_routine(ctx, existing_laps, opts, _stop_event=mock_stop)
+        mock_resolve.assert_called_once_with(ctx.client, ctx.race_id, ctx.car_number)

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -135,3 +135,20 @@ class TestResolveClassHistorical:
         sd['Session']['Categories'] = {}
         class_name, _ = _mod._resolve_class_historical('42', sd)
         assert class_name == '9'
+
+    def test_three_cars_tracked_car_in_middle(self):
+        # tracked laps: pos3, pos2 — one ahead at pos1 — one behind at pos8
+        sd = self._session('42', '1', others=[('10', [(1, 1), (2, 1)]), ('99', [(1, 8), (2, 8)])])
+        _, positions = _mod._resolve_class_historical('42', sd)
+        assert positions[1] == 2
+        assert positions[2] == 2
+
+    def test_classmate_missing_lap_not_counted_as_ahead(self):
+        # tracked car completes lap 2, class-mate only has lap 1 data
+        # class-mate's absence from lap 2 should not bump tracked car's class_pos
+        sd = self._session('42', '1', others=[('99', [(1, 1)])])  # 99 only has lap 1
+        _, positions = _mod._resolve_class_historical('42', sd)
+        # at lap 1: 99 is at pos1 < tracked pos3 → tracked is class_pos 2
+        assert positions[1] == 2
+        # at lap 2: 99 has no lap 2 record → not counted → tracked is class_pos 1
+        assert positions[2] == 1

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -57,3 +57,81 @@ class TestWriteCSV:
         combined = "".join(written)
         assert "Lap" in combined
         assert "LapTime" in combined
+
+
+class TestResolveClassHistorical:
+    def _session(self, tracked_number, cat_id, others=None):
+        """others: list of (car_number, [(lap_num, position), ...]) for same-class cars."""
+        def _make_competitor(number, laps_data, comp_id):
+            return {
+                'Number': number, 'Category': cat_id,
+                'ID': comp_id, 'SessionID': 1, 'RaceID': 1,
+                'FirstName': '', 'LastName': '', 'Position': '', 'Laps': '',
+                'LastLapTime': '', 'BestPosition': '', 'BestLap': '',
+                'BestLapTime': '', 'TotalTime': '', 'Transponder': '',
+                'Nationality': '', 'AdditionalData': '',
+                'LapTimes': [
+                    {'Lap': str(lap), 'LapTime': '0:01:30.000',
+                     'Position': str(pos), 'FlagStatus': 0,
+                     'TotalTime': '0:01:30.000'}
+                    for lap, pos in laps_data
+                ],
+            }
+
+        competitors = [_make_competitor(tracked_number, [(1, 3), (2, 2)], 1)]
+        for i, (num, laps_data) in enumerate(others or []):
+            competitors.append(_make_competitor(num, laps_data, i + 2))
+
+        return {
+            'Successful': True,
+            'Session': {
+                'ID': 1, 'RaceID': 1, 'Name': 'S1', 'SessionDate': '',
+                'SessionTime': '', 'SortMode': '', 'CategoryString': '',
+                'ResultsProcessorVersion': 1, 'SessionStartDateEpoc': 0,
+                'Categories': {cat_id: {'ID': cat_id, 'Name': 'A'}},
+                'SortedCompetitors': competitors,
+            },
+        }
+
+    def test_returns_class_name(self):
+        sd = self._session('42', '1')
+        class_name, _ = _mod._resolve_class_historical('42', sd)
+        assert class_name == 'A'
+
+    def test_class_name_spaces_replaced_with_underscores(self):
+        sd = self._session('42', '1')
+        sd['Session']['Categories']['1']['Name'] = 'Super Street'
+        class_name, _ = _mod._resolve_class_historical('42', sd)
+        assert class_name == 'Super_Street'
+
+    def test_only_car_in_class_is_always_position_1(self):
+        sd = self._session('42', '1')
+        _, positions = _mod._resolve_class_historical('42', sd)
+        assert positions[1] == 1
+        assert positions[2] == 1
+
+    def test_two_cars_tracked_car_ahead(self):
+        # tracked: lap1=pos3, lap2=pos2 — other: lap1=pos5, lap2=pos4
+        sd = self._session('42', '1', others=[('99', [(1, 5), (2, 4)])])
+        _, positions = _mod._resolve_class_historical('42', sd)
+        assert positions[1] == 1
+        assert positions[2] == 1
+
+    def test_two_cars_tracked_car_behind(self):
+        # tracked: lap1=pos3, lap2=pos2 — other: lap1=pos1, lap2=pos1
+        sd = self._session('42', '1', others=[('99', [(1, 1), (2, 1)])])
+        _, positions = _mod._resolve_class_historical('42', sd)
+        assert positions[1] == 2
+        assert positions[2] == 2
+
+    def test_car_not_in_session_returns_none_and_empty(self):
+        sd = self._session('42', '1')
+        class_name, positions = _mod._resolve_class_historical('99', sd)
+        assert class_name is None
+        assert positions == {}
+
+    def test_unknown_category_falls_back_to_raw_id(self):
+        sd = self._session('42', '9')
+        sd['Session']['Categories'] = {}
+        class_name, _ = _mod._resolve_class_historical('42', sd)
+        assert class_name == '9'

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -152,3 +152,69 @@ class TestResolveClassHistorical:
         assert positions[1] == 2
         # at lap 2: 99 has no lap 2 record → not counted → tracked is class_pos 1
         assert positions[2] == 1
+
+
+class TestResolveClassLive:
+    def _make_client(self, car_number, class_id, car_position, others=None):
+        """others: list of (car_number, class_id, position)."""
+        competitors = {
+            'r1': {
+                'RacerID': 'r1', 'Number': car_number, 'ClassID': class_id,
+                'Position': str(car_position), 'Transponder': '', 'FirstName': '',
+                'LastName': '', 'Nationality': '', 'AdditionalData': '',
+                'Laps': '', 'TotalTime': '', 'BestPosition': '',
+                'BestLap': '', 'BestLapTime': '', 'LastLapTime': '',
+            }
+        }
+        for i, (num, cid, pos) in enumerate(others or []):
+            competitors[f'r{i + 2}'] = {
+                'RacerID': f'r{i + 2}', 'Number': num, 'ClassID': cid,
+                'Position': str(pos), 'Transponder': '', 'FirstName': '',
+                'LastName': '', 'Nationality': '', 'AdditionalData': '',
+                'Laps': '', 'TotalTime': '', 'BestPosition': '',
+                'BestLap': '', 'BestLapTime': '', 'LastLapTime': '',
+            }
+        client = MagicMock()
+        client.live.get_session.return_value = {
+            'Successful': True,
+            'Session': {
+                'RunNumber': '', 'SessionName': '', 'TrackName': '',
+                'TrackLength': '', 'CurrentTime': '', 'SessionTime': '',
+                'TimeToGo': '', 'LapsToGo': '', 'FlagStatus': '', 'SortMode': '',
+                'Classes': {class_id: {'ClassID': class_id, 'Description': 'A'}},
+                'Competitors': competitors,
+            },
+        }
+        return client
+
+    def test_returns_class_name(self):
+        client = self._make_client('42', 'classA', 3)
+        client.live.get_session.return_value['Session']['Classes']['classA']['Description'] = 'A'
+        class_name, _ = _mod._resolve_class_live(client, '999', '42')
+        assert class_name == 'A'
+
+    def test_only_car_in_class_is_position_1(self):
+        client = self._make_client('42', 'classA', 3)
+        _, class_pos = _mod._resolve_class_live(client, '999', '42')
+        assert class_pos == 1
+
+    def test_tracked_car_ahead_in_class(self):
+        client = self._make_client('42', 'classA', 3, others=[('99', 'classA', 5)])
+        _, class_pos = _mod._resolve_class_live(client, '999', '42')
+        assert class_pos == 1
+
+    def test_tracked_car_behind_in_class(self):
+        client = self._make_client('42', 'classA', 5, others=[('99', 'classA', 1)])
+        _, class_pos = _mod._resolve_class_live(client, '999', '42')
+        assert class_pos == 2
+
+    def test_different_class_not_counted(self):
+        client = self._make_client('42', 'classA', 5, others=[('99', 'classB', 1)])
+        _, class_pos = _mod._resolve_class_live(client, '999', '42')
+        assert class_pos == 1
+
+    def test_car_not_found_returns_none_none(self):
+        client = self._make_client('42', 'classA', 3)
+        class_name, class_pos = _mod._resolve_class_live(client, '999', '99')
+        assert class_name is None
+        assert class_pos is None

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -104,6 +104,13 @@ class TestResolveClassHistorical:
         class_name, _ = _mod._resolve_class_historical('42', sd)
         assert class_name == 'Super_Street'
 
+    def test_class_name_special_chars_stripped(self):
+        sd = self._session('42', '1')
+        sd['Session']['Categories']['1']['Name'] = 'GT3,Pro=Am'
+        class_name, _ = _mod._resolve_class_historical('42', sd)
+        assert ',' not in class_name
+        assert '=' not in class_name
+
     def test_only_car_in_class_is_always_position_1(self):
         sd = self._session('42', '1')
         _, positions = _mod._resolve_class_historical('42', sd)
@@ -218,6 +225,21 @@ class TestResolveClassLive:
         class_name, class_pos = _mod._resolve_class_live(client, '999', '99')
         assert class_name is None
         assert class_pos is None
+
+    def test_api_failure_returns_none_none(self):
+        client = MagicMock()
+        client.live.get_session.return_value = {'Successful': False}
+        class_name, class_pos = _mod._resolve_class_live(client, '999', '42')
+        assert class_name is None
+        assert class_pos is None
+
+    def test_class_name_special_chars_stripped(self):
+        client = self._make_client('42', 'classA', 1)
+        client.live.get_session.return_value['Session']['Classes']['classA']['Description'] = (
+            'GT3,Pro=Am')
+        class_name, _ = _mod._resolve_class_live(client, '999', '42')
+        assert ',' not in class_name
+        assert '=' not in class_name
 
 
 class TestPushInfluxClassInfo:
@@ -360,6 +382,43 @@ class TestLiveClassWiring:
                     _mod.live_race(ctx, opts)
         _, kwargs = mock_push.call_args
         assert kwargs.get('class_name') == 'A'
+
+    def test_live_race_class_positions_only_has_last_lap(self):
+        ctx = self._make_ctx()
+        ctx.client.live.get_racer.return_value['Details']['Laps'] = [
+            {'Lap': '1', 'LapTime': '0:01:30.000', 'Position': '3',
+             'FlagStatus': '0', 'TotalTime': '0:01:30.000'},
+            {'Lap': '2', 'LapTime': '0:01:31.000', 'Position': '2',
+             'FlagStatus': '0', 'TotalTime': '0:03:01.000'},
+        ]
+        opts = _mod.RaceOptions(network_mode=True)
+        with patch.object(_mod, '_resolve_class_live', return_value=('A', 2)):
+            with patch.object(_mod, 'push_influx') as mock_push:
+                with patch.object(_mod, 'print_rankings'):
+                    _mod.live_race(ctx, opts)
+        _, kwargs = mock_push.call_args
+        class_positions = kwargs.get('class_positions')
+        assert class_positions == {2: 2}
+
+    def test_monitor_routine_push_influx_receives_only_new_lap(self):
+        ctx = self._make_ctx()
+        opts = _mod.RaceOptions(network_mode=True, interval=30)
+        existing_laps = [
+            {'Lap': '1', 'LapTime': '0:01:30.000', 'Position': '3',
+             'FlagStatus': '0', 'TotalTime': '0:01:30.000'},
+        ]
+        new_laps = existing_laps + [
+            {'Lap': '2', 'LapTime': '0:01:31.000', 'Position': '3',
+             'FlagStatus': '0', 'TotalTime': '0:03:01.000'},
+        ]
+        mock_stop = MagicMock()
+        mock_stop.wait.side_effect = [False, True]
+        with patch.object(_mod, 'refresh_competitor', return_value=new_laps):
+            with patch.object(_mod, '_resolve_class_live', return_value=('A', 1)):
+                with patch.object(_mod, 'push_influx') as mock_push:
+                    _mod.monitor_routine(ctx, existing_laps, opts, _stop_event=mock_stop)
+        laps_arg = mock_push.call_args[0][1]
+        assert laps_arg == [new_laps[-1]]
 
     def test_monitor_routine_calls_resolve_class_live_on_new_lap(self):
         ctx = self._make_ctx()

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -258,3 +258,62 @@ class TestPushInfluxClassInfo:
         ctx, write_api = self._ctx()
         _mod.push_influx(ctx, self._laps(), False)
         assert 'class_position' not in self._record(write_api)
+
+
+class TestOldRaceClassWiring:
+    def _session_details(self, car_number='42', cat_id='1', cat_name='A'):
+        return {
+            'Successful': True,
+            'Session': {
+                'ID': 1, 'RaceID': 999, 'Name': 'S1', 'SessionDate': '',
+                'SessionTime': '', 'SortMode': '', 'CategoryString': '',
+                'ResultsProcessorVersion': 1, 'SessionStartDateEpoc': 0,
+                'Categories': {cat_id: {'ID': cat_id, 'Name': cat_name}},
+                'SortedCompetitors': [{
+                    'Number': car_number, 'Category': cat_id,
+                    'ID': 1, 'SessionID': 1, 'RaceID': 999,
+                    'FirstName': 'Jane', 'LastName': 'Doe',
+                    'Position': '1', 'Laps': '1', 'LastLapTime': '',
+                    'BestPosition': '1', 'BestLap': '1',
+                    'BestLapTime': '0:01:30.000', 'TotalTime': '0:01:30.000',
+                    'Transponder': '', 'Nationality': '', 'AdditionalData': '',
+                    'LapTimes': [
+                        {'Lap': '1', 'LapTime': '0:01:30.000', 'Position': '1',
+                         'FlagStatus': 0, 'TotalTime': '0:01:30.000'},
+                    ],
+                }],
+            },
+        }
+
+    def test_calls_resolve_class_historical_per_session(self):
+        ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
+        opts = _mod.RaceOptions(network_mode=True)
+        ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
+        ctx.client.results.session_details.return_value = self._session_details()
+        with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})) as mock_resolve:
+            with patch.object(_mod, 'push_influx'):
+                with patch.object(_mod, 'print_rankings'):
+                    _mod.old_race(ctx, opts)
+        mock_resolve.assert_called_once_with('42', self._session_details())
+
+    def test_passes_class_name_to_push_influx(self):
+        ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
+        opts = _mod.RaceOptions(network_mode=True)
+        ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
+        ctx.client.results.session_details.return_value = self._session_details()
+        with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
+            with patch.object(_mod, 'push_influx') as mock_push:
+                with patch.object(_mod, 'print_rankings'):
+                    _mod.old_race(ctx, opts)
+        _, kwargs = mock_push.call_args
+        assert kwargs.get('class_name') == 'A'
+
+    def test_no_network_mode_skips_resolve(self):
+        ctx = _mod.RaceContext('999', '42', MagicMock(), None, 0)
+        opts = _mod.RaceOptions(network_mode=False)
+        ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
+        ctx.client.results.session_details.return_value = self._session_details()
+        with patch.object(_mod, '_resolve_class_historical') as mock_resolve:
+            with patch.object(_mod, 'print_rankings'):
+                _mod.old_race(ctx, opts)
+        mock_resolve.assert_not_called()

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -385,20 +385,30 @@ class TestLiveClassWiring:
 
     def test_live_race_class_positions_only_has_last_lap(self):
         ctx = self._make_ctx()
-        ctx.client.live.get_racer.return_value['Details']['Laps'] = [
+        two_laps = [
             {'Lap': '1', 'LapTime': '0:01:30.000', 'Position': '3',
              'FlagStatus': '0', 'TotalTime': '0:01:30.000'},
             {'Lap': '2', 'LapTime': '0:01:31.000', 'Position': '2',
              'FlagStatus': '0', 'TotalTime': '0:03:01.000'},
         ]
+        ctx.client.live.get_racer.return_value['Details']['Laps'] = two_laps
         opts = _mod.RaceOptions(network_mode=True)
         with patch.object(_mod, '_resolve_class_live', return_value=('A', 2)):
             with patch.object(_mod, 'push_influx') as mock_push:
                 with patch.object(_mod, 'print_rankings'):
                     _mod.live_race(ctx, opts)
-        _, kwargs = mock_push.call_args
-        class_positions = kwargs.get('class_positions')
-        assert class_positions == {2: 2}
+        args, kwargs = mock_push.call_args
+        assert args[1] == two_laps
+        assert kwargs.get('class_positions') == {2: 2}
+
+    def test_live_race_skips_influx_when_no_laps(self):
+        ctx = self._make_ctx()
+        ctx.client.live.get_racer.return_value['Details']['Laps'] = []
+        opts = _mod.RaceOptions(network_mode=True)
+        with patch.object(_mod, 'push_influx') as mock_push:
+            with patch.object(_mod, 'print_rankings'):
+                _mod.live_race(ctx, opts)
+        mock_push.assert_not_called()
 
     def test_monitor_routine_push_influx_receives_only_new_lap(self):
         ctx = self._make_ctx()

--- a/uv.lock
+++ b/uv.lock
@@ -86,11 +86,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.14"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/b1/efac073e0c297ecf2fb33c346989a529d4e19164f1759102dee5953ee17e/idna-3.14.tar.gz", hash = "sha256:466d810d7a2cc1022bea9b037c39728d51ae7dad40d480fc9b7d7ecf98ba8ee3", size = 198272, upload-time = "2026-05-10T20:32:15.935Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/3c/3f62dee257eb3d6b2c1ef2a09d36d9793c7111156a73b5654d2c2305e5ce/idna-3.14-py3-none-any.whl", hash = "sha256:e677eaf072e290f7b725f9acf0b3a2bd55f9fd6f7c70abe5f0e34823d0accf69", size = 72184, upload-time = "2026-05-10T20:32:14.295Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -128,7 +128,7 @@ race = [
 [package.metadata]
 requires-dist = [
     { name = "influxdb-client", specifier = "~=1.47" },
-    { name = "race-monitor", specifier = ">=0.3,<1" },
+    { name = "race-monitor", specifier = ">=0.5.1,<1" },
 ]
 
 [package.metadata.requires-dev]
@@ -260,14 +260,15 @@ wheels = [
 
 [[package]]
 name = "race-monitor"
-version = "0.4.0"
+version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
+    { name = "idna" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/52/1f1a785f6132d0cee40a1a330e2c9b34533a6b74fddebd0c48b5e6bdfb04/race_monitor-0.4.0.tar.gz", hash = "sha256:86118f8aedcdc69745c5829198a808b87fd582e2433918ef33411d3da694e5d6", size = 42714, upload-time = "2026-05-11T00:52:54.051Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/f4/9a8c144fa040a1f499597fccde38082c6d140df63f3e0fe69bbe5fed0002/race_monitor-0.5.1.tar.gz", hash = "sha256:89faa62e2eb7ae66dc635156f64ed13dbc007a8ab22350374602aab00964e74a", size = 10815, upload-time = "2026-06-06T17:57:23.776Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/d6/b6726c00407b2f14cf1749402b36dd16e2bacd85a5682a20111be80f597b/race_monitor-0.4.0-py3-none-any.whl", hash = "sha256:3053851b5dec56da7586988ec5db4f054e4fe48c81120c9273d81c15f931fc6e", size = 13122, upload-time = "2026-05-11T00:52:52.577Z" },
+    { url = "https://files.pythonhosted.org/packages/61/f8/5e4807b75a9f67d2b13b79bec1e4e559a514c123121ad1389279093372c8/race_monitor-0.5.1-py3-none-any.whl", hash = "sha256:c5dbf91cd0d3f3c1e0eadb571a388e3f765a5cadb2904db39ce14072f9f58863", size = 15973, upload-time = "2026-06-06T17:57:22.486Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -24,6 +24,15 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "flexcache"
 version = "0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -109,6 +118,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "lemongrass"
 version = "0.0.0"
 source = { virtual = "." }
@@ -118,6 +136,9 @@ dependencies = [
 ]
 
 [package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
 pi = [
     { name = "obd" },
 ]
@@ -132,6 +153,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8" }]
 pi = [{ name = "obd", specifier = "~=0.7" }]
 race = [{ name = "pandas", specifier = "~=2.3" }]
 
@@ -175,6 +197,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f9/37/3ae6fd261f911fb3292249a876061786a54486cd5899d49b1406c3483921/obd-0.7.3.tar.gz", hash = "sha256:27b8f043376ca700edb98bf5216e2912295ecde0e735b260999f2d9ddf342522", size = 72967, upload-time = "2025-04-07T05:21:25.892Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/47/8ef35b33fc80db40d4a42632b0a22b2b2ed7671832dbc9bda9d912a826b0/obd-0.7.3-py3-none-any.whl", hash = "sha256:f26da700f13683a27855e6a439db72f7025fff6f1fd47ad4c6c33089d9fe7cab", size = 72130, upload-time = "2025-04-07T05:21:24.094Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]
@@ -229,12 +260,46 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
 name = "pyserial"
 version = "3.5"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1e/7d/ae3f0a63f41e4d2f6cb66a5b57197850f919f59e558159a4dd3a818f5082/pyserial-3.5.tar.gz", hash = "sha256:3c77e014170dfffbd816e6ffc205e9842efb10be9f58ec16d3e8675b4925cddb", size = 159125, upload-time = "2020-11-23T03:59:15.045Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/bc/587a445451b253b285629263eb51c2d8e9bcea4fc97826266d186f96f558/pyserial-3.5-py2.py3-none-any.whl", hash = "sha256:c4451db6ba391ca6ca299fb3ec7bae67a5c55dde170964c7a14ceefec02f2cf0", size = 90585, upload-time = "2020-11-23T03:59:13.41Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds class-level position tracking to all InfluxDB lap writes:

- **`class` tag**: car's class name (spaces→underscores, commas/equals stripped for line protocol safety), resolved per session
- **`class_position` field**: 1-based rank within class at the time of each lap

**Historical path** (`old_race`): `_resolve_class_historical` computes per-lap class positions from `session_details` using a preprocessing pass over same-class competitors — O(M×L + N×M) rather than O(N×M×L), meaningful at 100+ car / 200+ lap race scale. Writes are per-session so qualifying and race sessions rank independently.

**Live path** (`live_race`, `monitor_routine`): `_resolve_class_live` resolves current class position from the live session state at write time. Class position is stamped only on the current lap (live API provides current position, not per-lap history).

**Dependency**: bumped `race-monitor` to `>=0.5.1` for typed API responses.

**Linter**: replaced `flake8` with `ruff` (drop-in swap, same rules and line length).

## Fixes included

- `monitor_routine` was re-writing all historical laps on every poll cycle with an incomplete `class_positions` dict; fixed to pass only the new lap
- `live_race` was stamping current class position across all historical laps; fixed to stamp only the last lap
- `_resolve_class_live` accessed `response['Session']` without checking `response['Successful']`; fixed with early-return guard
- `live_race` would crash with `IndexError` on `laps[-1]` if `get_racer` returns empty (car not yet on track); fixed with `and laps` guard
- `pytest` added to `dev` dependency group

## Test Plan

- [x] 38 unit tests pass (`uv run --group dev pytest tests/ -v`)
- [x] `uv run --with ruff ruff check .` reports no violations
- [ ] Verify InfluxDB data in Grafana shows `class` tag and `class_position` field per lap on a historical race
- [ ] Verify live race write includes class position in InfluxDB

🤖 Generated with [Claude Code](https://claude.com/claude-code)