### PR TITLE
feat(laps): enrich InfluxDB lap writes with race and competitor metadata

### DIFF
--- a/laps.py
+++ b/laps.py
@@ -48,6 +48,14 @@ class RaceOptions:
     interval: int = 30
 
 
+@dataclass
+class RaceMetadata:
+    """Race-level metadata resolved once at startup."""
+    race_name: str
+    track_name: str
+    series_name: str | None
+
+
 def _build_parser():
     """Build and return the argument parser."""
     parser = argparse.ArgumentParser(description='Interact with lap data')
@@ -599,6 +607,31 @@ def _resolve_class_live(client, race_id, car_number):
         car_number, class_name, tracked_pos, class_position,
     )
     return class_name, class_position
+
+
+def _resolve_race_metadata(race_details, client):
+    """Resolve race-level metadata from race details and a single series lookup."""
+    if not race_details.get('Successful'):
+        return RaceMetadata(race_name='', track_name='', series_name=None)
+    race = race_details['Race']
+    series_id = race.get('SeriesID')
+    series_name = None
+    if series_id is not None:
+        try:
+            resp = client.common.current_races(series_id=series_id)
+            if resp.get('Races'):
+                series_name = resp['Races'][0]['SeriesName']
+            else:
+                resp = client.common.past_races(series_id=series_id, max_results=1)
+                if resp.get('Races'):
+                    series_name = resp['Races'][0]['SeriesName']
+        except Exception:  # pylint: disable=broad-exception-caught
+            logging.warning("Failed to resolve series name for series_id=%s", series_id)
+    return RaceMetadata(
+        race_name=race['Name'],
+        track_name=race['Track'],
+        series_name=series_name,
+    )
 
 
 if __name__ == '__main__':

--- a/laps.py
+++ b/laps.py
@@ -227,6 +227,9 @@ def live_race(ctx, opts):
     competitor_details['Name'] = (
         competitor_details['FirstName'] + competitor_details['LastName'])
 
+    competitor_name = f"{competitor_details.get('FirstName', '')} {competitor_details.get('LastName', '')}".strip() or None
+    car_info = competitor_details.get('AdditionalData') or None
+
     print(UNDERLINE)
     # Print competitor detail block
     print(
@@ -254,7 +257,8 @@ def live_race(ctx, opts):
         # so any position we compute now is stale. monitor_routine owns class_position writes.
         class_name, _ = _resolve_class_live(ctx.client, ctx.race_id, ctx.car_number)
         logging.info("Car %s: class %r", ctx.car_number, class_name)
-        push_influx(ctx, laps, False, class_name=class_name, class_positions=None)
+        push_influx(ctx, laps, False, competitor_name=competitor_name, car_info=car_info,
+                    class_name=class_name, class_positions=None)
 
     if opts.save_file:
         # Create filename and call function to write to CSV
@@ -262,7 +266,7 @@ def live_race(ctx, opts):
         write_csv(filename, laps)
 
     if opts.monitor_mode:
-        monitor_routine(ctx, laps, opts)
+        monitor_routine(ctx, laps, opts, competitor_name=competitor_name, car_info=car_info)
 
 
 def old_race(ctx, opts):
@@ -412,7 +416,7 @@ def write_csv(filename, competitor_lap_times):
         writer.writerows(competitor_lap_times)
 
 
-def monitor_routine(ctx, laps, opts, _stop_event=None):
+def monitor_routine(ctx, laps, opts, competitor_name=None, car_info=None, _stop_event=None):
     """Monitor mode: poll for new laps and display/push as they arrive."""
     logging.info("Monitoring car %s...", ctx.car_number)
     print(UNDERLINE)
@@ -437,6 +441,8 @@ def monitor_routine(ctx, laps, opts, _stop_event=None):
                     {new_lap_num: class_position} if class_position is not None else None)
                 push_influx(
                     ctx, [current_competitor_lap_times[-1]], True,
+                    competitor_name=competitor_name,
+                    car_info=car_info,
                     class_name=class_name, class_positions=class_positions)
 
 

