### PR TITLE
fix(laps): don't write stale class_position on initial live_race push

### DIFF
--- a/laps.py
+++ b/laps.py
@@ -242,6 +242,7 @@ def live_race(ctx, opts):
         # class_position intentionally discarded: historical laps were completed before launch
         # so any position we compute now is stale. monitor_routine owns class_position writes.
         class_name, _ = _resolve_class_live(ctx.client, ctx.race_id, ctx.car_number)
+        logging.info("Car %s: class %r", ctx.car_number, class_name)
         push_influx(ctx, laps, False, class_name=class_name, class_positions=None)
 
     if opts.save_file:
@@ -589,7 +590,7 @@ def _resolve_class_live(client, race_id, car_number):
         except (ValueError, TypeError):
             pass
 
-    logging.info(
+    logging.debug(
         "_resolve_class_live: car=%s class=%r overall_pos=%s class_pos=%s",
         car_number, class_name, tracked_pos, class_position,
     )

--- a/laps.py
+++ b/laps.py
@@ -239,12 +239,8 @@ def live_race(ctx, opts):
     print(UNDERLINE)
 
     if opts.network_mode and laps:
-        class_name, class_position = _resolve_class_live(ctx.client, ctx.race_id, ctx.car_number)
-        class_positions = (
-            {int(laps[-1]['Lap']): class_position}
-            if class_position is not None else None
-        )
-        push_influx(ctx, laps, False, class_name=class_name, class_positions=class_positions)
+        class_name, _ = _resolve_class_live(ctx.client, ctx.race_id, ctx.car_number)
+        push_influx(ctx, laps, False, class_name=class_name, class_positions=None)
 
     if opts.save_file:
         # Create filename and call function to write to CSV
@@ -557,9 +553,15 @@ def _resolve_class_live(client, race_id, car_number):
             break
 
     if tracked is None:
+        logging.warning("_resolve_class_live: car %s not found in session competitors", car_number)
         return None, None
 
     class_id = tracked['ClassID']
+    logging.debug(
+        "_resolve_class_live: car=%s overall_pos=%s class_id=%r classes=%s",
+        car_number, tracked.get('Position'), class_id,
+        {k: v.get('Description') for k, v in classes.items()},
+    )
     class_name = (
         classes.get(class_id, {}).get('Description', class_id)
         .replace(' ', '_').replace(',', '').replace('=', '')
@@ -575,11 +577,20 @@ def _resolve_class_live(client, race_id, car_number):
         if competitor['Number'] == car_number or competitor['ClassID'] != class_id:
             continue
         try:
-            if int(competitor['Position']) < tracked_pos:
+            comp_pos = int(competitor['Position'])
+            if comp_pos < tracked_pos:
+                logging.debug(
+                    "_resolve_class_live: same-class car %s at pos %s counts as ahead",
+                    competitor['Number'], comp_pos,
+                )
                 class_position += 1
         except (ValueError, TypeError):
             pass
 
+    logging.info(
+        "_resolve_class_live: car=%s class=%r overall_pos=%s class_pos=%s",
+        car_number, class_name, tracked_pos, class_position,
+    )
     return class_name, class_position
 
 

--- a/laps.py
+++ b/laps.py
@@ -239,6 +239,8 @@ def live_race(ctx, opts):
     print(UNDERLINE)
 
     if opts.network_mode and laps:
+        # class_position intentionally discarded: historical laps were completed before launch
+        # so any position we compute now is stale. monitor_routine owns class_position writes.
         class_name, _ = _resolve_class_live(ctx.client, ctx.race_id, ctx.car_number)
         push_influx(ctx, laps, False, class_name=class_name, class_positions=None)
 

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -385,7 +385,7 @@ class TestLiveClassWiring:
         _, kwargs = mock_push.call_args
         assert kwargs.get('class_name') == 'A'
 
-    def test_live_race_class_positions_only_has_last_lap(self):
+    def test_live_race_does_not_write_class_positions(self):
         ctx = self._make_ctx()
         two_laps = [
             {'Lap': '1', 'LapTime': '0:01:30.000', 'Position': '3',
@@ -401,7 +401,7 @@ class TestLiveClassWiring:
                     _mod.live_race(ctx, opts)
         args, kwargs = mock_push.call_args
         assert args[1] == two_laps
-        assert kwargs.get('class_positions') == {2: 2}
+        assert kwargs.get('class_positions') is None
 
     def test_live_race_skips_influx_when_no_laps(self):
         ctx = self._make_ctx()

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -385,6 +385,17 @@ class TestLiveClassWiring:
         _, kwargs = mock_push.call_args
         assert kwargs.get('class_name') == 'A'
 
+    def test_live_race_passes_none_class_name_when_car_not_in_session(self):
+        ctx = self._make_ctx()
+        opts = _mod.RaceOptions(network_mode=True)
+        with patch.object(_mod, '_resolve_class_live', return_value=(None, None)):
+            with patch.object(_mod, 'push_influx') as mock_push:
+                with patch.object(_mod, 'print_rankings'):
+                    _mod.live_race(ctx, opts)
+        _, kwargs = mock_push.call_args
+        assert kwargs.get('class_name') is None
+        assert kwargs.get('class_positions') is None
+
     def test_live_race_does_not_write_class_positions(self):
         ctx = self._make_ctx()
         two_laps = [


### PR DESCRIPTION
## Summary

- `live_race` was calling `_resolve_class_live` once at launch and writing that class position onto the last historical lap in InfluxDB. Since that lap completed before the tool started, the stored value reflected the launch-time race state — not the state when the lap was actually run, producing a misleading/stale reading in Grafana.
- `monitor_routine` is correct: it resolves class position at the moment each new lap is detected. `live_race` now fetches `class_name` (still written as an InfluxDB tag) but passes `class_positions=None`, so the `class_position` field is owned exclusively by `monitor_routine`.
- Adds a comment at the discard site explaining the invariant, so it isn't accidentally re-introduced.
- Adds a test for the `(None, None)` path when the tracked car isn't yet visible in the live session at launch.
- Adds diagnostic `DEBUG`-level logging to `_resolve_class_live` (ClassID, per-competitor breakdown, resolved class_pos). Class identification is logged once at INFO on launch; monitor mode stays quiet at INFO level.

## Test plan

- [x] `pytest tests/test_laps.py` — 39 tests pass
- [x] `test_live_race_does_not_write_class_positions` asserts `class_positions=None`
- [x] `test_live_race_passes_none_class_name_when_car_not_in_session` covers the `(None, None)` path
- [ ] Verify in Grafana after next race launch that `class_position` only appears for laps completed while the monitor is running

🤖 Generated with [Claude Code](https://claude.com/claude-code)