### PR TITLE
fix(laps): anchor historical timestamps to SessionStartDateEpoc

### DIFF
--- a/laps.py
+++ b/laps.py
@@ -291,7 +291,8 @@ def old_race(ctx, opts):
             class_name, class_positions = _resolve_class_historical(ctx.car_number, session_details)
             push_influx(
                 ctx, influx_laps, False,
-                class_name=class_name, class_positions=class_positions)
+                class_name=class_name, class_positions=class_positions,
+                start_epoc=session_details['Session']['SessionStartDateEpoc'])
 
     if competitor_missing:
         logging.info('Car %s not found', ctx.car_number)
@@ -445,8 +446,9 @@ def refresh_competitor(ctx):
 def push_influx(ctx, laps, monitor_mode, class_name=None, class_positions=None, start_epoc=None):
     """Push lap data to InfluxDB."""
     logging.debug("Entering network mode.")
-    logging.debug("Start epoch in seconds: %s", ctx.start_epoc)
-    start_epoc_ms = (start_epoc if start_epoc is not None else ctx.start_epoc) * 1000
+    effective_epoc = start_epoc if start_epoc is not None else ctx.start_epoc
+    logging.debug("Start epoch in seconds: %s", effective_epoc)
+    start_epoc_ms = effective_epoc * 1000
     logging.debug("Start epoch in milliseconds: %s", start_epoc_ms)
 
     if not monitor_mode:

--- a/laps.py
+++ b/laps.py
@@ -292,7 +292,7 @@ def old_race(ctx, opts):
             push_influx(
                 ctx, influx_laps, False,
                 class_name=class_name, class_positions=class_positions,
-                start_epoc=session_details['Session']['SessionStartDateEpoc'])
+                start_epoc=session_details['Session'].get('SessionStartDateEpoc'))
 
     if competitor_missing:
         logging.info('Car %s not found', ctx.car_number)
@@ -447,6 +447,8 @@ def push_influx(ctx, laps, monitor_mode, class_name=None, class_positions=None, 
     """Push lap data to InfluxDB."""
     logging.debug("Entering network mode.")
     effective_epoc = start_epoc if start_epoc is not None else ctx.start_epoc
+    if effective_epoc == 0:
+        logging.warning("Start epoch is 0; lap timestamps will be anchored to Unix epoch")
     logging.debug("Start epoch in seconds: %s", effective_epoc)
     start_epoc_ms = effective_epoc * 1000
     logging.debug("Start epoch in milliseconds: %s", start_epoc_ms)

--- a/laps.py
+++ b/laps.py
@@ -442,11 +442,11 @@ def refresh_competitor(ctx):
     return laps
 
 
-def push_influx(ctx, laps, monitor_mode, class_name=None, class_positions=None):
+def push_influx(ctx, laps, monitor_mode, class_name=None, class_positions=None, start_epoc=None):
     """Push lap data to InfluxDB."""
     logging.debug("Entering network mode.")
     logging.debug("Start epoch in seconds: %s", ctx.start_epoc)
-    start_epoc_ms = ctx.start_epoc * 1000
+    start_epoc_ms = (start_epoc if start_epoc is not None else ctx.start_epoc) * 1000
     logging.debug("Start epoch in milliseconds: %s", start_epoc_ms)
 
     if not monitor_mode:

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -347,6 +347,21 @@ class TestOldRaceClassWiring:
         _, kwargs = mock_push.call_args
         assert kwargs.get('class_name') == 'A'
 
+    def test_passes_session_start_epoc_to_push_influx(self):
+        # ctx.start_epoc=9999 is intentionally different from SessionStartDateEpoc=5555
+        ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 9999)
+        opts = _mod.RaceOptions(network_mode=True)
+        session = self._session_details()
+        session['Session']['SessionStartDateEpoc'] = 5555
+        ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
+        ctx.client.results.session_details.return_value = session
+        with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
+            with patch.object(_mod, 'push_influx') as mock_push:
+                with patch.object(_mod, 'print_rankings'):
+                    _mod.old_race(ctx, opts)
+        _, kwargs = mock_push.call_args
+        assert kwargs.get('start_epoc') == 5555
+
     def test_no_network_mode_skips_resolve(self):
         ctx = _mod.RaceContext('999', '42', MagicMock(), None, 0)
         opts = _mod.RaceOptions(network_mode=False)

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-module-docstring,missing-class-docstring,missing-function-docstring
 import importlib.util