--- a/laps.py
+++ b/laps.py
@@ -283,6 +283,8 @@ def old_race(ctx, opts):
     laps = []
     competitor_details = {}
     competitor_missing = True
+    competitor_name = None
+    car_info = None
 
     for session_id in session_ids_for_race:
         logging.debug("Getting session details for %s including lap times.", session_id)
@@ -294,6 +296,11 @@ def old_race(ctx, opts):
             if competitor['Number'] == ctx.car_number:
                 competitor_missing = False
                 competitor_details = competitor
+                competitor_name = (
+                    f"{competitor.get('FirstName', '')} {competitor.get('LastName', '')}".strip()
+                    or None
+                )
+                car_info = competitor.get('AdditionalData') or None
                 session_laps = competitor['LapTimes'].copy()
                 laps = laps + [dict(lap) for lap in session_laps]
 
@@ -306,6 +313,8 @@ def old_race(ctx, opts):
             class_name, class_positions = _resolve_class_historical(ctx.car_number, session_details)
             push_influx(
                 ctx, influx_laps, False,
+                competitor_name=competitor_name,
+                car_info=car_info,
                 class_name=class_name, class_positions=class_positions,
                 start_epoc=session_details['Session'].get('SessionStartDateEpoc'))
 

--- a/laps.py
+++ b/laps.py
@@ -36,6 +36,7 @@ class RaceContext:
     client: object
     write_api: object
     start_epoc: int
+    metadata: RaceMetadata | None = None
 
 
 @dataclass
@@ -144,6 +145,8 @@ def main():  # pylint: disable=too-many-branches,too-many-statements,too-many-lo
             )
             print(UNDERLINE)
 
+        metadata = _resolve_race_metadata(race_details, client)
+
         if opts.selected_class:
             logging.info("Sorting results for class %s.", opts.selected_class.upper())
 
@@ -154,14 +157,14 @@ def main():  # pylint: disable=too-many-branches,too-many-statements,too-many-lo
 
         if not opts.network_mode:
             return _run_race(
-                RaceContext(race_id, car_number, client, None, start_epoc), opts, response)
+                RaceContext(race_id, car_number, client, None, start_epoc, metadata=metadata), opts, response)
 
         with InfluxDBClient(
             url='https://influxdb.focism.com', token=influx_token, org='focism'
         ) as influx_client:
             write_api = influx_client.write_api(write_options=SYNCHRONOUS)
             return _run_race(
-                RaceContext(race_id, car_number, client, write_api, start_epoc), opts, response)
+                RaceContext(race_id, car_number, client, write_api, start_epoc, metadata=metadata), opts, response)
 
 
 def _run_race(ctx, opts, response):

--- a/laps.py
+++ b/laps.py
@@ -29,6 +29,14 @@ UNDERLINE = "-" * 80
 
 
 @dataclass
+class RaceMetadata:
+    """Race-level metadata resolved once at startup."""
+    race_name: str
+    track_name: str
+    series_name: str | None
+
+
+@dataclass
 class RaceContext:
     """Fixed context for a run: race identity, API client, and optional InfluxDB handle."""
     race_id: str
@@ -47,14 +55,6 @@ class RaceOptions:
     save_file: bool = False
     selected_class: str | None = None
     interval: int = 30
-
-
-@dataclass
-class RaceMetadata:
-    """Race-level metadata resolved once at startup."""
-    race_name: str
-    track_name: str
-    series_name: str | None
 
 
 def _build_parser():
@@ -145,7 +145,7 @@ def main():  # pylint: disable=too-many-branches,too-many-statements,too-many-lo
             )
             print(UNDERLINE)
 
