### PR TITLE
feat: InfluxDB schema redesign with laps/races buckets and historical backfill

### DIFF
--- a/backfill.py
+++ b/backfill.py
@@ -24,11 +24,11 @@ Usage:
 
 Required environment variables:
     RACEMONITOR_TOKEN      — RaceMonitor API token (always required)
-    INFLUX_TELEMETRY_TOKEN — InfluxDB write token (required for --validate)
+    INFLUX_TELEMETRY_TOKEN — InfluxDB token (read-only sufficient for --validate;
+                             full backfill requires write access via laps.py)
 """
 
 import argparse
-import importlib.util
 import logging
 import os
 import pathlib
@@ -38,15 +38,10 @@ from datetime import datetime, timezone
 
 from race_monitor import RaceMonitorClient
 
-_migrate = importlib.util.spec_from_file_location(
-    "migrate", pathlib.Path(__file__).parent / "migrate.py")
-_migrate_mod = importlib.util.module_from_spec(_migrate)
-_migrate.loader.exec_module(_migrate_mod)
-validate_migration = _migrate_mod.validate_migration
-
 LEMONS_SEARCH_TERMS = ['Real Hoopties', 'GP du Lac', 'Halloween Hoop']
 DEFAULT_CAR_NUMBER = '252'
 DEFAULT_START_YEAR = 2021
+EPOCH_START = '1970-01-01T00:00:00Z'
 
 
 class _OverrideAction(argparse.Action):
@@ -102,8 +97,69 @@ def resolve_car_number(race_id, default, overrides):
     return overrides.get(str(race_id), default)
 
 
+def validate_backfill(pairs, query_api):
+    """Check every race has metadata and every expected car has laps; show counts."""
+    by_race = {}
+    for race_id, car_number in pairs:
+        by_race.setdefault(race_id, []).append(car_number)
+
+    all_ok = True
+    for race_id, expected_cars in sorted(by_race.items()):
+        race_tables = query_api.query(
+            f'from(bucket: "races")\n'
+            f'  |> range(start: {EPOCH_START})\n'
+            f'  |> filter(fn: (r) => r._measurement == "race"\n'
+            f'      and r.race_id == "{race_id}")\n'
+            f'  |> filter(fn: (r) => r._field == "end_time_epoc")\n'
+            f'  |> first()'
+        )
+        race_records = [r for t in race_tables for r in t.records]
+        if not race_records:
+            logging.warning("race %s: metadata MISSING", race_id)
+            all_ok = False
+            continue
+
+        race_name = race_records[0].values.get('race_name', 'unknown')
+        range_start = race_records[0].get_time().strftime('%Y-%m-%dT%H:%M:%SZ')
+        end_epoc = race_records[0].get_value()
+        if not end_epoc:
+            logging.warning("race %s: end_time_epoc=0 in races bucket, using now() as range stop",
+                            race_id)
+        range_stop = (datetime.fromtimestamp(end_epoc, tz=timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+                      if end_epoc else datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'))
+
+        lap_tables = query_api.query(
+            f'from(bucket: "laps")\n'
+            f'  |> range(start: {range_start}, stop: {range_stop})\n'
+            f'  |> filter(fn: (r) => r._measurement == "lap"\n'
+            f'      and r.race_id == "{race_id}"\n'
+            f'      and r._field == "lap_no")\n'
+            f'  |> group(columns: ["car_number"])\n'
+            f'  |> count()'
+        )
+        actual = {r.values['car_number']: r.values['_value']
+                  for t in lap_tables for r in t.records}
+
+        missing = sorted(set(expected_cars) - set(actual))
+        if missing:
+            logging.warning("race %s (%s): MISSING cars %s | have: %s",
+                            race_id, race_name, missing,
+                            [f'{c}={actual[c]}laps' for c in sorted(actual)])
+            all_ok = False
+        else:
+            logging.info("race %s (%s): OK | cars: %s",
+                         race_id, race_name,
+                         [f'{c}={actual[c]}laps' for c in sorted(actual)])
+
+    return all_ok
+
+
+_LAPS_PY = str(pathlib.Path(__file__).parent / 'laps.py')
+
+
 def run_backfill(races, default_car, overrides, dry_run=False):
     """Run laps.py -n for each race, using per-race car number overrides where set."""
+    failures = []
     for race in races:
         race_id = str(race['ID'])
         car_number = resolve_car_number(race_id, default_car, overrides)
@@ -114,11 +170,15 @@ def run_backfill(races, default_car, overrides, dry_run=False):
         logging.info("Backfilling race %s (%s) car %s",
                      race_id, race['Name'], car_number)
         result = subprocess.run(
-            [sys.executable, 'laps.py', '-n', race_id, car_number],
+            [sys.executable, _LAPS_PY, '-n', race_id, car_number],
             capture_output=False,
         )
         if result.returncode != 0:
             logging.error("Backfill failed for race %s car %s", race_id, car_number)
+            failures.append((race_id, car_number))
+    if failures:
+        logging.error("%d race(s) failed: %s", len(failures), failures)
+    return failures
 
 
 def main():
@@ -145,10 +205,12 @@ def main():
             pairs = build_pairs(races, args.car_number, args.overrides)
             with InfluxDBClient(url='https://influxdb.focism.com',
                                 token=influx_token, org='focism') as influx_client:
-                ok = validate_migration(pairs, influx_client.query_api())
+                ok = validate_backfill(pairs, influx_client.query_api())
             sys.exit(0 if ok else 1)
 
-        run_backfill(races, args.car_number, args.overrides, dry_run=args.dry_run)
+        failures = run_backfill(races, args.car_number, args.overrides, dry_run=args.dry_run)
+        if failures:
+            sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/backfill.py
+++ b/backfill.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Discover and backfill historical 24 Hours of Lemons lap data.
+
+Searches the RaceMonitor API for past Real Hoopties, GP du Lac, and Halloween
+Hoop races and writes lap data for a given car number to the laps/races InfluxDB
+buckets by shelling out to laps.py -n for each race found.
+
+Usage:
+    # Preview what would be backfilled (no writes)
+    uv run python backfill.py --dry-run
+
+    # Run the backfill (default car 252, from 2021 onwards)
+    uv run python backfill.py
+
+    # Override car number for a specific race (e.g. 2022 Hoopties used car 253)
+    uv run python backfill.py --override 120037:253
+
+    # Validate that backfilled races have data in InfluxDB
+    uv run python backfill.py --validate --override 120037:253
+
+    # Backfill from a different year or for a different default car
+    uv run python backfill.py --start-year 2023 --car 82
+
+Required environment variables:
+    RACEMONITOR_TOKEN      — RaceMonitor API token (always required)
+    INFLUX_TELEMETRY_TOKEN — InfluxDB write token (required for --validate)
+"""
+
+import argparse
+import importlib.util
+import logging
+import os
+import pathlib
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+from race_monitor import RaceMonitorClient
+
+_migrate = importlib.util.spec_from_file_location(
+    "migrate", pathlib.Path(__file__).parent / "migrate.py")
+_migrate_mod = importlib.util.module_from_spec(_migrate)
+_migrate.loader.exec_module(_migrate_mod)
+validate_migration = _migrate_mod.validate_migration
+
+LEMONS_SEARCH_TERMS = ['Real Hoopties', 'GP du Lac', 'Halloween Hoop']
+DEFAULT_CAR_NUMBER = '252'
+DEFAULT_START_YEAR = 2021
+
+
+class _OverrideAction(argparse.Action):
+    """argparse Action that accumulates RACE_ID:CAR_NUMBER pairs into a dict."""
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        overrides = getattr(namespace, self.dest) or {}
+        race_id, car = values.split(':', 1)
+        overrides[race_id] = car
+        setattr(namespace, self.dest, overrides)
+
+
+def _build_parser():
+    parser = argparse.ArgumentParser(
+        description='Discover and backfill historical Lemons lap data.')
+    parser.add_argument('--dry-run', dest='dry_run', action='store_true', default=False,
+                        help='Print what would be run without writing anything')
+    parser.add_argument('--override', dest='overrides', metavar='RACE_ID:CAR_NUMBER',
+                        action=_OverrideAction, default={},
+                        help='Override car number for a specific race (repeatable)')
+    parser.add_argument('--start-year', dest='start_year', type=int,
+                        default=DEFAULT_START_YEAR,
+                        help=f'Earliest year to include (default: {DEFAULT_START_YEAR})')
+    parser.add_argument('--car', dest='car_number', default=DEFAULT_CAR_NUMBER,
+                        help=f'Default car number (default: {DEFAULT_CAR_NUMBER})')
+    parser.add_argument('--validate', dest='validate', action='store_true', default=False,
+                        help='Check that every backfilled race has data in the new buckets')
+    return parser
+
+
+def find_matching_races(client, start_year_epoc):
+    """Search for matching Lemons races at or after start_year_epoc.
+
+    Makes one API call per search term and deduplicates by race ID.
+    """
+    seen = {}
+    for term in LEMONS_SEARCH_TERMS:
+        resp = client.results.search_results(term)
+        for race in resp.get('Races', []):
+            if race['StartDateEpoc'] >= start_year_epoc:
+                seen[race['ID']] = race
+    return sorted(seen.values(), key=lambda r: r['StartDateEpoc'])
+
+
+def build_pairs(races, default_car, overrides):
+    """Return (race_id, car_number) pairs for all races, applying overrides."""
+    return [(str(race['ID']), resolve_car_number(str(race['ID']), default_car, overrides))
+            for race in races]
+
+
+def resolve_car_number(race_id, default, overrides):
+    """Return the override car number for race_id, or default if none is set."""
+    return overrides.get(str(race_id), default)
+
+
+def run_backfill(races, default_car, overrides, dry_run=False):
+    """Run laps.py -n for each race, using per-race car number overrides where set."""
+    for race in races:
+        race_id = str(race['ID'])
+        car_number = resolve_car_number(race_id, default_car, overrides)
+        if dry_run:
+            logging.info("Would backfill race %s (%s) car %s",
+                         race_id, race['Name'], car_number)
+            continue
+        logging.info("Backfilling race %s (%s) car %s",
+                     race_id, race['Name'], car_number)
+        result = subprocess.run(
+            [sys.executable, 'laps.py', '-n', race_id, car_number],
+            capture_output=False,
+        )
+        if result.returncode != 0:
+            logging.error("Backfill failed for race %s car %s", race_id, car_number)
+
+
+def main():
+    """Entry point: parse args, discover races, then backfill or validate."""
+    args = _build_parser().parse_args()
+
+    token = os.environ.get('RACEMONITOR_TOKEN')
+    if not token:
+        logging.error("RACEMONITOR_TOKEN environment variable not set")
+        sys.exit(1)
+
+    start_year_epoc = int(datetime(args.start_year, 1, 1, tzinfo=timezone.utc).timestamp())
+
+    with RaceMonitorClient(api_token=token) as client:
+        races = find_matching_races(client, start_year_epoc)
+        logging.info("Found %d matching races", len(races))
+
+        if args.validate:
+            influx_token = os.environ.get('INFLUX_TELEMETRY_TOKEN')
+            if not influx_token:
+                logging.error("INFLUX_TELEMETRY_TOKEN environment variable not set")
+                sys.exit(1)
+            from influxdb_client import InfluxDBClient
+            pairs = build_pairs(races, args.car_number, args.overrides)
+            with InfluxDBClient(url='https://influxdb.focism.com',
+                                token=influx_token, org='focism') as influx_client:
+                ok = validate_migration(pairs, influx_client.query_api())
+            sys.exit(0 if ok else 1)
+
+        run_backfill(races, args.car_number, args.overrides, dry_run=args.dry_run)
+
+
+if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+    main()

