### PR TITLE
feat(laps): delete-and-replace car laps on historical backfill

### DIFF
--- a/diagnose_race.py
+++ b/diagnose_race.py
@@ -121,9 +121,11 @@ def main():
     influx_token = os.environ.get('INFLUX_TELEMETRY_TOKEN')
 
     if not rm_token:
-        print("RACEMONITOR_TOKEN not set"); sys.exit(1)
+        print("RACEMONITOR_TOKEN not set")
+        sys.exit(1)
     if not influx_token:
-        print("INFLUX_TELEMETRY_TOKEN not set"); sys.exit(1)
+        print("INFLUX_TELEMETRY_TOKEN not set")
+        sys.exit(1)
 
     with RaceMonitorClient(api_token=rm_token) as client:
         start_epoc, end_epoc = diagnose_api(client, race_id, car_number)

--- a/laps.py
+++ b/laps.py
@@ -294,6 +294,7 @@ def old_race(ctx, opts):
     competitor_missing = True
     competitor_name = None
     car_info = None
+    deleted = False
 
     for session_id in session_ids_for_race:
         logging.debug("Getting session details for %s including lap times.", session_id)
@@ -319,6 +320,9 @@ def old_race(ctx, opts):
                 {**lap, 'FlagStatus': flag_map.get(lap['FlagStatus'], str(lap['FlagStatus']))}
                 for lap in session_laps
             ]