-        metadata = _resolve_race_metadata(race_details, client)
+        metadata = _resolve_race_metadata(race_details, client) if opts.network_mode else None
 
         if opts.selected_class:
             logging.info("Sorting results for class %s.", opts.selected_class.upper())
@@ -225,7 +225,7 @@ def live_race(ctx, opts):
 
     # Make name
     competitor_details['Name'] = (
-        competitor_details['FirstName'] + competitor_details['LastName'])
+        competitor_details['FirstName'] + ' ' + competitor_details['LastName'])
 
     competitor_name = f"{competitor_details.get('FirstName', '')} {competitor_details.get('LastName', '')}".strip() or None
     car_info = competitor_details.get('AdditionalData') or None
@@ -499,9 +499,9 @@ def push_influx(ctx, laps, monitor_mode, competitor_name=None, car_info=None,
 
         point = (
             Point(f"laps{ctx.race_id}")
-            .tag("race_name", meta.race_name if meta else None)
-            .tag("track_name", meta.track_name if meta else None)
-            .tag("series_name", meta.series_name if meta else None)
+            .tag("race_name", meta.race_name if meta is not None else None)
+            .tag("track_name", meta.track_name if meta is not None else None)
+            .tag("series_name", meta.series_name if meta is not None else None)
             .tag("competitor_name", competitor_name)
             .tag("car_info", car_info)
             .tag("class", class_name)

--- a/laps.py
+++ b/laps.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 from operator import itemgetter
 
 import pandas
-from influxdb_client import InfluxDBClient
+from influxdb_client import InfluxDBClient, Point, WritePrecision
 from influxdb_client.client.write_api import SYNCHRONOUS
 from race_monitor import RaceMonitorClient
 
@@ -454,7 +454,8 @@ def refresh_competitor(ctx):
     return laps
 
 
-def push_influx(ctx, laps, monitor_mode, class_name=None, class_positions=None, start_epoc=None):
+def push_influx(ctx, laps, monitor_mode, competitor_name=None, car_info=None,
+                class_name=None, class_positions=None, start_epoc=None):
     """Push lap data to InfluxDB."""
     logging.debug("Entering network mode.")
     effective_epoc = start_epoc if start_epoc is not None else ctx.start_epoc
@@ -467,38 +468,44 @@ def push_influx(ctx, laps, monitor_mode, class_name=None, class_positions=None, 
     if not monitor_mode:
         logging.info("Writing laps to influx...")
 
-    current_driver = "Driver" + str(ctx.car_number)
-    tag_str = (
-        f"class={class_name},driver={current_driver}"
-        if class_name else f"driver={current_driver}"
-    )
-
+    meta = ctx.metadata
     write_success = True
     for lap in laps:
         h, m, s = lap['TotalTime'].split(':')
         s, ms = s.split('.')
         lap_finish_ms = int(h) * 3600000 + int(m) * 60000 + int(s) * 1000 + int(ms)
         time_lap_completed_ms = start_epoc_ms + lap_finish_ms
-        lap_timestamp = str(time_lap_completed_ms).replace(".", '')
 
         h, m, s = lap['LapTime'].split(':')
         s, ms = s.split('.')
         lap_time_ms = int(h) * 3600000 + int(m) * 60000 + int(s) * 1000 + int(ms)
 
         lap_num = int(lap['Lap'])
-        field_str = (
-            f"lap_no={lap_num},lap_time={lap_time_ms},"
-            f"position={lap['Position']},flag_status=\"{lap['FlagStatus']}\""
+
+        point = (
+            Point(f"laps{ctx.race_id}")
+            .tag("race_name", meta.race_name if meta else None)
+            .tag("track_name", meta.track_name if meta else None)
+            .tag("series_name", meta.series_name if meta else None)
+            .tag("competitor_name", competitor_name)
+            .tag("car_info", car_info)
+            .tag("class", class_name)
+            .tag("driver", f"Driver{ctx.car_number}")
+            .field("lap_no", lap_num)
+            .field("lap_time", lap_time_ms)
+            .field("position", int(lap['Position']))
+            .field("flag_status", lap['FlagStatus'])
+            .time(time_lap_completed_ms, WritePrecision.MS)
         )
+
         if class_positions is not None:
             class_pos = class_positions.get(lap_num)
             if class_pos is not None:
-                field_str += f",class_position={class_pos}"
+                point = point.field("class_position", class_pos)
 
-        data = [f"laps{ctx.race_id},{tag_str} {field_str} {lap_timestamp}"]
-        logging.debug(data)
+        logging.debug(point.to_line_protocol())
         try:
-            ctx.write_api.write(bucket='laps_252/autogen', record=data, write_precision='ms')
+            ctx.write_api.write(bucket='laps_252/autogen', record=point)
             logging.debug("Lap %s written to influx.", lap['Lap'])
         except Exception as e:  # pylint: disable=broad-exception-caught
             logging.error("Writing lap failed: %s", e)
@@ -534,7 +541,6 @@ def _resolve_class_historical(car_number, session_details):
     class_name = (
         categories.get(tracked_category, {})
         .get('Name', tracked_category)
-        .replace(' ', '_').replace(',', '').replace('=', '')
     )
 
     class_lap_positions = defaultdict(list)
@@ -580,10 +586,7 @@ def _resolve_class_live(client, race_id, car_number):
         car_number, tracked.get('Position'), class_id,
         {k: v.get('Description') for k, v in classes.items()},
     )
-    class_name = (
-        classes.get(class_id, {}).get('Description', class_id)
-        .replace(' ', '_').replace(',', '').replace('=', '')
-    )
+    class_name = classes.get(class_id, {}).get('Description', class_id)
 
     try:
         tracked_pos = int(tracked['Position'])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,6 @@ import sys
 from unittest.mock import MagicMock
 
 for _mod in [
-    'influxdb_client',
-    'influxdb_client.client',
-    'influxdb_client.client.write_api',
     'obd',
     'pandas',
     'race_monitor',

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -514,3 +514,76 @@ class TestLiveClassWiring:
                 with patch.object(_mod, 'push_influx'):
                     _mod.monitor_routine(ctx, existing_laps, opts, _stop_event=mock_stop)
         mock_resolve.assert_called_once_with(ctx.client, ctx.race_id, ctx.car_number)
+
+
+class TestResolveRaceMetadata:
+    def _race_details(self, series_id=145):
+        return {
+            'Successful': True,
+            'Race': {
+                'ID': 166153,
+                'Name': 'The Sausage Fest 2026',
+                'SeriesID': series_id,
+                'Track': 'Road America',
+            }
+        }
+
+    def _client_with_series(self, series_name='24 Hours of Lemons'):
+        client = MagicMock()
+        client.common.current_races.return_value = {
+            'Successful': True,
+            'Races': [{'SeriesName': series_name}],
+        }
+        return client
+
+    def test_race_name_extracted(self):
+        meta = _mod._resolve_race_metadata(self._race_details(), self._client_with_series())
+        assert meta.race_name == 'The Sausage Fest 2026'
+
+    def test_track_name_extracted(self):
+        meta = _mod._resolve_race_metadata(self._race_details(), self._client_with_series())
+        assert meta.track_name == 'Road America'
+
+    def test_series_name_from_current_races(self):
+        client = self._client_with_series('24 Hours of Lemons')
+        meta = _mod._resolve_race_metadata(self._race_details(series_id=145), client)
+        assert meta.series_name == '24 Hours of Lemons'
+        client.common.current_races.assert_called_once_with(series_id=145)
+
+    def test_series_name_falls_back_to_past_races(self):
+        client = MagicMock()
+        client.common.current_races.return_value = {'Successful': True, 'Races': []}
+        client.common.past_races.return_value = {
+            'Successful': True,
+            'Races': [{'SeriesName': '24 Hours of Lemons'}],
+        }
+        meta = _mod._resolve_race_metadata(self._race_details(series_id=145), client)
+        assert meta.series_name == '24 Hours of Lemons'
+        client.common.past_races.assert_called_once_with(series_id=145, max_results=1)
+
+    def test_series_name_none_when_series_id_is_none(self):
+        client = MagicMock()
+        meta = _mod._resolve_race_metadata(self._race_details(series_id=None), client)
+        assert meta.series_name is None
+        client.common.current_races.assert_not_called()
+
+    def test_series_name_none_when_both_lookups_empty(self):
+        client = MagicMock()
+        client.common.current_races.return_value = {'Successful': True, 'Races': []}
+        client.common.past_races.return_value = {'Successful': True, 'Races': []}
+        meta = _mod._resolve_race_metadata(self._race_details(series_id=145), client)
+        assert meta.series_name is None
+
+    def test_series_name_none_when_lookup_raises(self):
+        client = MagicMock()
+        client.common.current_races.side_effect = Exception('API error')
+        meta = _mod._resolve_race_metadata(self._race_details(series_id=145), client)
+        assert meta.series_name is None
+
+    def test_returns_empty_metadata_when_unsuccessful(self):
+        client = MagicMock()
+        meta = _mod._resolve_race_metadata({'Successful': False}, client)
+        assert meta.race_name == ''
+        assert meta.track_name == ''
+        assert meta.series_name is None
+        client.common.current_races.assert_not_called()

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -303,6 +303,26 @@ class TestPushInfluxClassInfo:
         assert any('epoch' in r.message.lower() and r.levelno == logging.WARNING
                    for r in caplog.records)
 
+    def test_includes_competitor_name_tag_when_provided(self):
+        ctx, write_api = self._ctx()
+        _mod.push_influx(ctx, self._laps(), False, competitor_name='Jane Doe')
+        assert 'competitor_name=Jane\\ Doe' in self._record(write_api)
+
+    def test_omits_competitor_name_tag_when_none(self):
+        ctx, write_api = self._ctx()
+        _mod.push_influx(ctx, self._laps(), False)
+        assert 'competitor_name' not in self._record(write_api)
+
+    def test_includes_car_info_tag_when_provided(self):
+        ctx, write_api = self._ctx()
+        _mod.push_influx(ctx, self._laps(), False, car_info='2005/Toy/Celica')
+        assert 'car_info=2005/Toy/Celica' in self._record(write_api)
+
+    def test_omits_car_info_tag_when_none(self):
+        ctx, write_api = self._ctx()
+        _mod.push_influx(ctx, self._laps(), False)
+        assert 'car_info' not in self._record(write_api)
+
 
 class TestOldRaceClassWiring:
     def _session_details(self, car_number='42', cat_id='1', cat_name='A'):

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -99,18 +99,17 @@ class TestResolveClassHistorical:
         class_name, _ = _mod._resolve_class_historical('42', sd)
         assert class_name == 'A'
 
-    def test_class_name_spaces_replaced_with_underscores(self):
+    def test_class_name_spaces_preserved(self):
         sd = self._session('42', '1')
         sd['Session']['Categories']['1']['Name'] = 'Super Street'
         class_name, _ = _mod._resolve_class_historical('42', sd)
-        assert class_name == 'Super_Street'
+        assert class_name == 'Super Street'
 
-    def test_class_name_special_chars_stripped(self):
+    def test_class_name_special_chars_preserved(self):
         sd = self._session('42', '1')
         sd['Session']['Categories']['1']['Name'] = 'GT3,Pro=Am'
         class_name, _ = _mod._resolve_class_historical('42', sd)
-        assert ',' not in class_name
-        assert '=' not in class_name
+        assert class_name == 'GT3,Pro=Am'
 
     def test_only_car_in_class_is_always_position_1(self):
         sd = self._session('42', '1')
@@ -234,13 +233,12 @@ class TestResolveClassLive:
         assert class_name is None
         assert class_pos is None
 
-    def test_class_name_special_chars_stripped(self):
+    def test_class_name_special_chars_preserved(self):
         client = self._make_client('42', 'classA', 1)
         client.live.get_session.return_value['Session']['Classes']['classA']['Description'] = (
             'GT3,Pro=Am')
         class_name, _ = _mod._resolve_class_live(client, '999', '42')
-        assert ',' not in class_name
-        assert '=' not in class_name
+        assert class_name == 'GT3,Pro=Am'
 
 
 class TestPushInfluxClassInfo:
@@ -254,7 +252,8 @@ class TestPushInfluxClassInfo:
         return ctx, write_api
 
     def _record(self, write_api):
-        return write_api.write.call_args[1]['record'][0]
+        point = write_api.write.call_args[1]['record']
+        return point.to_line_protocol()
 
     def test_includes_class_tag_when_provided(self):
         ctx, write_api = self._ctx()
@@ -270,7 +269,7 @@ class TestPushInfluxClassInfo:
     def test_includes_class_position_field_when_provided(self):
         ctx, write_api = self._ctx()
         _mod.push_influx(ctx, self._laps(), False, class_name='A', class_positions={1: 2})
-        assert 'class_position=2' in self._record(write_api)
+        assert 'class_position=2i' in self._record(write_api)
 
     def test_omits_class_tag_when_not_provided(self):
         ctx, write_api = self._ctx()

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -393,6 +393,47 @@ class TestOldRaceClassWiring:
                 _mod.old_race(ctx, opts)
         mock_resolve.assert_not_called()
 
+    def test_passes_competitor_name_to_push_influx(self):
+        ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
+        opts = _mod.RaceOptions(network_mode=True)
+        ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
+        ctx.client.results.session_details.return_value = self._session_details()
+        with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
+            with patch.object(_mod, 'push_influx') as mock_push:
+                with patch.object(_mod, 'print_rankings'):
+                    _mod.old_race(ctx, opts)
+        _, kwargs = mock_push.call_args
+        assert kwargs.get('competitor_name') == 'Jane Doe'
+
+    def test_passes_car_info_to_push_influx(self):
+        ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
+        opts = _mod.RaceOptions(network_mode=True)
+        session = self._session_details()
+        session['Session']['SortedCompetitors'][0]['AdditionalData'] = '2005/Toy/Celica'
+        ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
+        ctx.client.results.session_details.return_value = session
+        with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
+            with patch.object(_mod, 'push_influx') as mock_push:
+                with patch.object(_mod, 'print_rankings'):
+                    _mod.old_race(ctx, opts)
+        _, kwargs = mock_push.call_args
+        assert kwargs.get('car_info') == '2005/Toy/Celica'
+
+    def test_competitor_name_none_when_both_name_fields_empty(self):
+        ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
+        opts = _mod.RaceOptions(network_mode=True)
+        session = self._session_details()
+        session['Session']['SortedCompetitors'][0]['FirstName'] = ''
+        session['Session']['SortedCompetitors'][0]['LastName'] = ''
+        ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
+        ctx.client.results.session_details.return_value = session
+        with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
+            with patch.object(_mod, 'push_influx') as mock_push:
+                with patch.object(_mod, 'print_rankings'):
+                    _mod.old_race(ctx, opts)
+        _, kwargs = mock_push.call_args
+        assert kwargs.get('competitor_name') is None
+
 
 class TestLiveClassWiring:
     def _make_ctx(self):

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -514,6 +514,50 @@ class TestLiveClassWiring:
                     _mod.monitor_routine(ctx, existing_laps, opts, _stop_event=mock_stop)
         mock_resolve.assert_called_once_with(ctx.client, ctx.race_id, ctx.car_number)
 
+    def test_live_race_passes_competitor_name_to_push_influx(self):
+        ctx = self._make_ctx()
+        opts = _mod.RaceOptions(network_mode=True)
+        with patch.object(_mod, '_resolve_class_live', return_value=('A', 1)):
+            with patch.object(_mod, 'push_influx') as mock_push:
+                with patch.object(_mod, 'print_rankings'):
+                    _mod.live_race(ctx, opts)
+        _, kwargs = mock_push.call_args
+        assert kwargs.get('competitor_name') == 'Jane Doe'
+
+    def test_live_race_passes_car_info_to_push_influx(self):
+        ctx = self._make_ctx()
+        opts = _mod.RaceOptions(network_mode=True)
+        ctx.client.live.get_racer.return_value['Details']['Competitor']['AdditionalData'] = '2005/Toy/Celica'
+        with patch.object(_mod, '_resolve_class_live', return_value=('A', 1)):
+            with patch.object(_mod, 'push_influx') as mock_push:
+                with patch.object(_mod, 'print_rankings'):
+                    _mod.live_race(ctx, opts)
+        _, kwargs = mock_push.call_args
+        assert kwargs.get('car_info') == '2005/Toy/Celica'
+
+    def test_monitor_routine_forwards_competitor_name_and_car_info_to_push_influx(self):
+        ctx = self._make_ctx()
+        opts = _mod.RaceOptions(network_mode=True, interval=30)
+        existing_laps = [
+            {'Lap': '1', 'LapTime': '0:01:30.000', 'Position': '3',
+             'FlagStatus': '0', 'TotalTime': '0:01:30.000'},
+        ]
+        new_laps = existing_laps + [
+            {'Lap': '2', 'LapTime': '0:01:31.000', 'Position': '3',
+             'FlagStatus': '0', 'TotalTime': '0:03:01.000'},
+        ]
+        mock_stop = MagicMock()
+        mock_stop.wait.side_effect = [False, True]
+        with patch.object(_mod, 'refresh_competitor', return_value=new_laps):
+            with patch.object(_mod, '_resolve_class_live', return_value=('A', 1)):
+                with patch.object(_mod, 'push_influx') as mock_push:
+                    _mod.monitor_routine(ctx, existing_laps, opts,
+                                         competitor_name='Jane Doe', car_info='2005/Toy/Celica',
+                                         _stop_event=mock_stop)
+        _, kwargs = mock_push.call_args
+        assert kwargs.get('competitor_name') == 'Jane Doe'
+        assert kwargs.get('car_info') == '2005/Toy/Celica'
+
 
 class TestResolveRaceMetadata:
     def _race_details(self, series_id=145):


### PR DESCRIPTION
## Summary

- Adds \`race_name\`, \`track_name\`, \`series_name\`, \`competitor_name\`, and \`car_info\` InfluxDB tags to every lap write, enabling Grafana filtering/grouping by race, track, series, and competitor
- Migrates \`push_influx\` from hand-rolled line protocol strings to the \`influxdb_client.Point\` API, eliminating encoding bugs and removing all manual tag sanitization
- Introduces \`RaceMetadata\` dataclass resolved once at startup; series name resolved via \`common.current_races(series_id=N)\` with \`common.past_races\` fallback
- \`_resolve_race_metadata\` is now guarded by \`network_mode\` — no extra API calls in offline/display-only runs

## Breaking Change

Integer fields (\`lap_no\`, \`lap_time\`, \`position\`, \`class_position\`) are now written as **int64** instead of float64. Existing \`laps<race_id>\` measurements were migrated prior to merge.

## Test Plan

- [x] 85 unit tests pass (\`uv run pytest\`)
- [x] Existing InfluxDB \`laps*\` measurements migrated from float64 to int64
- [x] Verified new tags appear in InfluxDB after a live run (race 166153, car 182)
- [x] Verified integer field types on freshly written laps

🤖 Generated with [Claude Code](https://claude.com/claude-code)