--- a/diagnose_race.py
+++ b/diagnose_race.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Diagnose lap data discrepancies for a specific race and car number.
+
+Queries both the RaceMonitor API and InfluxDB and prints side-by-side lap
+counts, session breakdown, and all stored lap numbers so you can pinpoint
+whether a count mismatch is an API issue or a write issue.
+
+Usage:
+    uv run python diagnose_race.py <race_id> <car_number>
+
+Example:
+    uv run python diagnose_race.py 144185 252
+
+Required environment variables:
+    RACEMONITOR_TOKEN      — RaceMonitor API token
+    INFLUX_TELEMETRY_TOKEN — InfluxDB read token
+"""
+
+import os
+import sys
+from datetime import datetime, timezone
+
+from influxdb_client import InfluxDBClient
+from race_monitor import RaceMonitorClient
+
+INFLUX_URL = 'https://influxdb.focism.com'
+INFLUX_ORG = 'focism'
+EPOCH_START = '1970-01-01T00:00:00Z'
+
+
+def epoc_to_str(epoc):
+    """Convert a Unix epoch integer to a human-readable UTC string."""
+    if not epoc:
+        return f'{epoc} (zero/null)'
+    return datetime.fromtimestamp(epoc, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')
+
+
+def diagnose_api(client, race_id, car_number):
+    """Print race metadata and per-session lap counts from the RaceMonitor API."""
+    print(f'\n=== RaceMonitor API: race {race_id}, car {car_number} ===')
+
+    race_details = client.race.details(race_id)
+    if race_details.get('Successful'):
+        race = race_details['Race']
+        print(f"Race name:       {race['Name']}")
+        print(f"StartDateEpoc:   {epoc_to_str(race.get('StartDateEpoc'))}")
+        print(f"EndDateEpoc:     {epoc_to_str(race.get('EndDateEpoc'))}")
+
+    sessions_resp = client.results.sessions_for_race(race_id)
+    sessions = sessions_resp.get('Sessions', [])
+    print(f"\nSessions ({len(sessions)} total):")
+
+    total_laps = 0
+    for s in sessions:
+        session_id = s['ID']
+        detail = client.results.session_details(session_id, include_lap_times=True)
+        session = detail['Session']
+        session_start = session.get('SessionStartDateEpoc')
+
+        car_laps = []
+        for competitor in session.get('SortedCompetitors', []):
+            if competitor['Number'] == car_number:
+                car_laps = competitor.get('LapTimes', [])
+                break
+
+        total_laps += len(car_laps)
+        print(f"  Session {session_id}: SessionStartDateEpoc={epoc_to_str(session_start)}"
+              f"  car {car_number} laps={len(car_laps)}")
+
+    print(f"\nTotal laps for car {car_number} across all sessions: {total_laps}")
+
+
+def diagnose_influx(query_api, race_id, car_number):
+    """Print stored lap count, time range, and all lap numbers from InfluxDB."""
+    print(f'\n=== InfluxDB: race {race_id}, car {car_number} ===')
+
+    tables = query_api.query(
+        f'from(bucket: "laps")\n'
+        f'  |> range(start: {EPOCH_START})\n'
+        f'  |> filter(fn: (r) => r._measurement == "lap"\n'
+        f'      and r.race_id == "{race_id}"\n'
+        f'      and r.car_number == "{car_number}"\n'
+        f'      and r._field == "lap_no")\n'
+        f'  |> sort(columns: ["_time"])'
+    )
+    records = [r for t in tables for r in t.records]
+    if not records:
+        print("  No laps found in InfluxDB.")
+        return
+
+    print(f"  Stored laps: {len(records)}")
+    print(f"  First lap timestamp: {records[0].get_time()}")
+    print(f"  Last lap timestamp:  {records[-1].get_time()}")
+    print(f"  Lap numbers stored: {sorted(int(r.get_value()) for r in records)}")
+
+
+def main():
+    """Entry point: read args and env vars, then run both diagnose functions."""
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <race_id> <car_number>")
+        sys.exit(1)
+
+    race_id, car_number = sys.argv[1], sys.argv[2]
+
+    rm_token = os.environ.get('RACEMONITOR_TOKEN')
+    influx_token = os.environ.get('INFLUX_TELEMETRY_TOKEN')
+
+    if not rm_token:
+        print("RACEMONITOR_TOKEN not set"); sys.exit(1)
+    if not influx_token:
+        print("INFLUX_TELEMETRY_TOKEN not set"); sys.exit(1)
+
+    with RaceMonitorClient(api_token=rm_token) as client:
+        diagnose_api(client, race_id, car_number)
+
+    with InfluxDBClient(url=INFLUX_URL, token=influx_token, org=INFLUX_ORG) as influx:
+        diagnose_influx(influx.query_api(), race_id, car_number)
+
+
+if __name__ == '__main__':
+    main()

--- a/diagnose_race.py
+++ b/diagnose_race.py
@@ -37,15 +37,21 @@ def epoc_to_str(epoc):
 
 
 def diagnose_api(client, race_id, car_number):
-    """Print race metadata and per-session lap counts from the RaceMonitor API."""
+    """Print race metadata and per-session lap counts from the RaceMonitor API.
+
+    Returns (start_epoc, end_epoc) from race details, or (0, 0) if unavailable.
+    """
     print(f'\n=== RaceMonitor API: race {race_id}, car {car_number} ===')
 
+    start_epoc, end_epoc = 0, 0
     race_details = client.race.details(race_id)
     if race_details.get('Successful'):
         race = race_details['Race']
+        start_epoc = race.get('StartDateEpoc', 0)
+        end_epoc = race.get('EndDateEpoc', 0)
         print(f"Race name:       {race['Name']}")
-        print(f"StartDateEpoc:   {epoc_to_str(race.get('StartDateEpoc'))}")
-        print(f"EndDateEpoc:     {epoc_to_str(race.get('EndDateEpoc'))}")
+        print(f"StartDateEpoc:   {epoc_to_str(start_epoc)}")
+        print(f"EndDateEpoc:     {epoc_to_str(end_epoc)}")
 
     sessions_resp = client.results.sessions_for_race(race_id)
     sessions = sessions_resp.get('Sessions', [])
@@ -69,15 +75,23 @@ def diagnose_api(client, race_id, car_number):
               f"  car {car_number} laps={len(car_laps)}")
 
     print(f"\nTotal laps for car {car_number} across all sessions: {total_laps}")
+    return start_epoc, end_epoc
 
 
-def diagnose_influx(query_api, race_id, car_number):
+def diagnose_influx(query_api, race_id, car_number, start_epoc=0, end_epoc=0):
     """Print stored lap count, time range, and all lap numbers from InfluxDB."""
     print(f'\n=== InfluxDB: race {race_id}, car {car_number} ===')
 
+    range_start = (datetime.fromtimestamp(start_epoc, tz=timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+                   if start_epoc else EPOCH_START)
+    if not end_epoc:
+        print(f"  Warning: end_time_epoc not set for race {race_id}, using now() as range stop")
+    range_stop = (datetime.fromtimestamp(end_epoc, tz=timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+                  if end_epoc else datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'))
+
     tables = query_api.query(
         f'from(bucket: "laps")\n'
-        f'  |> range(start: {EPOCH_START})\n'
+        f'  |> range(start: {range_start}, stop: {range_stop})\n'
         f'  |> filter(fn: (r) => r._measurement == "lap"\n'
         f'      and r.race_id == "{race_id}"\n'
         f'      and r.car_number == "{car_number}"\n'
@@ -112,10 +126,10 @@ def main():
         print("INFLUX_TELEMETRY_TOKEN not set"); sys.exit(1)
 
     with RaceMonitorClient(api_token=rm_token) as client:
-        diagnose_api(client, race_id, car_number)
+        start_epoc, end_epoc = diagnose_api(client, race_id, car_number)
 
     with InfluxDBClient(url=INFLUX_URL, token=influx_token, org=INFLUX_ORG) as influx:
-        diagnose_influx(influx.query_api(), race_id, car_number)
+        diagnose_influx(influx.query_api(), race_id, car_number, start_epoc, end_epoc)
 
 
 if __name__ == '__main__':

--- a/laps.py
+++ b/laps.py
@@ -447,6 +447,14 @@ def monitor_routine(ctx, laps, opts, competitor_name=None, car_info=None, _stop_
 
     stop = _stop_event if _stop_event is not None else threading.Event()
     while not stop.wait(timeout=opts.interval):
+        if opts.network_mode and ctx.start_epoc == 0:
+            race_details = ctx.client.race.details(ctx.race_id)
+            if race_details.get('Successful'):
+                new_epoc = race_details['Race'].get('StartDateEpoc', 0)
+                if new_epoc != 0:
+                    ctx.start_epoc = new_epoc
+                    push_influx_race(ctx, ctx.start_epoc * 1000)
+
         current_competitor_lap_times = refresh_competitor(ctx)
         if current_competitor_lap_times[-1] not in laps:
             current_competitor_lap_time_df = pandas.json_normalize(

--- a/laps.py
+++ b/laps.py
@@ -46,6 +46,7 @@ class RaceContext:
     write_api: object
     start_epoc: int
     metadata: RaceMetadata | None = None
+    delete_api: object = None
 
 
 @dataclass
@@ -164,8 +165,10 @@ def main():  # pylint: disable=too-many-branches,too-many-statements,too-many-lo
             url='https://influxdb.focism.com', token=influx_token, org='focism'
         ) as influx_client:
             write_api = influx_client.write_api(write_options=SYNCHRONOUS)
+            delete_api = influx_client.delete_api()
             return _run_race(
-                RaceContext(race_id, car_number, client, write_api, start_epoc, metadata=metadata), opts, response)
+                RaceContext(race_id, car_number, client, write_api, start_epoc,
+                            metadata=metadata, delete_api=delete_api), opts, response)
 
 
 def _run_race(ctx, opts, response):

--- a/laps.py
+++ b/laps.py
@@ -34,6 +34,7 @@ class RaceMetadata:
     race_name: str
     track_name: str
     series_name: str | None
+    end_time_epoc: int
 
 
 @dataclass
@@ -633,7 +634,7 @@ def _resolve_class_live(client, race_id, car_number):
 def _resolve_race_metadata(race_details, client):
     """Resolve race-level metadata from race details and a single series lookup."""
     if not race_details.get('Successful'):
-        return RaceMetadata(race_name='', track_name='', series_name=None)
+        return RaceMetadata(race_name='', track_name='', series_name=None, end_time_epoc=0)
     race = race_details['Race']
     series_id = race.get('SeriesID')
     series_name = None
@@ -652,6 +653,7 @@ def _resolve_race_metadata(race_details, client):
         race_name=race['Name'],
         track_name=race['Track'],
         series_name=series_name,
+        end_time_epoc=race.get('EndDateEpoc', 0),
     )
 
 

--- a/laps.py
+++ b/laps.py
@@ -256,13 +256,17 @@ def live_race(ctx, opts):
     print(lap_time_df.to_string(index=False))
     print(UNDERLINE)
 
-    if opts.network_mode and laps:
-        # class_position intentionally discarded: historical laps were completed before launch
-        # so any position we compute now is stale. monitor_routine owns class_position writes.
-        class_name, _ = _resolve_class_live(ctx.client, ctx.race_id, ctx.car_number)
-        logging.info("Car %s: class %r", ctx.car_number, class_name)
-        push_influx(ctx, laps, False, competitor_name=competitor_name, car_info=car_info,
-                    class_name=class_name, class_positions=None)
+    if opts.network_mode:
+        race_ts_ms = ctx.start_epoc * 1000 if ctx.start_epoc != 0 else int(time.time() * 1000)
+        push_influx_race(ctx, race_ts_ms)
+        if laps:
+            # class_position intentionally discarded: historical laps were completed before
+            # launch so any position we compute now is stale. monitor_routine owns
+            # class_position writes.
+            class_name, _ = _resolve_class_live(ctx.client, ctx.race_id, ctx.car_number)
+            logging.info("Car %s: class %r", ctx.car_number, class_name)
+            push_influx(ctx, laps, False, competitor_name=competitor_name, car_info=car_info,
+                        class_name=class_name, class_positions=None)
 
     if opts.save_file:
         # Create filename and call function to write to CSV
@@ -325,6 +329,9 @@ def old_race(ctx, opts):
     if competitor_missing:
         logging.info('Car %s not found', ctx.car_number)
         return
+
+    if opts.network_mode:
+        push_influx_race(ctx, ctx.start_epoc * 1000)
 
     print_rankings(sorted_competitors, False, opts.selected_class)
 

--- a/laps.py
+++ b/laps.py
@@ -484,7 +484,6 @@ def push_influx(ctx, laps, monitor_mode, competitor_name=None, car_info=None,
     if not monitor_mode:
         logging.info("Writing laps to influx...")
 
-    meta = ctx.metadata
     write_success = True
     for lap in laps:
         h, m, s = lap['TotalTime'].split(':')

--- a/laps.py
+++ b/laps.py
@@ -533,6 +533,27 @@ def push_influx(ctx, laps, monitor_mode, competitor_name=None, car_info=None,
     print(UNDERLINE)
 
 
+def push_influx_race(ctx, timestamp_ms):
+    """Write one race metadata point to the races bucket, replacing any prior point."""
+    ctx.delete_api.delete(
+        start='1970-01-01T00:00:00Z',
+        stop='2030-01-01T00:00:00Z',
+        predicate=f'_measurement="race" AND race_id="{ctx.race_id}"',
+        bucket='races',
+    )
+    meta = ctx.metadata
+    point = (
+        Point("race")
+        .tag("race_id", ctx.race_id)
+        .tag("race_name", meta.race_name)
+        .tag("track_name", meta.track_name)
+        .tag("series_name", meta.series_name)
+        .field("end_time_epoc", meta.end_time_epoc)
+        .time(timestamp_ms, WritePrecision.MS)
+    )
+    ctx.write_api.write(bucket='races/autogen', record=point)
+
+
 def _resolve_class_historical(car_number, session_details):
     """Return (class_name, {lap_num: class_position}) for the tracked car."""
     session = session_details['Session']

--- a/laps.py
+++ b/laps.py
@@ -332,7 +332,8 @@ def old_race(ctx, opts):
         return
 
     if opts.network_mode:
-        push_influx_race(ctx, ctx.start_epoc * 1000)
+        race_ts_ms = ctx.start_epoc * 1000 if ctx.start_epoc != 0 else int(time.time() * 1000)
+        push_influx_race(ctx, race_ts_ms)
 
     print_rankings(sorted_competitors, False, opts.selected_class)
 
@@ -454,6 +455,9 @@ def monitor_routine(ctx, laps, opts, competitor_name=None, car_info=None, _stop_
                 new_epoc = race_details['Race'].get('StartDateEpoc', 0)
                 if new_epoc != 0:
                     ctx.start_epoc = new_epoc
+                    if ctx.metadata is not None:
+                        ctx.metadata.end_time_epoc = race_details['Race'].get(
+                            'EndDateEpoc', ctx.metadata.end_time_epoc)
                     push_influx_race(ctx, ctx.start_epoc * 1000)
 
         current_competitor_lap_times = refresh_competitor(ctx)
@@ -551,10 +555,13 @@ def push_influx(ctx, laps, monitor_mode, competitor_name=None, car_info=None,
 
 def push_influx_race(ctx, timestamp_ms):
     """Write one race metadata point to the races bucket, replacing any prior point."""
+    if ctx.metadata is None:
+        logging.warning("push_influx_race called with no metadata for race %s", ctx.race_id)
+        return
     try:
         ctx.delete_api.delete(
             start='1970-01-01T00:00:00Z',
-            stop=datetime.now(timezone.utc).isoformat(),
+            stop=datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
             predicate=f'_measurement="race" AND race_id="{ctx.race_id}"',
             bucket='races',
         )

--- a/laps.py
+++ b/laps.py
@@ -18,6 +18,7 @@ import sys
 import threading
 import time
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from operator import itemgetter
 
 import pandas
@@ -536,7 +537,7 @@ def push_influx(ctx, laps, monitor_mode, competitor_name=None, car_info=None,
 
         logging.debug(point.to_line_protocol())
         try:
-            ctx.write_api.write(bucket='laps/autogen', record=point)
+            ctx.write_api.write(bucket='laps', record=point)
             logging.debug("Lap %s written to influx.", lap['Lap'])
         except Exception as e:  # pylint: disable=broad-exception-caught
             logging.error("Writing lap failed: %s", e)
@@ -550,23 +551,26 @@ def push_influx(ctx, laps, monitor_mode, competitor_name=None, car_info=None,
 
 def push_influx_race(ctx, timestamp_ms):
     """Write one race metadata point to the races bucket, replacing any prior point."""
-    ctx.delete_api.delete(
-        start='1970-01-01T00:00:00Z',
-        stop='2030-01-01T00:00:00Z',
-        predicate=f'_measurement="race" AND race_id="{ctx.race_id}"',
-        bucket='races',
-    )
-    meta = ctx.metadata
-    point = (
-        Point("race")
-        .tag("race_id", ctx.race_id)
-        .tag("race_name", meta.race_name)
-        .tag("track_name", meta.track_name)
-        .tag("series_name", meta.series_name)
-        .field("end_time_epoc", meta.end_time_epoc)
-        .time(timestamp_ms, WritePrecision.MS)
-    )
-    ctx.write_api.write(bucket='races/autogen', record=point)
+    try:
+        ctx.delete_api.delete(
+            start='1970-01-01T00:00:00Z',
+            stop=datetime.now(timezone.utc).isoformat(),
+            predicate=f'_measurement="race" AND race_id="{ctx.race_id}"',
+            bucket='races',
+        )
+        meta = ctx.metadata
+        point = (
+            Point("race")
+            .tag("race_id", ctx.race_id)
+            .tag("race_name", meta.race_name)
+            .tag("track_name", meta.track_name)
+            .tag("series_name", meta.series_name)
+            .field("end_time_epoc", meta.end_time_epoc)
+            .time(timestamp_ms, WritePrecision.MS)
+        )
+        ctx.write_api.write(bucket='races', record=point)
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        logging.error("Writing race failed: %s", e)
 
 
 def _resolve_class_historical(car_number, session_details):

--- a/laps.py
+++ b/laps.py
@@ -499,14 +499,12 @@ def push_influx(ctx, laps, monitor_mode, competitor_name=None, car_info=None,
         lap_num = int(lap['Lap'])
 
         point = (
-            Point(f"laps{ctx.race_id}")
-            .tag("race_name", meta.race_name if meta is not None else None)
-            .tag("track_name", meta.track_name if meta is not None else None)
-            .tag("series_name", meta.series_name if meta is not None else None)
+            Point("lap")
+            .tag("race_id", ctx.race_id)
             .tag("competitor_name", competitor_name)
             .tag("car_info", car_info)
             .tag("class", class_name)
-            .tag("driver", f"Driver{ctx.car_number}")
+            .tag("car_number", ctx.car_number)
             .field("lap_no", lap_num)
             .field("lap_time", lap_time_ms)
             .field("position", int(lap['Position']))
@@ -521,7 +519,7 @@ def push_influx(ctx, laps, monitor_mode, competitor_name=None, car_info=None,
 
         logging.debug(point.to_line_protocol())
         try:
-            ctx.write_api.write(bucket='laps_252/autogen', record=point)
+            ctx.write_api.write(bucket='laps/autogen', record=point)
             logging.debug("Lap %s written to influx.", lap['Lap'])
         except Exception as e:  # pylint: disable=broad-exception-caught
             logging.error("Writing lap failed: %s", e)

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -1,0 +1,177 @@
+import importlib.util
+import pathlib
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+_spec = importlib.util.spec_from_file_location(
+    "backfill",
+    pathlib.Path(__file__).parent.parent / "backfill.py",
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+
+def _make_race(id, name, start_epoc):
+    return {'ID': id, 'Name': name, 'StartDateEpoc': start_epoc}
+
+
+EPOC_2020 = 1577836800
+EPOC_2021 = 1609459200
+EPOC_2022 = 1640995200
+EPOC_2023 = 1672531200
+
+
+class TestFindMatchingRaces:
+    def _client(self, responses_by_term):
+        """responses_by_term: dict mapping search term → list of race dicts."""
+        client = MagicMock()
+        client.results.search_results.side_effect = lambda term: {
+            'Races': responses_by_term.get(term, [])
+        }
+        return client
+
+    def test_searches_each_lemons_term(self):
+        client = self._client({})
+        _mod.find_matching_races(client, start_year_epoc=EPOC_2021)
+        called_terms = [c.args[0] for c in client.results.search_results.call_args_list]
+        for term in _mod.LEMONS_SEARCH_TERMS:
+            assert term in called_terms
+
+    def test_returns_races_at_or_after_start_year(self):
+        client = self._client({
+            'Real Hoopties': [_make_race(1, 'Real Hoopties 2022', EPOC_2022)],
+        })
+        races = _mod.find_matching_races(client, start_year_epoc=EPOC_2021)
+        assert len(races) == 1
+        assert races[0]['ID'] == 1
+
+    def test_excludes_races_before_start_year(self):
+        client = self._client({
+            'Real Hoopties': [_make_race(1, 'Real Hoopties 2020', EPOC_2020)],
+        })
+        races = _mod.find_matching_races(client, start_year_epoc=EPOC_2021)
+        assert races == []
+
+    def test_deduplicates_races_appearing_in_multiple_searches(self):
+        client = self._client({
+            'Real Hoopties': [_make_race(1, 'Real Hoopties Halloween 2022', EPOC_2022)],
+            'GP du Lac': [],
+            'Halloween Hoop': [_make_race(1, 'Real Hoopties Halloween 2022', EPOC_2022)],
+        })
+        races = _mod.find_matching_races(client, start_year_epoc=EPOC_2021)
+        assert len(races) == 1
+
+    def test_returns_races_sorted_by_start_date(self):
+        client = self._client({
+            'Real Hoopties': [
+                _make_race(2, 'Real Hoopties 2023', EPOC_2023),
+                _make_race(1, 'Real Hoopties 2022', EPOC_2022),
+            ],
+        })
+        races = _mod.find_matching_races(client, start_year_epoc=EPOC_2021)
+        assert [r['ID'] for r in races] == [1, 2]
+
+
+class TestResolveCarNumber:
+    def test_returns_default_when_no_override(self):
+        assert _mod.resolve_car_number('101', default='252', overrides={}) == '252'
+
+    def test_returns_override_when_present(self):
+        assert _mod.resolve_car_number('101', default='252', overrides={'101': '253'}) == '253'
+
+    def test_override_does_not_affect_other_races(self):
+        assert _mod.resolve_car_number('202', default='252', overrides={'101': '253'}) == '252'
+
+
+class TestRunBackfill:
+    def _races(self):
+        return [
+            _make_race(101, 'Real Hoopties 2022', EPOC_2022),
+            _make_race(202, 'Halloween Hoop 2022', EPOC_2022),
+        ]
+
+    def test_calls_laps_for_each_race(self):
+        with patch.object(_mod.subprocess, 'run') as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            _mod.run_backfill(self._races(), default_car='252', overrides={})
+        assert mock_run.call_count == 2
+
+    def test_uses_override_car_number(self):
+        with patch.object(_mod.subprocess, 'run') as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            _mod.run_backfill(self._races(), default_car='252', overrides={'101': '253'})
+        calls = [c.args[0] for c in mock_run.call_args_list]
+        assert '253' in calls[0]
+        assert '252' in calls[1]
+
+    def test_dry_run_does_not_call_subprocess(self):
+        with patch.object(_mod.subprocess, 'run') as mock_run:
+            _mod.run_backfill(self._races(), default_car='252', overrides={}, dry_run=True)
+        mock_run.assert_not_called()
+
+    def test_dry_run_logs_race_name_and_car(self, caplog):
+        import logging
+        with caplog.at_level(logging.INFO, logger='root'):
+            _mod.run_backfill(self._races(), default_car='252', overrides={}, dry_run=True)
+        assert any('Real Hoopties 2022' in r.message and '252' in r.message
+                   for r in caplog.records)
+
+    def test_dry_run_logs_override_car(self, caplog):
+        import logging
+        with caplog.at_level(logging.INFO, logger='root'):
+            _mod.run_backfill(self._races(), default_car='252',
+                              overrides={'101': '253'}, dry_run=True)
+        assert any('Real Hoopties 2022' in r.message and '253' in r.message
+                   for r in caplog.records)
+
+
+class TestBuildPairs:
+    def test_builds_pairs_from_races(self):
+        races = [_make_race(101, 'Real Hoopties 2022', EPOC_2022)]
+        pairs = _mod.build_pairs(races, default_car='252', overrides={})
+        assert pairs == [('101', '252')]
+
+    def test_applies_override_to_matching_race(self):
+        races = [_make_race(101, 'Real Hoopties 2022', EPOC_2022)]
+        pairs = _mod.build_pairs(races, default_car='252', overrides={'101': '253'})
+        assert pairs == [('101', '253')]
+
+    def test_builds_multiple_pairs(self):
+        races = [
+            _make_race(101, 'Real Hoopties 2022', EPOC_2022),
+            _make_race(202, 'GP du Lac 2022', EPOC_2022),
+        ]
+        pairs = _mod.build_pairs(races, default_car='252', overrides={'101': '253'})
+        assert pairs == [('101', '253'), ('202', '252')]
+
+
+class TestArgParsing:
+    def test_dry_run_flag(self):
+        args = _mod._build_parser().parse_args(['--dry-run'])
+        assert args.dry_run is True
+
+    def test_dry_run_default(self):
+        args = _mod._build_parser().parse_args([])
+        assert args.dry_run is False
+
+    def test_override_single(self):
+        args = _mod._build_parser().parse_args(['--override', '12345:253'])
+        assert args.overrides == {'12345': '253'}
+
+    def test_override_multiple(self):
+        args = _mod._build_parser().parse_args(
+            ['--override', '12345:253', '--override', '99999:84'])
+        assert args.overrides == {'12345': '253', '99999': '84'}
+
+    def test_override_default_empty(self):
+        args = _mod._build_parser().parse_args([])
+        assert args.overrides == {}
+
+    def test_validate_flag_accepted(self):
+        args = _mod._build_parser().parse_args(['--validate'])
+        assert args.validate is True
+
+    def test_validate_default_false(self):
+        args = _mod._build_parser().parse_args([])
+        assert args.validate is False

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -1,6 +1,7 @@
 import importlib.util
 import pathlib
-from unittest.mock import MagicMock, call, patch
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -125,6 +126,42 @@ class TestRunBackfill:
         assert any('Real Hoopties 2022' in r.message and '253' in r.message
                    for r in caplog.records)
 
+    def test_subprocess_uses_absolute_path_to_laps_py(self):
+        with patch.object(_mod.subprocess, 'run') as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            _mod.run_backfill(self._races()[:1], default_car='252', overrides={})
+        laps_path = mock_run.call_args.args[0][1]
+        assert pathlib.Path(laps_path).is_absolute()
+        assert laps_path.endswith('laps.py')
+
+    def test_failure_summary_logged_when_any_race_fails(self, caplog):
+        import logging
+        with patch.object(_mod.subprocess, 'run') as mock_run:
+            mock_run.return_value = MagicMock(returncode=1)
+            with caplog.at_level(logging.ERROR, logger='root'):
+                _mod.run_backfill(self._races(), default_car='252', overrides={})
+        assert any('2 race(s) failed' in r.message for r in caplog.records)
+
+    def test_no_failure_summary_when_all_succeed(self, caplog):
+        import logging
+        with patch.object(_mod.subprocess, 'run') as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            with caplog.at_level(logging.ERROR, logger='root'):
+                _mod.run_backfill(self._races(), default_car='252', overrides={})
+        assert not any('failed' in r.message for r in caplog.records)
+
+    def test_returns_failed_race_ids(self):
+        with patch.object(_mod.subprocess, 'run') as mock_run:
+            mock_run.side_effect = [MagicMock(returncode=0), MagicMock(returncode=1)]
+            failures = _mod.run_backfill(self._races(), default_car='252', overrides={})
+        assert failures == [('202', '252')]
+
+    def test_returns_empty_list_when_all_succeed(self):
+        with patch.object(_mod.subprocess, 'run') as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            failures = _mod.run_backfill(self._races(), default_car='252', overrides={})
+        assert failures == []
+
 
 class TestBuildPairs:
     def test_builds_pairs_from_races(self):
@@ -144,6 +181,103 @@ class TestBuildPairs:
         ]
         pairs = _mod.build_pairs(races, default_car='252', overrides={'101': '253'})
         assert pairs == [('101', '253'), ('202', '252')]
+
+
+class TestValidateBackfill:
+    def _make_query_api(self, race_name='My Race', actual_cars=None,
+                        race_start=None, race_end_epoc=1672531200):
+        if actual_cars is None:
+            actual_cars = {}
+        if race_start is None:
+            race_start = datetime(2022, 1, 1, tzinfo=timezone.utc)
+
+        def fake_query(flux):
+            table = MagicMock()
+            if 'bucket: "races"' in flux:
+                if race_name is None:
+                    table.records = []
+                else:
+                    rec = MagicMock()
+                    rec.values = {'race_name': race_name}
+                    rec.get_time.return_value = race_start
+                    rec.get_value.return_value = race_end_epoc
+                    table.records = [rec]
+            else:
+                table.records = []
+                for car, count in actual_cars.items():
+                    rec = MagicMock()
+                    rec.values = {'car_number': car, '_value': count}
+                    table.records.append(rec)
+            return [table]
+
+        api = MagicMock()
+        api.query.side_effect = fake_query
+        return api
+
+    def test_returns_true_when_all_expected_cars_present(self):
+        query_api = self._make_query_api(actual_cars={'42': 10, '99': 5})
+        result = _mod.validate_backfill([('101', '42'), ('101', '99')], query_api)
+        assert result is True
+
+    def test_returns_false_when_a_car_is_missing(self):
+        query_api = self._make_query_api(actual_cars={'42': 10})
+        result = _mod.validate_backfill([('101', '42'), ('101', '99')], query_api)
+        assert result is False
+
+    def test_returns_false_when_race_metadata_missing(self):
+        query_api = self._make_query_api(race_name=None, actual_cars={'42': 10})
+        result = _mod.validate_backfill([('101', '42')], query_api)
+        assert result is False
+
+    def test_logs_race_name_in_output(self, caplog):
+        import logging
+        query_api = self._make_query_api(race_name='Lemons 2026', actual_cars={'42': 10})
+        with caplog.at_level(logging.INFO, logger='root'):
+            _mod.validate_backfill([('101', '42')], query_api)
+        assert any('Lemons 2026' in r.message for r in caplog.records)
+
+    def test_logs_ok_with_car_numbers_and_lap_counts(self, caplog):
+        import logging
+        query_api = self._make_query_api(actual_cars={'42': 10, '99': 5})
+        with caplog.at_level(logging.INFO, logger='root'):
+            _mod.validate_backfill([('101', '42'), ('101', '99')], query_api)
+        assert any('OK' in r.message and '42' in r.message and '10' in r.message
+                   for r in caplog.records)
+
+    def test_logs_missing_cars(self, caplog):
+        import logging
+        query_api = self._make_query_api(actual_cars={'42': 10})
+        with caplog.at_level(logging.WARNING, logger='root'):
+            _mod.validate_backfill([('101', '42'), ('101', '99')], query_api)
+        assert any('MISSING' in r.message and '99' in r.message for r in caplog.records)
+
+    def test_laps_not_queried_when_race_metadata_missing(self):
+        query_api = self._make_query_api(race_name=None)
+        _mod.validate_backfill([('101', '42')], query_api)
+        assert query_api.query.call_count == 1
+
+    def test_laps_query_scoped_to_race_time_bounds(self):
+        race_start = datetime(2022, 6, 1, tzinfo=timezone.utc)
+        query_api = self._make_query_api(actual_cars={'42': 10},
+                                         race_start=race_start, race_end_epoc=1672531200)
+        _mod.validate_backfill([('101', '42')], query_api)
+        laps_flux = query_api.query.call_args_list[1].args[0]
+        assert '1970-01-01' not in laps_flux
+        assert '2022-06-01' in laps_flux
+
+    def test_races_query_filters_by_end_time_epoc_field(self):
+        query_api = self._make_query_api(actual_cars={'42': 10})
+        _mod.validate_backfill([('101', '42')], query_api)
+        races_flux = query_api.query.call_args_list[0].args[0]
+        assert '_field == "end_time_epoc"' in races_flux
+
+    def test_logs_warning_when_end_time_epoc_zero(self, caplog):
+        import logging
+        query_api = self._make_query_api(actual_cars={'42': 10}, race_end_epoc=0)
+        with caplog.at_level(logging.WARNING, logger='root'):
+            _mod.validate_backfill([('101', '42')], query_api)
+        assert any('end_time_epoc' in r.message for r in caplog.records
+                   if r.levelno == logging.WARNING)
 
 
 class TestArgParsing:
@@ -172,6 +306,7 @@ class TestArgParsing:
         args = _mod._build_parser().parse_args(['--validate'])
         assert args.validate is True
 
-    def test_validate_default_false(self):
+    def test_validate_defaults_to_false(self):
         args = _mod._build_parser().parse_args([])
         assert args.validate is False
+

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -391,8 +391,9 @@ class TestOldRaceClassWiring:
             _mod, '_resolve_class_historical', return_value=('A', {1: 1})
         ) as mock_resolve:
             with patch.object(_mod, 'push_influx'):
-                with patch.object(_mod, 'print_rankings'):
-                    _mod.old_race(ctx, opts)
+                with patch.object(_mod, 'push_influx_race'):
+                    with patch.object(_mod, 'print_rankings'):
+                        _mod.old_race(ctx, opts)
         mock_resolve.assert_called_once_with('42', self._session_details())
 
     def test_passes_class_name_to_push_influx(self):
@@ -402,8 +403,9 @@ class TestOldRaceClassWiring:
         ctx.client.results.session_details.return_value = self._session_details()
         with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
             with patch.object(_mod, 'push_influx') as mock_push:
-                with patch.object(_mod, 'print_rankings'):
-                    _mod.old_race(ctx, opts)
+                with patch.object(_mod, 'push_influx_race'):
+                    with patch.object(_mod, 'print_rankings'):
+                        _mod.old_race(ctx, opts)
         _, kwargs = mock_push.call_args
         assert kwargs.get('class_name') == 'A'
 
@@ -417,8 +419,9 @@ class TestOldRaceClassWiring:
         ctx.client.results.session_details.return_value = session
         with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
             with patch.object(_mod, 'push_influx') as mock_push:
-                with patch.object(_mod, 'print_rankings'):
-                    _mod.old_race(ctx, opts)
+                with patch.object(_mod, 'push_influx_race'):
+                    with patch.object(_mod, 'print_rankings'):
+                        _mod.old_race(ctx, opts)
         _, kwargs = mock_push.call_args
         assert kwargs.get('start_epoc') == 5555
 
@@ -431,8 +434,9 @@ class TestOldRaceClassWiring:
         ctx.client.results.session_details.return_value = session
         with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
             with patch.object(_mod, 'push_influx') as mock_push:
-                with patch.object(_mod, 'print_rankings'):
-                    _mod.old_race(ctx, opts)
+                with patch.object(_mod, 'push_influx_race'):
+                    with patch.object(_mod, 'print_rankings'):
+                        _mod.old_race(ctx, opts)
         _, kwargs = mock_push.call_args
         assert kwargs.get('start_epoc') is None
 
@@ -453,8 +457,9 @@ class TestOldRaceClassWiring:
         ctx.client.results.session_details.return_value = self._session_details()
         with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
             with patch.object(_mod, 'push_influx') as mock_push:
-                with patch.object(_mod, 'print_rankings'):
-                    _mod.old_race(ctx, opts)
+                with patch.object(_mod, 'push_influx_race'):
+                    with patch.object(_mod, 'print_rankings'):
+                        _mod.old_race(ctx, opts)
         _, kwargs = mock_push.call_args
         assert kwargs.get('competitor_name') == 'Jane Doe'
 
@@ -467,8 +472,9 @@ class TestOldRaceClassWiring:
         ctx.client.results.session_details.return_value = session
         with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
             with patch.object(_mod, 'push_influx') as mock_push:
-                with patch.object(_mod, 'print_rankings'):
-                    _mod.old_race(ctx, opts)
+                with patch.object(_mod, 'push_influx_race'):
+                    with patch.object(_mod, 'print_rankings'):
+                        _mod.old_race(ctx, opts)
         _, kwargs = mock_push.call_args
         assert kwargs.get('car_info') == '2005/Toy/Celica'
 
@@ -482,10 +488,54 @@ class TestOldRaceClassWiring:
         ctx.client.results.session_details.return_value = session
         with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
             with patch.object(_mod, 'push_influx') as mock_push:
-                with patch.object(_mod, 'print_rankings'):
-                    _mod.old_race(ctx, opts)
+                with patch.object(_mod, 'push_influx_race'):
+                    with patch.object(_mod, 'print_rankings'):
+                        _mod.old_race(ctx, opts)
         _, kwargs = mock_push.call_args
         assert kwargs.get('competitor_name') is None
+
+    def test_old_race_calls_push_influx_race_once_across_multiple_sessions(self):
+        ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 1000)
+        opts = _mod.RaceOptions(network_mode=True)
+        ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}, {'ID': 2}]}
+        ctx.client.results.session_details.return_value = self._session_details()
+        with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
+            with patch.object(_mod, 'push_influx'):
+                with patch.object(_mod, 'push_influx_race') as mock_race:
+                    with patch.object(_mod, 'print_rankings'):
+                        _mod.old_race(ctx, opts)
+        assert mock_race.call_count == 1
+
+    def test_old_race_push_influx_race_timestamp_uses_start_epoc(self):
+        ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 5000)
+        opts = _mod.RaceOptions(network_mode=True)
+        ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
+        ctx.client.results.session_details.return_value = self._session_details()
+        with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
+            with patch.object(_mod, 'push_influx'):
+                with patch.object(_mod, 'push_influx_race') as mock_race:
+                    with patch.object(_mod, 'print_rankings'):
+                        _mod.old_race(ctx, opts)
+        assert mock_race.call_args.args[1] == 5000 * 1000
+
+    def test_old_race_push_influx_race_not_called_when_not_network_mode(self):
+        ctx = _mod.RaceContext('999', '42', MagicMock(), None, 0)
+        opts = _mod.RaceOptions(network_mode=False)
+        ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
+        ctx.client.results.session_details.return_value = self._session_details()
+        with patch.object(_mod, 'push_influx_race') as mock_race:
+            with patch.object(_mod, 'print_rankings'):
+                _mod.old_race(ctx, opts)
+        mock_race.assert_not_called()
+
+    def test_old_race_push_influx_race_not_called_when_car_not_found(self):
+        ctx = _mod.RaceContext('999', '99', MagicMock(), MagicMock(), 1000)
+        opts = _mod.RaceOptions(network_mode=True)
+        ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
+        ctx.client.results.session_details.return_value = self._session_details(car_number='42')
+        with patch.object(_mod, 'push_influx_race') as mock_race:
+            _mod.old_race(ctx, opts)
+        mock_race.assert_not_called()
 
 
 class TestLiveClassWiring:
@@ -516,8 +566,9 @@ class TestLiveClassWiring:
         opts = _mod.RaceOptions(network_mode=True)
         with patch.object(_mod, '_resolve_class_live', return_value=('A', 1)) as mock_resolve:
             with patch.object(_mod, 'push_influx'):
-                with patch.object(_mod, 'print_rankings'):
-                    _mod.live_race(ctx, opts)
+                with patch.object(_mod, 'push_influx_race'):
+                    with patch.object(_mod, 'print_rankings'):
+                        _mod.live_race(ctx, opts)
         mock_resolve.assert_called_once_with(ctx.client, ctx.race_id, ctx.car_number)
 
     def test_live_race_passes_class_name_to_push_influx(self):
@@ -525,8 +576,9 @@ class TestLiveClassWiring:
         opts = _mod.RaceOptions(network_mode=True)
         with patch.object(_mod, '_resolve_class_live', return_value=('A', 2)):
             with patch.object(_mod, 'push_influx') as mock_push:
-                with patch.object(_mod, 'print_rankings'):
-                    _mod.live_race(ctx, opts)
+                with patch.object(_mod, 'push_influx_race'):
+                    with patch.object(_mod, 'print_rankings'):
+                        _mod.live_race(ctx, opts)
         _, kwargs = mock_push.call_args
         assert kwargs.get('class_name') == 'A'
 
@@ -535,8 +587,9 @@ class TestLiveClassWiring:
         opts = _mod.RaceOptions(network_mode=True)
         with patch.object(_mod, '_resolve_class_live', return_value=(None, None)):
             with patch.object(_mod, 'push_influx') as mock_push:
-                with patch.object(_mod, 'print_rankings'):
-                    _mod.live_race(ctx, opts)
+                with patch.object(_mod, 'push_influx_race'):
+                    with patch.object(_mod, 'print_rankings'):
+                        _mod.live_race(ctx, opts)
         _, kwargs = mock_push.call_args
         assert kwargs.get('class_name') is None
         assert kwargs.get('class_positions') is None
@@ -553,8 +606,9 @@ class TestLiveClassWiring:
         opts = _mod.RaceOptions(network_mode=True)
         with patch.object(_mod, '_resolve_class_live', return_value=('A', 2)):
             with patch.object(_mod, 'push_influx') as mock_push:
-                with patch.object(_mod, 'print_rankings'):
-                    _mod.live_race(ctx, opts)
+                with patch.object(_mod, 'push_influx_race'):
+                    with patch.object(_mod, 'print_rankings'):
+                        _mod.live_race(ctx, opts)
         args, kwargs = mock_push.call_args
         assert args[1] == two_laps
         assert kwargs.get('class_positions') is None
@@ -564,9 +618,64 @@ class TestLiveClassWiring:
         ctx.client.live.get_racer.return_value['Details']['Laps'] = []
         opts = _mod.RaceOptions(network_mode=True)
         with patch.object(_mod, 'push_influx') as mock_push:
+            with patch.object(_mod, 'push_influx_race'):
+                with patch.object(_mod, 'print_rankings'):
+                    _mod.live_race(ctx, opts)
+        mock_push.assert_not_called()
+
+    def test_live_race_calls_push_influx_race_in_network_mode(self):
+        ctx = self._make_ctx()
+        ctx.start_epoc = 1000
+        opts = _mod.RaceOptions(network_mode=True)
+        with patch.object(_mod, '_resolve_class_live', return_value=('A', 1)):
+            with patch.object(_mod, 'push_influx'):
+                with patch.object(_mod, 'push_influx_race') as mock_race:
+                    with patch.object(_mod, 'print_rankings'):
+                        _mod.live_race(ctx, opts)
+        mock_race.assert_called_once()
+
+    def test_live_race_push_influx_race_timestamp_uses_start_epoc(self):
+        ctx = self._make_ctx()
+        ctx.start_epoc = 1000
+        opts = _mod.RaceOptions(network_mode=True)
+        with patch.object(_mod, '_resolve_class_live', return_value=('A', 1)):
+            with patch.object(_mod, 'push_influx'):
+                with patch.object(_mod, 'push_influx_race') as mock_race:
+                    with patch.object(_mod, 'print_rankings'):
+                        _mod.live_race(ctx, opts)
+        assert mock_race.call_args.args[1] == 1000 * 1000
+
+    def test_live_race_push_influx_race_timestamp_uses_wall_clock_when_start_epoc_zero(self):
+        ctx = self._make_ctx()
+        ctx.start_epoc = 0
+        opts = _mod.RaceOptions(network_mode=True)
+        with patch.object(_mod, '_resolve_class_live', return_value=('A', 1)):
+            with patch.object(_mod, 'push_influx'):
+                with patch.object(_mod, 'push_influx_race') as mock_race:
+                    with patch.object(_mod, 'print_rankings'):
+                        _mod.live_race(ctx, opts)
+        assert mock_race.called
+        assert mock_race.call_args.args[1] > 0
+
+    def test_live_race_push_influx_race_called_even_when_no_laps(self):
+        ctx = self._make_ctx()
+        ctx.start_epoc = 1000
+        ctx.client.live.get_racer.return_value['Details']['Laps'] = []
+        opts = _mod.RaceOptions(network_mode=True)
+        with patch.object(_mod, 'push_influx') as mock_push:
+            with patch.object(_mod, 'push_influx_race') as mock_race:
+                with patch.object(_mod, 'print_rankings'):
+                    _mod.live_race(ctx, opts)
+        mock_push.assert_not_called()
+        mock_race.assert_called_once()
+
+    def test_live_race_push_influx_race_not_called_when_not_network_mode(self):
+        ctx = self._make_ctx()
+        opts = _mod.RaceOptions(network_mode=False)
+        with patch.object(_mod, 'push_influx_race') as mock_race:
             with patch.object(_mod, 'print_rankings'):
                 _mod.live_race(ctx, opts)
-        mock_push.assert_not_called()
+        mock_race.assert_not_called()
 
     def test_monitor_routine_push_influx_receives_only_new_lap(self):
         ctx = self._make_ctx()
@@ -613,8 +722,9 @@ class TestLiveClassWiring:
         opts = _mod.RaceOptions(network_mode=True)
         with patch.object(_mod, '_resolve_class_live', return_value=('A', 1)):
             with patch.object(_mod, 'push_influx') as mock_push:
-                with patch.object(_mod, 'print_rankings'):
-                    _mod.live_race(ctx, opts)
+                with patch.object(_mod, 'push_influx_race'):
+                    with patch.object(_mod, 'print_rankings'):
+                        _mod.live_race(ctx, opts)
         _, kwargs = mock_push.call_args
         assert kwargs.get('competitor_name') == 'Jane Doe'
 
@@ -624,8 +734,9 @@ class TestLiveClassWiring:
         ctx.client.live.get_racer.return_value['Details']['Competitor']['AdditionalData'] = '2005/Toy/Celica'
         with patch.object(_mod, '_resolve_class_live', return_value=('A', 1)):
             with patch.object(_mod, 'push_influx') as mock_push:
-                with patch.object(_mod, 'print_rankings'):
-                    _mod.live_race(ctx, opts)
+                with patch.object(_mod, 'push_influx_race'):
+                    with patch.object(_mod, 'print_rankings'):
+                        _mod.live_race(ctx, opts)
         _, kwargs = mock_push.call_args
         assert kwargs.get('car_info') == '2005/Toy/Celica'
 

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -733,3 +733,83 @@ class TestResolveRaceMetadata:
     def test_end_time_epoc_zero_when_unsuccessful(self):
         meta = _mod._resolve_race_metadata({'Successful': False}, MagicMock())
         assert meta.end_time_epoc == 0
+
+
+class TestPushInfluxRace:
+    def _ctx(self):
+        write_api = MagicMock()
+        delete_api = MagicMock()
+        ctx = _mod.RaceContext('999', '42', MagicMock(), write_api, 1000000)
+        ctx.delete_api = delete_api
+        ctx.metadata = _mod.RaceMetadata(
+            race_name='The Sausage Fest 2026',
+            track_name='Road America',
+            series_name='24 Hours of Lemons',
+            end_time_epoc=1749132000,
+        )
+        return ctx, write_api, delete_api
+
+    def _record(self, write_api):
+        return write_api.write.call_args.kwargs['record'].to_line_protocol()
+
+    def test_calls_delete_before_write(self):
+        ctx, write_api, delete_api = self._ctx()
+        _mod.push_influx_race(ctx, 5000000)
+        assert delete_api.delete.called
+        assert write_api.write.called
+        # delete must be called before write
+        try:
+            ordering_ok = (
+                delete_api.delete.call_args_list[0] < write_api.write.call_args_list[0])
+        except TypeError:
+            ordering_ok = True  # can't compare kwargs-only calls; fall back to presence check
+        assert ordering_ok or delete_api.delete.called
+
+    def test_delete_targets_correct_race_id(self):
+        ctx, write_api, delete_api = self._ctx()
+        _mod.push_influx_race(ctx, 5000000)
+        predicate = delete_api.delete.call_args.kwargs['predicate']
+        assert 'race_id="999"' in predicate
+        assert '_measurement="race"' in predicate
+
+    def test_delete_targets_races_bucket(self):
+        ctx, write_api, delete_api = self._ctx()
+        _mod.push_influx_race(ctx, 5000000)
+        assert delete_api.delete.call_args.kwargs['bucket'] == 'races'
+
+    def test_writes_to_races_bucket(self):
+        ctx, write_api, delete_api = self._ctx()
+        _mod.push_influx_race(ctx, 5000000)
+        assert write_api.write.call_args.kwargs['bucket'] == 'races/autogen'
+
+    def test_measurement_is_race(self):
+        ctx, write_api, delete_api = self._ctx()
+        _mod.push_influx_race(ctx, 5000000)
+        assert self._record(write_api).startswith('race,')
+
+    def test_race_id_tag(self):
+        ctx, write_api, delete_api = self._ctx()
+        _mod.push_influx_race(ctx, 5000000)
+        assert 'race_id=999' in self._record(write_api)
+
+    def test_track_name_tag(self):
+        ctx, write_api, delete_api = self._ctx()
+        _mod.push_influx_race(ctx, 5000000)
+        assert 'track_name=Road\\ America' in self._record(write_api)
+
+    def test_end_time_epoc_field(self):
+        ctx, write_api, delete_api = self._ctx()
+        _mod.push_influx_race(ctx, 5000000)
+        assert 'end_time_epoc=1749132000i' in self._record(write_api)
+
+    def test_uses_provided_timestamp(self):
+        ctx, write_api, delete_api = self._ctx()
+        _mod.push_influx_race(ctx, 5000)
+        assert self._record(write_api).endswith('5000')
+
+    def test_omits_series_name_tag_when_none(self):
+        ctx, write_api, delete_api = self._ctx()
+        ctx.metadata = _mod.RaceMetadata(
+            race_name='Race', track_name='Track', series_name=None, end_time_epoc=0)
+        _mod.push_influx_race(ctx, 1000)
+        assert 'series_name=' not in self._record(write_api)

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -260,7 +260,7 @@ class TestPushInfluxClassInfo:
         _mod.push_influx(ctx, self._laps(), False, class_name='A', class_positions={1: 2})
         assert 'class=A' in self._record(write_api)
 
-    def test_class_tag_before_car_number_tag(self):
+    def test_car_number_tag_before_class_tag(self):
         ctx, write_api = self._ctx()
         _mod.push_influx(ctx, self._laps(), False, class_name='A', class_positions={1: 1})
         record = self._record(write_api)
@@ -354,7 +354,7 @@ class TestPushInfluxClassInfo:
     def test_bucket_is_laps(self):
         ctx, write_api = self._ctx()
         _mod.push_influx(ctx, self._laps(), False)
-        assert write_api.write.call_args.kwargs['bucket'] == 'laps/autogen'
+        assert write_api.write.call_args.kwargs['bucket'] == 'laps'
 
 
 class TestOldRaceClassWiring:
@@ -976,7 +976,7 @@ class TestPushInfluxRace:
     def test_writes_to_races_bucket(self):
         ctx, write_api, delete_api = self._ctx()
         _mod.push_influx_race(ctx, 5000000)
-        assert write_api.write.call_args.kwargs['bucket'] == 'races/autogen'
+        assert write_api.write.call_args.kwargs['bucket'] == 'races'
 
     def test_measurement_is_race(self):
         ctx, write_api, delete_api = self._ctx()
@@ -1002,6 +1002,16 @@ class TestPushInfluxRace:
         ctx, write_api, delete_api = self._ctx()
         _mod.push_influx_race(ctx, 5000)
         assert self._record(write_api).endswith('5000')
+
+    def test_exception_during_delete_is_logged_not_raised(self):
+        ctx, write_api, delete_api = self._ctx()
+        delete_api.delete.side_effect = Exception("network error")
+        _mod.push_influx_race(ctx, 5000000)  # must not raise
+
+    def test_exception_during_write_is_logged_not_raised(self):
+        ctx, write_api, delete_api = self._ctx()
+        write_api.write.side_effect = Exception("network error")
+        _mod.push_influx_race(ctx, 5000000)  # must not raise
 
     def test_omits_series_name_tag_when_none(self):
         ctx, write_api, delete_api = self._ctx()

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -754,16 +754,11 @@ class TestPushInfluxRace:
 
     def test_calls_delete_before_write(self):
         ctx, write_api, delete_api = self._ctx()
+        call_order = []
+        delete_api.delete.side_effect = lambda **kw: call_order.append('delete')
+        write_api.write.side_effect = lambda **kw: call_order.append('write')
         _mod.push_influx_race(ctx, 5000000)
-        assert delete_api.delete.called
-        assert write_api.write.called
-        # delete must be called before write
-        try:
-            ordering_ok = (
-                delete_api.delete.call_args_list[0] < write_api.write.call_args_list[0])
-        except TypeError:
-            ordering_ok = True  # can't compare kwargs-only calls; fall back to presence check
-        assert ordering_ok or delete_api.delete.called
+        assert call_order == ['delete', 'write']
 
     def test_delete_targets_correct_race_id(self):
         ctx, write_api, delete_api = self._ctx()

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -693,7 +693,8 @@ class TestLiveClassWiring:
         with patch.object(_mod, 'refresh_competitor', return_value=new_laps):
             with patch.object(_mod, '_resolve_class_live', return_value=('A', 1)):
                 with patch.object(_mod, 'push_influx') as mock_push:
-                    _mod.monitor_routine(ctx, existing_laps, opts, _stop_event=mock_stop)
+                    with patch.object(_mod, 'push_influx_race'):
+                        _mod.monitor_routine(ctx, existing_laps, opts, _stop_event=mock_stop)
         laps_arg = mock_push.call_args[0][1]
         assert laps_arg == [new_laps[-1]]
 
@@ -714,7 +715,8 @@ class TestLiveClassWiring:
         with patch.object(_mod, 'refresh_competitor', return_value=new_laps):
             with patch.object(_mod, '_resolve_class_live', return_value=('A', 1)) as mock_resolve:
                 with patch.object(_mod, 'push_influx'):
-                    _mod.monitor_routine(ctx, existing_laps, opts, _stop_event=mock_stop)
+                    with patch.object(_mod, 'push_influx_race'):
+                        _mod.monitor_routine(ctx, existing_laps, opts, _stop_event=mock_stop)
         mock_resolve.assert_called_once_with(ctx.client, ctx.race_id, ctx.car_number)
 
     def test_live_race_passes_competitor_name_to_push_influx(self):
@@ -756,12 +758,100 @@ class TestLiveClassWiring:
         with patch.object(_mod, 'refresh_competitor', return_value=new_laps):
             with patch.object(_mod, '_resolve_class_live', return_value=('A', 1)):
                 with patch.object(_mod, 'push_influx') as mock_push:
-                    _mod.monitor_routine(ctx, existing_laps, opts,
-                                         competitor_name='Jane Doe', car_info='2005/Toy/Celica',
-                                         _stop_event=mock_stop)
+                    with patch.object(_mod, 'push_influx_race'):
+                        _mod.monitor_routine(ctx, existing_laps, opts,
+                                             competitor_name='Jane Doe', car_info='2005/Toy/Celica',
+                                             _stop_event=mock_stop)
         _, kwargs = mock_push.call_args
         assert kwargs.get('competitor_name') == 'Jane Doe'
         assert kwargs.get('car_info') == '2005/Toy/Celica'
+
+
+class TestMonitorRoutineEpocRecheck:
+    # A lap that is already in the laps list — refresh_competitor returns it so the
+    # "new lap" branch never executes, keeping tests focused on the recheck logic.
+    _existing_lap = {
+        'Lap': '1', 'LapTime': '0:01:30.000', 'Position': '1',
+        'FlagStatus': '0', 'TotalTime': '0:01:30.000',
+    }
+
+    def _make_ctx(self, start_epoc=0):
+        ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), start_epoc)
+        ctx.delete_api = MagicMock()
+        ctx.metadata = _mod.RaceMetadata(
+            race_name='Test', track_name='Track', series_name=None, end_time_epoc=0)
+        ctx.client.race.details.return_value = {'Successful': False}
+        return ctx
+
+    def _stop_after(self, n):
+        stop = MagicMock()
+        stop.wait.side_effect = [False] * n + [True]
+        return stop
+
+    def test_rechecks_race_details_each_iteration_when_start_epoc_zero(self):
+        ctx = self._make_ctx(start_epoc=0)
+        opts = _mod.RaceOptions(network_mode=True, interval=30)
+        with patch.object(_mod, 'refresh_competitor', return_value=[self._existing_lap]):
+            with patch.object(_mod, 'push_influx_race'):
+                _mod.monitor_routine(ctx, [self._existing_lap], opts,
+                                     _stop_event=self._stop_after(1))
+        ctx.client.race.details.assert_called_once_with(ctx.race_id)
+
+    def test_does_not_recheck_when_start_epoc_nonzero(self):
+        ctx = self._make_ctx(start_epoc=1000)
+        opts = _mod.RaceOptions(network_mode=True, interval=30)
+        with patch.object(_mod, 'refresh_competitor', return_value=[self._existing_lap]):
+            _mod.monitor_routine(ctx, [self._existing_lap], opts,
+                                 _stop_event=self._stop_after(1))
+        ctx.client.race.details.assert_not_called()
+
+    def test_does_not_recheck_when_not_network_mode(self):
+        ctx = self._make_ctx(start_epoc=0)
+        opts = _mod.RaceOptions(network_mode=False, interval=30)
+        with patch.object(_mod, 'refresh_competitor', return_value=[self._existing_lap]):
+            _mod.monitor_routine(ctx, [self._existing_lap], opts,
+                                 _stop_event=self._stop_after(1))
+        ctx.client.race.details.assert_not_called()
+
+    def test_updates_ctx_start_epoc_when_api_returns_nonzero(self):
+        ctx = self._make_ctx(start_epoc=0)
+        opts = _mod.RaceOptions(network_mode=True, interval=30)
+        ctx.client.race.details.return_value = {
+            'Successful': True,
+            'Race': {'StartDateEpoc': 5000, 'EndDateEpoc': 9000, 'Name': '', 'Track': ''},
+        }
+        with patch.object(_mod, 'refresh_competitor', return_value=[self._existing_lap]):
+            with patch.object(_mod, 'push_influx_race'):
+                _mod.monitor_routine(ctx, [self._existing_lap], opts,
+                                     _stop_event=self._stop_after(1))
+        assert ctx.start_epoc == 5000
+
+    def test_calls_push_influx_race_with_updated_timestamp(self):
+        ctx = self._make_ctx(start_epoc=0)
+        opts = _mod.RaceOptions(network_mode=True, interval=30)
+        ctx.client.race.details.return_value = {
+            'Successful': True,
+            'Race': {'StartDateEpoc': 5000, 'EndDateEpoc': 9000, 'Name': '', 'Track': ''},
+        }
+        with patch.object(_mod, 'refresh_competitor', return_value=[self._existing_lap]):
+            with patch.object(_mod, 'push_influx_race') as mock_race:
+                _mod.monitor_routine(ctx, [self._existing_lap], opts,
+                                     _stop_event=self._stop_after(1))
+        mock_race.assert_called_once_with(ctx, 5000 * 1000)
+
+    def test_stops_rechecking_once_start_epoc_set(self):
+        ctx = self._make_ctx(start_epoc=0)
+        opts = _mod.RaceOptions(network_mode=True, interval=30)
+        ctx.client.race.details.return_value = {
+            'Successful': True,
+            'Race': {'StartDateEpoc': 5000, 'EndDateEpoc': 9000, 'Name': '', 'Track': ''},
+        }
+        with patch.object(_mod, 'refresh_competitor', return_value=[self._existing_lap]):
+            with patch.object(_mod, 'push_influx_race'):
+                _mod.monitor_routine(ctx, [self._existing_lap], opts,
+                                     _stop_event=self._stop_after(2))
+        # First iteration sets epoc; second iteration skips the re-check
+        assert ctx.client.race.details.call_count == 1
 
 
 class TestResolveRaceMetadata:

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -518,6 +518,19 @@ class TestOldRaceClassWiring:
                         _mod.old_race(ctx, opts)
         assert mock_race.call_args.args[1] == 5000 * 1000
 
+    def test_old_race_push_influx_race_uses_wall_clock_when_start_epoc_zero(self):
+        ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
+        opts = _mod.RaceOptions(network_mode=True)
+        ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
+        ctx.client.results.session_details.return_value = self._session_details()
+        with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
+            with patch.object(_mod, 'push_influx'):
+                with patch.object(_mod, 'push_influx_race') as mock_race:
+                    with patch.object(_mod, 'print_rankings'):
+                        with patch.object(_mod.time, 'time', return_value=12345.0):
+                            _mod.old_race(ctx, opts)
+        assert mock_race.call_args.args[1] == 12345000
+
     def test_old_race_push_influx_race_not_called_when_not_network_mode(self):
         ctx = _mod.RaceContext('999', '42', MagicMock(), None, 0)
         opts = _mod.RaceOptions(network_mode=False)
@@ -839,6 +852,19 @@ class TestMonitorRoutineEpocRecheck:
                                      _stop_event=self._stop_after(1))
         mock_race.assert_called_once_with(ctx, 5000 * 1000)
 
+    def test_updates_metadata_end_time_epoc_when_api_returns_epoc(self):
+        ctx = self._make_ctx(start_epoc=0)
+        opts = _mod.RaceOptions(network_mode=True, interval=30)
+        ctx.client.race.details.return_value = {
+            'Successful': True,
+            'Race': {'StartDateEpoc': 5000, 'EndDateEpoc': 9000, 'Name': '', 'Track': ''},
+        }
+        with patch.object(_mod, 'refresh_competitor', return_value=[self._existing_lap]):
+            with patch.object(_mod, 'push_influx_race'):
+                _mod.monitor_routine(ctx, [self._existing_lap], opts,
+                                     _stop_event=self._stop_after(1))
+        assert ctx.metadata.end_time_epoc == 9000
+
     def test_stops_rechecking_once_start_epoc_set(self):
         ctx = self._make_ctx(start_epoc=0)
         opts = _mod.RaceOptions(network_mode=True, interval=30)
@@ -1019,3 +1045,10 @@ class TestPushInfluxRace:
             race_name='Race', track_name='Track', series_name=None, end_time_epoc=0)
         _mod.push_influx_race(ctx, 1000)
         assert 'series_name=' not in self._record(write_api)
+
+    def test_metadata_none_skips_delete_and_write(self):
+        ctx, write_api, delete_api = self._ctx()
+        ctx.metadata = None
+        _mod.push_influx_race(ctx, 1000)
+        delete_api.delete.assert_not_called()
+        write_api.write.assert_not_called()

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -629,6 +629,7 @@ class TestResolveRaceMetadata:
                 'Name': 'The Sausage Fest 2026',
                 'SeriesID': series_id,
                 'Track': 'Road America',
+                'EndDateEpoc': 1749132000,
             }
         }
 
@@ -691,3 +692,11 @@ class TestResolveRaceMetadata:
         assert meta.track_name == ''
         assert meta.series_name is None
         client.common.current_races.assert_not_called()
+
+    def test_end_time_epoc_extracted(self):
+        meta = _mod._resolve_race_metadata(self._race_details(), self._client_with_series())
+        assert meta.end_time_epoc == 1749132000
+
+    def test_end_time_epoc_zero_when_unsuccessful(self):
+        meta = _mod._resolve_race_metadata({'Successful': False}, MagicMock())
+        assert meta.end_time_epoc == 0

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -260,11 +260,11 @@ class TestPushInfluxClassInfo:
         _mod.push_influx(ctx, self._laps(), False, class_name='A', class_positions={1: 2})
         assert 'class=A' in self._record(write_api)
 
-    def test_class_tag_before_driver_tag(self):
+    def test_class_tag_before_car_number_tag(self):
         ctx, write_api = self._ctx()
         _mod.push_influx(ctx, self._laps(), False, class_name='A', class_positions={1: 1})
         record = self._record(write_api)
-        assert record.index('class=') < record.index('driver=')
+        assert record.index('car_number=') < record.index('class=')
 
     def test_includes_class_position_field_when_provided(self):
         ctx, write_api = self._ctx()
@@ -322,6 +322,39 @@ class TestPushInfluxClassInfo:
         ctx, write_api = self._ctx()
         _mod.push_influx(ctx, self._laps(), False)
         assert 'car_info' not in self._record(write_api)
+
+    def test_measurement_is_lap(self):
+        ctx, write_api = self._ctx()
+        _mod.push_influx(ctx, self._laps(), False)
+        assert self._record(write_api).startswith('lap,')
+
+    def test_race_id_tag_present(self):
+        ctx, write_api = self._ctx()
+        _mod.push_influx(ctx, self._laps(), False)
+        assert 'race_id=999' in self._record(write_api)
+
+    def test_car_number_tag_replaces_driver(self):
+        ctx, write_api = self._ctx()
+        _mod.push_influx(ctx, self._laps(), False)
+        record = self._record(write_api)
+        assert 'car_number=42' in record
+        assert 'driver=' not in record
+
+    def test_race_metadata_tags_absent_from_lap(self):
+        ctx, write_api = self._ctx()
+        ctx.metadata = _mod.RaceMetadata(
+            race_name='Test Race', track_name='Road America',
+            series_name='Lemons', end_time_epoc=9999)
+        _mod.push_influx(ctx, self._laps(), False)
+        record = self._record(write_api)
+        assert 'race_name=' not in record
+        assert 'track_name=' not in record
+        assert 'series_name=' not in record
+
+    def test_bucket_is_laps(self):
+        ctx, write_api = self._ctx()
+        _mod.push_influx(ctx, self._laps(), False)
+        assert write_api.write.call_args.kwargs['bucket'] == 'laps/autogen'
 
 
 class TestOldRaceClassWiring:


### PR DESCRIPTION
## Summary

- **New two-bucket schema**: writes lap telemetry to `laps` bucket (`lap` measurement, `race_id` tag) and race metadata to `races` bucket, replacing the old per-race measurements in `laps_252`
- **Delete-before-insert idempotency**: `push_influx_race` deletes existing data for a race before writing, so reruns are safe
- **`StartDateEpoc` recheck**: `monitor_routine` polls for the race start epoch when it isn't available at startup, updates both `ctx.start_epoc` and `ctx.metadata.end_time_epoc` once resolved
- **Historical backfill**: `backfill.py` discovers past Real Hoopties, GP du Lac, and Halloween Hoop races via the RaceMonitor search API and backfills lap data for car 252 (with per-race overrides); `--validate` mode queries InfluxDB to confirm data landed, scoped to race time bounds
- **Diagnostic tooling**: `diagnose_race.py` compares API vs InfluxDB lap counts side-by-side, scoped to race time bounds from the API

## Key changes

- `laps.py`: `push_influx_race` with delete-before-insert, `ctx.metadata is None` guard before delete fires, wall-clock fallback when `start_epoc=0` in both `live_race` and `old_race`, `strftime` for RFC 3339 timestamps, `monitor_routine` updates `end_time_epoc` on recheck
- `backfill.py`: `--dry-run`, `--override RACE_ID:CAR`, `--validate`, `--start-year` flags; `validate_backfill` lives here natively (no `migrate.py` dependency); laps query scoped to race time bounds with `_field` filter before `first()`; `run_backfill` returns failures list and `main()` exits non-zero on failure; absolute path for `laps.py` subprocess
- `diagnose_race.py`: scoped InfluxDB queries using API-derived time bounds; warns when `end_time_epoc` not available

## Test plan

- [ ] `uv run pytest` — 160 tests pass
- [ ] `uv run python backfill.py --dry-run` shows expected races
- [ ] `uv run python backfill.py --validate` confirms all backfilled races have data
- [ ] `uv run python diagnose_race.py <race_id> 252` shows consistent counts between API and InfluxDB

🤖 Generated with [Claude Code](https://claude.com/claude-code)