+            if not deleted:
+                delete_existing_laps(ctx)
+                deleted = True
             class_name, class_positions = _resolve_class_historical(ctx.car_number, session_details)
             push_influx(
                 ctx, influx_laps, False,

--- a/laps.py
+++ b/laps.py
@@ -4,10 +4,15 @@
 #
 # Last tested with Python 3.12 on 2026-04-05
 #
-# TODO:
-#   When in live race mode timestamps are tagging with an offset different than the historical view.
-#   If this time offset can be adjusted it would be preferable to store the data in live view
-#   format over the weekend.
+# Timestamp anchoring (design decision):
+#   Live mode anchors lap timestamps on Race['StartDateEpoc']; the historical view anchors on
+#   SessionStartDateEpoc, so the two disagree by up to ~35 min. Aligning the live anchor was
+#   ruled out: the live API never exposes SessionStartDateEpoc, and the live feed's cumulative
+#   offset differs from historical, so even the same anchor would not produce matching points.
+#   Instead, historical is treated as the source of truth: a post-race network-mode run
+#   (old_race) deletes the tracked car's lap points and rewrites the complete historical set
+#   (correct timestamps + class_position on every lap) via delete_existing_laps. Live/monitor
+#   writes are the during-race approximation; the backfill makes the final record authoritative.
 
 import argparse
 import csv

--- a/laps.py
+++ b/laps.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 """Interact with the RaceMonitor lap timing system."""
 #
-# Last tested with Python 3.12 on 2026-04-05
-#
 # Timestamp anchoring (design decision):
 #   Live mode anchors lap timestamps on Race['StartDateEpoc']; the historical view anchors on
 #   SessionStartDateEpoc, so the two disagree by up to ~35 min. Aligning the live anchor was

--- a/laps.py
+++ b/laps.py
@@ -580,6 +580,22 @@ def push_influx_race(ctx, timestamp_ms):
         logging.error("Writing race failed: %s", e)
 
 
+def delete_existing_laps(ctx):
+    """Delete all lap points for the tracked car so a backfill can replace them."""
+    try:
+        ctx.delete_api.delete(
+            start='1970-01-01T00:00:00Z',
+            stop=datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
+            predicate=(
+                f'_measurement="lap" AND race_id="{ctx.race_id}" '
+                f'AND car_number="{ctx.car_number}"'
+            ),
+            bucket='laps',
+        )
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        logging.error("Deleting existing laps failed: %s", e)
+
+
 def _resolve_class_historical(car_number, session_details):
     """Return (class_name, {lap_num: class_position}) for the tracked car."""
     session = session_details['Session']

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -3,8 +3,6 @@ import pathlib
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 _spec = importlib.util.spec_from_file_location(
     "backfill",
     pathlib.Path(__file__).parent.parent / "backfill.py",

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -550,6 +550,67 @@ class TestOldRaceClassWiring:
             _mod.old_race(ctx, opts)
         mock_race.assert_not_called()
 
+    def test_deletes_existing_laps_before_push(self):
+        ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
+        ctx.delete_api = MagicMock()
+        opts = _mod.RaceOptions(network_mode=True)
+        ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
+        ctx.client.results.session_details.return_value = self._session_details()
+        order = []
+        with patch.object(_mod, 'delete_existing_laps',
+                          side_effect=lambda c: order.append('delete')) as mock_del:
+            with patch.object(_mod, 'push_influx',
+                              side_effect=lambda *a, **k: order.append('push')):
+                with patch.object(_mod, 'push_influx_race'):
+                    with patch.object(_mod, 'print_rankings'):
+                        with patch.object(_mod, '_resolve_class_historical',
+                                          return_value=('A', {1: 1})):
+                            _mod.old_race(ctx, opts)
+        mock_del.assert_called_once_with(ctx)
+        assert order == ['delete', 'push']
+
+    def test_delete_fires_once_across_multiple_sessions(self):
+        ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
+        ctx.delete_api = MagicMock()
+        opts = _mod.RaceOptions(network_mode=True)
+        ctx.client.results.sessions_for_race.return_value = {
+            'Sessions': [{'ID': 1}, {'ID': 2}]}
+        ctx.client.results.session_details.return_value = self._session_details()
+        with patch.object(_mod, 'delete_existing_laps') as mock_del:
+            with patch.object(_mod, 'push_influx'):
+                with patch.object(_mod, 'push_influx_race'):
+                    with patch.object(_mod, 'print_rankings'):
+                        with patch.object(_mod, '_resolve_class_historical',
+                                          return_value=('A', {1: 1})):
+                            _mod.old_race(ctx, opts)
+        mock_del.assert_called_once_with(ctx)
+
+    def test_no_delete_when_competitor_missing(self):
+        ctx = _mod.RaceContext('999', '77', MagicMock(), MagicMock(), 0)
+        ctx.delete_api = MagicMock()
+        opts = _mod.RaceOptions(network_mode=True)
+        # session contains car 42 only; tracked car 77 is absent
+        ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
+        ctx.client.results.session_details.return_value = self._session_details()
+        with patch.object(_mod, 'delete_existing_laps') as mock_del:
+            with patch.object(_mod, 'push_influx'):
+                with patch.object(_mod, 'push_influx_race'):
+                    with patch.object(_mod, 'print_rankings'):
+                        _mod.old_race(ctx, opts)
+        mock_del.assert_not_called()
+
+    def test_no_delete_when_not_network_mode(self):
+        ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
+        ctx.delete_api = MagicMock()
+        opts = _mod.RaceOptions(network_mode=False)
+        ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
+        ctx.client.results.session_details.return_value = self._session_details()
+        with patch.object(_mod, 'delete_existing_laps') as mock_del:
+            with patch.object(_mod, 'push_influx'):
+                with patch.object(_mod, 'print_rankings'):
+                    _mod.old_race(ctx, opts)
+        mock_del.assert_not_called()
+
 
 class TestLiveClassWiring:
     def _make_ctx(self):

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -585,6 +585,29 @@ class TestOldRaceClassWiring:
                             _mod.old_race(ctx, opts)
         mock_del.assert_called_once_with(ctx)
 
+    def test_delete_fires_on_first_session_that_has_the_car(self):
+        # Car 42 is absent from session 1 (which holds car 99) and present in
+        # session 2. The delete must fire while processing session 2, not before.
+        ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
+        ctx.delete_api = MagicMock()
+        opts = _mod.RaceOptions(network_mode=True)
+        ctx.client.results.sessions_for_race.return_value = {
+            'Sessions': [{'ID': 1}, {'ID': 2}]}
+        ctx.client.results.session_details.side_effect = [
+            self._session_details(car_number='99'),
+            self._session_details(car_number='42'),
+        ]
+        with patch.object(_mod, 'delete_existing_laps') as mock_del:
+            with patch.object(_mod, 'push_influx') as mock_push:
+                with patch.object(_mod, 'push_influx_race'):
+                    with patch.object(_mod, 'print_rankings'):
+                        with patch.object(_mod, '_resolve_class_historical',
+                                          return_value=('A', {1: 1})):
+                            _mod.old_race(ctx, opts)
+        # Only session 2 yields laps, so exactly one delete and one push occur.
+        mock_del.assert_called_once_with(ctx)
+        mock_push.assert_called_once()
+
     def test_no_delete_when_competitor_missing(self):
         ctx = _mod.RaceContext('999', '77', MagicMock(), MagicMock(), 0)
         ctx.delete_api = MagicMock()

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -1052,3 +1052,30 @@ class TestPushInfluxRace:
         _mod.push_influx_race(ctx, 1000)
         delete_api.delete.assert_not_called()
         write_api.write.assert_not_called()
+
+
+class TestDeleteExistingLaps:
+    def _ctx(self):
+        delete_api = MagicMock()
+        ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
+        ctx.delete_api = delete_api
+        return ctx, delete_api
+
+    def test_predicate_targets_measurement_race_and_car(self):
+        ctx, delete_api = self._ctx()
+        _mod.delete_existing_laps(ctx)
+        predicate = delete_api.delete.call_args.kwargs['predicate']
+        assert '_measurement="lap"' in predicate
+        assert 'race_id="999"' in predicate
+        assert 'car_number="42"' in predicate
+
+    def test_targets_laps_bucket(self):
+        ctx, delete_api = self._ctx()
+        _mod.delete_existing_laps(ctx)
+        assert delete_api.delete.call_args.kwargs['bucket'] == 'laps'
+
+    def test_delete_failure_is_swallowed_and_logged(self, caplog):
+        ctx, delete_api = self._ctx()
+        delete_api.delete.side_effect = Exception("network error")
+        _mod.delete_existing_laps(ctx)  # must not raise
+        assert "Deleting existing laps failed" in caplog.text


### PR DESCRIPTION
## Summary
- Add `delete_existing_laps(ctx)` helper that deletes the tracked car's lap points from the `laps` bucket (predicate scoped to `_measurement="lap"`, `race_id`, `car_number`), mirroring the existing delete-then-write pattern in `push_influx_race`.
- Wire a one-time, lazy delete into `old_race`: on the first session that yields laps for the car, delete the car's existing lap points before rewriting the complete historical set.

## Why
Monitor mode only writes `class_position` for laps that arrive *after* `-m` starts; earlier laps are written with `class_position=None`. A post-race backfill can't fill those in place because live and historical timestamps anchor to different epochs (`Race['StartDateEpoc']` vs `SessionStartDateEpoc`), so InfluxDB sees different points. Instead of reconciling timestamps, the historical backfill now deletes and replaces the car's laps so the post-race `session_details` data — which has correct timestamps and `class_position` on every lap — becomes authoritative.

The delete is once-per-run (a `deleted` flag prevents later sessions from wiping earlier writes) and lazy (only fires when there's real data to replace, so a missing car or non-network run never deletes).

## Test Plan
- [x] `uv run pytest tests/test_laps.py` — 106 passing
- New tests: delete fires once before push, fires once across multiple sessions, does not fire when the competitor is missing, does not fire in non-network mode; plus predicate/bucket/error-handling tests for the helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)