### PR TITLE
feat(influx): batch point writes to reduce HTTP requests

### DIFF
--- a/laps.py
+++ b/laps.py
@@ -22,7 +22,6 @@ import threading
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from operator import itemgetter
 
 import pandas
 from influxdb_client import InfluxDBClient, Point, WritePrecision
@@ -192,33 +191,7 @@ def live_race(ctx, opts):
     """Called if a race ID is live."""
     ctx.client.live.get_session(ctx.race_id)
 
-    list_of_competitors = []
-
-    # for competitor in competitors:
-    #    list_of_competitors.append(competitors[competitor])
-
-    for competitor in list_of_competitors:
-        for key, value in competitor.items():
-            try:
-                if key == 'Position':
-                    competitor[key] = int(value)
-            except ValueError:
-                value = None
-
-    # Remove competitors (LOSERS) with no position
-    list_of_competitors = [racer for racer in list_of_competitors if racer['Number'] != '']
-
-    for item in list_of_competitors:
-        print(item)
-        if item['Position'] == '':
-            print("Dirty data")
-            list_of_competitors.remove(item)
-            break
-
-    sorted_competitors = sorted(
-        list_of_competitors, key=lambda k: int(itemgetter('Position')(k)))
-
-    print_rankings(sorted_competitors, True, opts.selected_class)
+    print_rankings([], True, opts.selected_class)
 
     competitor_details = {}
     laps = []