+import logging
 import pathlib
 import threading
 from unittest.mock import MagicMock, mock_open, patch
@@ -296,6 +297,13 @@ class TestPushInfluxClassInfo:
         # start_epoc=1000 → timestamp = 1000*1000 + 90000 = 1090000
         assert record.endswith('1090000')
 
+    def test_warns_when_effective_epoc_is_zero(self, caplog):
+        ctx, write_api = self._ctx()  # ctx.start_epoc = 0
+        with caplog.at_level(logging.WARNING):
+            _mod.push_influx(ctx, self._laps(), False)
+        assert any('epoch' in r.message.lower() and r.levelno == logging.WARNING
+                   for r in caplog.records)
+
 
 class TestOldRaceClassWiring:
     def _session_details(self, car_number='42', cat_id='1', cat_name='A'):
@@ -361,6 +369,20 @@ class TestOldRaceClassWiring:
                     _mod.old_race(ctx, opts)
         _, kwargs = mock_push.call_args
         assert kwargs.get('start_epoc') == 5555
+
+    def test_handles_missing_session_start_epoc_key(self):
+        ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
+        opts = _mod.RaceOptions(network_mode=True)
+        session = self._session_details()
+        del session['Session']['SessionStartDateEpoc']
+        ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
+        ctx.client.results.session_details.return_value = session
+        with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
+            with patch.object(_mod, 'push_influx') as mock_push:
+                with patch.object(_mod, 'print_rankings'):
+                    _mod.old_race(ctx, opts)
+        _, kwargs = mock_push.call_args
+        assert kwargs.get('start_epoc') is None
 
     def test_no_network_mode_skips_resolve(self):
         ctx = _mod.RaceContext('999', '42', MagicMock(), None, 0)

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -281,6 +281,21 @@ class TestPushInfluxClassInfo:
         _mod.push_influx(ctx, self._laps(), False)
         assert 'class_position' not in self._record(write_api)
 
+    def test_ctx_start_epoc_used_when_no_override(self):
+        ctx, write_api = self._ctx()  # ctx.start_epoc = 0
+        _mod.push_influx(ctx, self._laps(), False)
+        record = self._record(write_api)
+        # start_epoc=0 → timestamp = 0*1000 + 90000 = 90000
+        # TotalTime '0:01:30.000' = 90000 ms
+        assert record.endswith('90000')
+
+    def test_start_epoc_override_changes_timestamp(self):
+        ctx, write_api = self._ctx()  # ctx.start_epoc = 0, would give 90000
+        _mod.push_influx(ctx, self._laps(), False, start_epoc=1000)
+        record = self._record(write_api)
+        # start_epoc=1000 → timestamp = 1000*1000 + 90000 = 1090000
+        assert record.endswith('1090000')
+
 
 class TestOldRaceClassWiring:
     def _session_details(self, car_number='42', cat_id='1', cat_name='A'):


### PR DESCRIPTION
## Summary

- \`push_influx\` now accepts an optional \`start_epoc\` parameter that overrides \`ctx.start_epoc\` (Race.StartDateEpoc) when provided
- \`old_race\` passes \`session_details['Session'].get('SessionStartDateEpoc')\` as \`start_epoc\`, fixing a timestamp offset of up to 35+ minutes when historical TotalTime counts from session open rather than green flag
- \`push_influx\` now logs a warning when \`effective_epoc == 0\` so misconfigured timestamps surface immediately in logs
- Live mode and monitor_routine are unchanged — the live API is green-flag anchored and was already correct

## Background

\`Race.StartDateEpoc\` is the scheduled event start time. The historical results API's \`TotalTime\` values count from \`Session.SessionStartDateEpoc\` — when the timing system's session actually opened. These can differ significantly (observed 35 min on race 166153). Writing historical laps with the wrong anchor produced timestamps that diverged from live-written data for the same race.

Using \`.get()\` for the key lookup also guards against sessions where the API omits \`SessionStartDateEpoc\` (e.g. test/pre-season sessions), falling back to \`ctx.start_epoc\` rather than crashing with a \`KeyError\`.

## Test Plan
- [x] \`uv run pytest tests/ -v\` — 67 tests pass
- [ ] Run \`old_race\` in \`-n\` mode against a completed race and verify first-lap timestamps land at a plausible wall-clock time (within seconds of green flag)