@@ -514,7 +487,7 @@ def push_influx(ctx, laps, monitor_mode, competitor_name=None, car_info=None,
     if not monitor_mode:
         logging.info("Writing laps to influx...")
 
-    write_success = True
+    points = []
     for lap in laps:
         h, m, s = lap['TotalTime'].split(':')
         s, ms = s.split('.')
@@ -547,15 +520,20 @@ def push_influx(ctx, laps, monitor_mode, competitor_name=None, car_info=None,
                 point = point.field("class_position", class_pos)
 
         logging.debug(point.to_line_protocol())
-        try:
-            ctx.write_api.write(bucket='laps', record=point)
-            logging.debug("Lap %s written to influx.", lap['Lap'])
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            logging.error("Writing lap failed: %s", e)
-            write_success = False
+        points.append(point)
 
-    if write_success and not monitor_mode:
-        logging.info('All lap data written successfully')
+    if points:
+        # One atomic write per session/backfill call. No re-queue on failure
+        # (unlike telem.py's flush loop): this is a one-shot push, and the
+        # backfill path deletes-and-replaces a car's laps wholesale, so the
+        # recovery for a failed write is to re-run, not to retry in-place.
+        try:
+            ctx.write_api.write(bucket='laps', record=points)
+            logging.debug("Wrote %d laps to influx.", len(points))
+            if not monitor_mode:
+                logging.info('All lap data written successfully')
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            logging.error("Writing %d laps failed: %s", len(points), e)
 
     print(UNDERLINE)
 

--- a/pisugar-monitor.py
+++ b/pisugar-monitor.py
@@ -83,19 +83,30 @@ def exec_command(command, token=None):
         return raw
 
 
-def send_value(write_api, measurement, value, tags=None):
-    """Write a single measurement point to InfluxDB."""
-    ts = datetime.now(timezone.utc)
+def build_point(measurement, value, tags=None):
+    """Build a single InfluxDB measurement point."""
     point = Point(measurement)
     for k, v in (tags or {}).items():
         point = point.tag(k, v)
-    point = point.field("value", value).time(ts)
+    point = point.field("value", value).time(datetime.now(timezone.utc))
     logger.debug(point)
+    return point
+
+
+def write_points(write_api, points):
+    """Write all points to InfluxDB in a single request.
+
+    The batch is atomic: if one point is rejected (e.g. a malformed PiSugar
+    response yields a non-numeric value for a normally-float field), all six
+    readings for this tick are dropped. We don't re-queue on failure because
+    the 0.5s loop re-reads fresh values next iteration -- a stale battery
+    reading has no value worth preserving.
+    """
     try:
-        write_api.write(bucket='stats_252/autogen', record=point)
-        logger.info("Wrote %s: %s", measurement, value)
+        write_api.write(bucket='stats_252/autogen', record=points)
+        logger.info("Wrote %d points to InfluxDB", len(points))
     except Exception:  # pylint: disable=broad-exception-caught
-        logger.exception("Failed to write %s to InfluxDB", measurement)
+        logger.exception("Failed to write %d points to InfluxDB", len(points))
 
 
 def main():
@@ -140,12 +151,14 @@ def main():
                 plugged = exec_command("get battery_power_plugged", pisugar_token)
                 voltage = exec_command("get battery_v", pisugar_token)
                 temperature = exec_command("get temperature", pisugar_token)
-                send_value(write_api, "pisugar-battery-charging", charging, device_tags)
-                send_value(write_api, "pisugar-battery-current", current, device_tags)
-                send_value(write_api, "pisugar-battery-level", level, device_tags)
-                send_value(write_api, "pisugar-battery-power-plugged", plugged, device_tags)
-                send_value(write_api, "pisugar-battery-voltage", voltage, device_tags)
-                send_value(write_api, "pisugar-temperature", temperature, device_tags)
+                write_points(write_api, [
+                    build_point("pisugar-battery-charging", charging, device_tags),
+                    build_point("pisugar-battery-current", current, device_tags),
+                    build_point("pisugar-battery-level", level, device_tags),
+                    build_point("pisugar-battery-power-plugged", plugged, device_tags),
+                    build_point("pisugar-battery-voltage", voltage, device_tags),
+                    build_point("pisugar-temperature", temperature, device_tags),
+                ])
             except urllib.error.HTTPError as e:
                 if e.code == 401 and username and password:
                     logger.warning("PiSugar token expired, re-authenticating")

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -252,8 +252,23 @@ class TestPushInfluxClassInfo:
         return ctx, write_api
 
     def _record(self, write_api):
-        point = write_api.write.call_args[1]['record']
-        return point.to_line_protocol()
+        record = write_api.write.call_args[1]['record']
+        points = record if isinstance(record, list) else [record]
+        return points[0].to_line_protocol()
+
+    def test_multiple_laps_written_in_single_batch(self):
+        ctx, write_api = self._ctx()
+        laps = [
+            {'Lap': '1', 'LapTime': '0:01:30.000', 'Position': '3',
+             'FlagStatus': 'Green', 'TotalTime': '0:01:30.000'},
+            {'Lap': '2', 'LapTime': '0:01:31.000', 'Position': '2',
+             'FlagStatus': 'Green', 'TotalTime': '0:03:01.000'},
+        ]
+        _mod.push_influx(ctx, laps, False)
+        write_api.write.assert_called_once()
+        record = write_api.write.call_args[1]['record']
+        assert isinstance(record, list)
+        assert len(record) == 2
 
     def test_includes_class_tag_when_provided(self):
         ctx, write_api = self._ctx()


### PR DESCRIPTION
## Summary

Batch InfluxDB point writes to cut per-point HTTP requests, mirroring the existing `flush_points` batching in `telem.py`. Point construction is byte-for-byte unchanged — only the write call is hoisted out of the loop.

- **`pisugar-monitor.py`**: replaced per-measurement `send_value` with `build_point` + `write_points`. The six battery/temperature points per tick now write in a single request (**6× fewer writes per 0.5s loop**).
- **`laps.py`**: `push_influx` accumulates lap points and writes once. Biggest win on the historical backfill path (hundreds of laps → **one write per session**), which compounds across `backfill.py`. Also removed provably-dead code in `live_race` (an always-empty `list_of_competitors` block) and the now-unused `itemgetter` import.
- Documented the atomic-batch and no-requeue tradeoffs at both write sites.

## Tradeoffs (intentional)

- **All-or-nothing batches.** A single rejected point now fails the whole batch. Acceptable: pisugar self-heals on the next 0.5s tick; `push_influx` is one-shot per session and the backfill deletes-and-replaces a car's laps wholesale.
- **No re-queue on failure** (unlike `telem.py`'s live buffer) — correct for both call sites since the data is either regenerated each tick or recovered by re-running the backfill.

## Testing

- `tests/test_laps.py`: updated `_record` helper for the batched list record; added `test_multiple_laps_written_in_single_batch` asserting `push_influx` issues exactly one `write` carrying all points.
- Full suite green: **169 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)