### PR TITLE
feat(backfill): skip already-backfilled races; fix lap time parsing; show class

### DIFF
--- a/backfill.py
+++ b/backfill.py
@@ -10,7 +10,7 @@ Usage:
     # Preview what would be backfilled (no writes)
     uv run python backfill.py --dry-run
 
-    # Run the backfill (default car 252, from 2021 onwards). Races whose laps are
+    # Run the backfill (default car 252, from 2017 onwards). Races whose laps are
     # already complete and written under the current schema version are skipped.
     uv run python backfill.py
 

--- a/backfill.py
+++ b/backfill.py
@@ -10,8 +10,13 @@ Usage:
     # Preview what would be backfilled (no writes)
     uv run python backfill.py --dry-run
 
-    # Run the backfill (default car 252, from 2021 onwards)
+    # Run the backfill (default car 252, from 2021 onwards). Races whose laps are
+    # already complete and written under the current schema version are skipped.
     uv run python backfill.py
+
+    # Force a re-backfill of every race, even ones already complete and current
+    # (e.g. after bumping SCHEMA_VERSION in laps.py to migrate historical data)
+    uv run python backfill.py --force
 
     # Override car number for a specific race (e.g. 2022 Hoopties used car 253)
     uv run python backfill.py --override 120037:253
@@ -40,7 +45,7 @@ from race_monitor import RaceMonitorClient
 
 LEMONS_SEARCH_TERMS = ['Real Hoopties', 'GP du Lac', 'Halloween Hoop']
 DEFAULT_CAR_NUMBER = '252'
-DEFAULT_START_YEAR = 2021
+DEFAULT_START_YEAR = 2017
 EPOCH_START = '1970-01-01T00:00:00Z'
 
 
@@ -69,6 +74,9 @@ def _build_parser():
                         help=f'Default car number (default: {DEFAULT_CAR_NUMBER})')
     parser.add_argument('--validate', dest='validate', action='store_true', default=False,
                         help='Check that every backfilled race has data in the new buckets')
+    parser.add_argument('--force', dest='force', action='store_true', default=False,
+                        help='Re-backfill every race even if its laps are already complete and '
+                             'current; by default complete races are skipped')
     return parser
 
 
@@ -157,22 +165,27 @@ def validate_backfill(pairs, query_api):
 _LAPS_PY = str(pathlib.Path(__file__).parent / 'laps.py')
 
 
-def run_backfill(races, default_car, overrides, dry_run=False):
-    """Run laps.py -n for each race, using per-race car number overrides where set."""
+def run_backfill(races, default_car, overrides, dry_run=False, force=False):
+    """Run laps.py -n for each race, using per-race car number overrides where set.
+
+    Unless force is set, passes --skip-if-complete so laps.py skips races whose
+    laps are already complete and written under the current schema version.
+    """
     failures = []
     for race in races:
         race_id = str(race['ID'])
         car_number = resolve_car_number(race_id, default_car, overrides)
+        cmd = [sys.executable, _LAPS_PY, '-n']
+        if not force:
+            cmd.append('--skip-if-complete')
+        cmd += [race_id, car_number]
         if dry_run:
             logging.info("Would backfill race %s (%s) car %s",
                          race_id, race['Name'], car_number)
             continue
         logging.info("Backfilling race %s (%s) car %s",
                      race_id, race['Name'], car_number)
-        result = subprocess.run(
-            [sys.executable, _LAPS_PY, '-n', race_id, car_number],
-            capture_output=False,
-        )
+        result = subprocess.run(cmd, capture_output=False)
         if result.returncode != 0:
             logging.error("Backfill failed for race %s car %s", race_id, car_number)
             failures.append((race_id, car_number))
@@ -208,7 +221,8 @@ def main():
                 ok = validate_backfill(pairs, influx_client.query_api())
             sys.exit(0 if ok else 1)
 
-        failures = run_backfill(races, args.car_number, args.overrides, dry_run=args.dry_run)
+        failures = run_backfill(races, args.car_number, args.overrides,
+                                dry_run=args.dry_run, force=args.force)
         if failures:
             sys.exit(1)
 

--- a/laps.py
+++ b/laps.py
@@ -541,12 +541,19 @@ def _time_to_ms(value):
     Accepts variable precision: 'H:MM:SS.mmm', 'MM:SS.mmm', or 'SS.mmm', with the
     fractional '.mmm' part optional. RaceMonitor omits the hours component when a
     value is under an hour, so we right-align the colon-separated parts.
+
+    Returns 0 for unparseable values; the API occasionally returns garbage for
+    invalid or pit laps.
     """
-    parts = value.split(':')
-    sec, _, ms = parts[-1].partition('.')
-    hours = int(parts[-3]) if len(parts) >= 3 else 0
-    minutes = int(parts[-2]) if len(parts) >= 2 else 0
-    return hours * 3600000 + minutes * 60000 + int(sec) * 1000 + int(ms or 0)
+    try:
+        parts = value.split(':')
+        sec, _, ms = parts[-1].partition('.')
+        hours = int(parts[-3]) if len(parts) >= 3 else 0
+        minutes = int(parts[-2]) if len(parts) >= 2 else 0
+        return hours * 3600000 + minutes * 60000 + int(sec) * 1000 + int(ms or 0)
+    except (ValueError, AttributeError):
+        logging.warning("unparseable lap time %r; writing 0 ms", value)
+        return 0
 
 
 def push_influx(ctx, laps, monitor_mode, competitor_name=None, car_info=None,

--- a/laps.py
+++ b/laps.py
@@ -30,6 +30,24 @@ from race_monitor import RaceMonitorClient
 
 UNDERLINE = "-" * 80
 
+EPOCH_START = '1970-01-01T00:00:00Z'
+
+# Version of the lap write/normalization schema. Stamped on every lap point
+# written by the historical backfill (push_influx) and used by --skip-if-complete
+# to decide whether a race's existing laps are current.
+#
+# When to bump: increment this whenever the way laps are written or normalized
+# changes such that previously-written laps would now come out differently —
+# e.g. a new/renamed field, a changed flag-status mapping, a timestamp-anchoring
+# fix, or any other change to the lap point shape or values.
+#
+# Effect of bumping: the next backfill run with --skip-if-complete will treat all
+# previously-written races as stale (their stamp no longer matches) and re-backfill
+# them, rewriting historical data under the new schema. That "rewrite everything"
+# behavior is itself a useful migration tool — bump the version and re-run the
+# backfill to bring all historical races up to the current schema.
+SCHEMA_VERSION = 1
+
 
 @dataclass
 class RaceMetadata:
@@ -50,6 +68,7 @@ class RaceContext:
     start_epoc: int
     metadata: RaceMetadata | None = None
     delete_api: object = None
+    query_api: object = None
 
 
 @dataclass
@@ -60,6 +79,7 @@ class RaceOptions:
     save_file: bool = False
     selected_class: str | None = None
     interval: int = 30
+    skip_if_complete: bool = False
 
 
 def _build_parser():
@@ -80,6 +100,10 @@ def _build_parser():
         default=False,
         action='store_true',
         help='Write lap times to CSV')
+    parser.add_argument('--skip-if-complete', dest='skip_if_complete', default=False,
+                        action='store_true',
+                        help='Skip the backfill if this car already has all its laps written '
+                             'under the current schema version (historical -n mode only)')
     parser.add_argument('-v', '--verbose', help="Set debug logging", action='store_true')
     parser.add_argument(
         '--interval',
@@ -128,6 +152,7 @@ def main():  # pylint: disable=too-many-branches,too-many-statements,too-many-lo
         save_file=args.save_file,
         selected_class=args.selected_class,
         interval=args.interval,
+        skip_if_complete=args.skip_if_complete,
     )
 
     with RaceMonitorClient(api_token=token) as client:
@@ -169,9 +194,11 @@ def main():  # pylint: disable=too-many-branches,too-many-statements,too-many-lo
         ) as influx_client:
             write_api = influx_client.write_api(write_options=SYNCHRONOUS)
             delete_api = influx_client.delete_api()
+            query_api = influx_client.query_api()
             return _run_race(
                 RaceContext(race_id, car_number, client, write_api, start_epoc,
-                            metadata=metadata, delete_api=delete_api), opts, response)
+                            metadata=metadata, delete_api=delete_api,
+                            query_api=query_api), opts, response)
 
 
 def _run_race(ctx, opts, response):
@@ -270,8 +297,11 @@ def old_race(ctx, opts):
     competitor_missing = True
     competitor_name = None
     car_info = None
-    deleted = False
+    pending_writes = []
 
+    # First pass: gather every session's laps for the tracked car. We accumulate
+    # the write payloads instead of writing inline so the skip check below can see
+    # the complete expected lap count before any delete/write happens.
     for session_id in session_ids_for_race:
         logging.debug("Getting session details for %s including lap times.", session_id)
         session_details = ctx.client.results.session_details(session_id, include_lap_times=True)
@@ -296,22 +326,44 @@ def old_race(ctx, opts):
                 {**lap, 'FlagStatus': flag_map.get(lap['FlagStatus'], str(lap['FlagStatus']))}
                 for lap in session_laps
             ]
-            if not deleted:
-                delete_existing_laps(ctx)
-                deleted = True
             class_name, class_positions = _resolve_class_historical(ctx.car_number, session_details)
-            push_influx(
-                ctx, influx_laps, False,
-                competitor_name=competitor_name,
-                car_info=car_info,
-                class_name=class_name, class_positions=class_positions,
-                start_epoc=session_details['Session'].get('SessionStartDateEpoc'))
+            pending_writes.append({
+                'influx_laps': influx_laps,
+                'competitor_name': competitor_name,
+                'car_info': car_info,
+                'class_name': class_name,
+                'class_positions': class_positions,
+                'start_epoc': session_details['Session'].get('SessionStartDateEpoc'),
+            })
 
     if competitor_missing:
         logging.info('Car %s not found', ctx.car_number)
         return
 
     if opts.network_mode:
+        expected = len(laps)
+        if opts.skip_if_complete and expected > 0:
+            total, current = existing_lap_counts(ctx)
+            if total == expected and current == expected:
+                logging.info(
+                    "SKIP: race %s car %s already complete and current "
+                    "(%d laps, schema v%d)",
+                    ctx.race_id, ctx.car_number, total, SCHEMA_VERSION)
+                return
+
+        # Second pass: delete-and-replace the car's laps, then write each session.
+        deleted = False
+        for write in pending_writes:
+            if not deleted:
+                delete_existing_laps(ctx)
+                deleted = True
+            push_influx(
+                ctx, write['influx_laps'], False,
+                competitor_name=write['competitor_name'],
+                car_info=write['car_info'],
+                class_name=write['class_name'], class_positions=write['class_positions'],
+                start_epoc=write['start_epoc'])
+
         race_ts_ms = ctx.start_epoc * 1000 if ctx.start_epoc != 0 else int(time.time() * 1000)
         push_influx_race(ctx, race_ts_ms)
 
@@ -511,6 +563,7 @@ def push_influx(ctx, laps, monitor_mode, competitor_name=None, car_info=None,
             .field("lap_time", lap_time_ms)
             .field("position", int(lap['Position']))
             .field("flag_status", lap['FlagStatus'])
+            .field("schema_version", SCHEMA_VERSION)
             .time(time_lap_completed_ms, WritePrecision.MS)
         )
 
@@ -563,6 +616,33 @@ def push_influx_race(ctx, timestamp_ms):
         ctx.write_api.write(bucket='races', record=point)
     except Exception as e:  # pylint: disable=broad-exception-caught
         logging.error("Writing race failed: %s", e)
+
+
+def existing_lap_counts(ctx):
+    """Return (total_laps, current_laps) for the tracked car's laps in this race.
+
+    total_laps  — number of lap points written for the car.
+    current_laps — number of those laps stamped with the current SCHEMA_VERSION.
+
+    A race is safe to skip only when both equal RaceMonitor's reported lap total:
+    total < expected means a partial/truncated backfill, current < total means
+    some laps predate the current schema (written by an older laps.py).
+    """
+    def _count(field_filter):
+        tables = ctx.query_api.query(
+            f'from(bucket: "laps")\n'
+            f'  |> range(start: {EPOCH_START})\n'
+            f'  |> filter(fn: (r) => r._measurement == "lap"\n'
+            f'      and r.race_id == "{ctx.race_id}"\n'
+            f'      and r.car_number == "{ctx.car_number}")\n'
+            f'  |> filter(fn: (r) => {field_filter})\n'
+            f'  |> count()'
+        )
+        return sum(r.get_value() for t in tables for r in t.records)
+
+    total = _count('r._field == "lap_no"')
+    current = _count(f'r._field == "schema_version" and r._value == {SCHEMA_VERSION}')
+    return total, current
 
 
 def delete_existing_laps(ctx):

--- a/laps.py
+++ b/laps.py
@@ -352,6 +352,8 @@ def old_race(ctx, opts):
         if opts.skip_if_complete and expected > 0:
             total, current = existing_lap_counts(ctx)
             if total == expected and current == expected:
+                race_ts_ms = ctx.start_epoc * 1000 if ctx.start_epoc != 0 else int(time.time() * 1000)
+                push_influx_race(ctx, race_ts_ms)
                 logging.info(
                     "SKIP: race %s car %s already complete and current "
                     "(%d laps, schema v%d)",

--- a/laps.py
+++ b/laps.py
@@ -216,7 +216,7 @@ def _run_race(ctx, opts, response):
 
 def live_race(ctx, opts):
     """Called if a race ID is live."""
-    ctx.client.live.get_session(ctx.race_id)
+    session_response = ctx.client.live.get_session(ctx.race_id)
 
     print_rankings([], True, opts.selected_class)
 
@@ -237,12 +237,14 @@ def live_race(ctx, opts):
 
     competitor_name = f"{competitor_details.get('FirstName', '')} {competitor_details.get('LastName', '')}".strip() or None
     car_info = competitor_details.get('AdditionalData') or None
+    class_name, _ = _resolve_class_live(session_response, ctx.car_number)
 
     print(UNDERLINE)
     # Print competitor detail block
     print(
         f"Team: {competitor_details['Name']:<6} "
         f"Car Number: {competitor_details['Number']:<4} "
+        f"Class: {class_name} "
         f"Transponder: {competitor_details['Transponder']}"
     )
     print(
@@ -266,8 +268,7 @@ def live_race(ctx, opts):
         if laps:
             # class_position intentionally discarded: historical laps were completed before
             # launch so any position we compute now is stale. monitor_routine owns
-            # class_position writes.
-            class_name, _ = _resolve_class_live(ctx.client, ctx.race_id, ctx.car_number)
+            # class_position writes. class_name was resolved above from session_response.
             logging.info("Car %s: class %r", ctx.car_number, class_name)
             push_influx(ctx, laps, False, competitor_name=competitor_name, car_info=car_info,
                         class_name=class_name, class_positions=None)
@@ -297,6 +298,7 @@ def old_race(ctx, opts):
     competitor_missing = True
     competitor_name = None
     car_info = None
+    display_class_name = None
     pending_writes = []
 
     # First pass: gather every session's laps for the tracked car. We accumulate
@@ -317,6 +319,11 @@ def old_race(ctx, opts):
                     or None
                 )
                 car_info = competitor.get('AdditionalData') or None
+                category = competitor.get('Category')
+                display_class_name = (
+                    session_details['Session']['Categories']
+                    .get(category, {}).get('Name', category)
+                )
                 session_laps = competitor['LapTimes'].copy()
                 laps = laps + [dict(lap) for lap in session_laps]
 
@@ -372,6 +379,7 @@ def old_race(ctx, opts):
     print(
         f"Team: {competitor_details['FirstName']:<6}\t"
         f"Car Number: {competitor_details['Number']:<4}\t"
+        f"Class: {display_class_name}\t"
         f"Transponder: {competitor_details['Transponder']}"
     )
     print(
@@ -500,7 +508,7 @@ def monitor_routine(ctx, laps, opts, competitor_name=None, car_info=None, _stop_
             laps.append(current_competitor_lap_times[-1])
             if opts.network_mode:
                 class_name, class_position = _resolve_class_live(
-                    ctx.client, ctx.race_id, ctx.car_number)
+                    ctx.client.live.get_session(ctx.race_id), ctx.car_number)
                 new_lap_num = int(current_competitor_lap_times[-1]['Lap'])
                 class_positions = (
                     {new_lap_num: class_position} if class_position is not None else None)
@@ -525,6 +533,20 @@ def refresh_competitor(ctx):
     return laps
 
 
+def _time_to_ms(value):
+    """Parse a RaceMonitor time string to milliseconds.
+
+    Accepts variable precision: 'H:MM:SS.mmm', 'MM:SS.mmm', or 'SS.mmm', with the
+    fractional '.mmm' part optional. RaceMonitor omits the hours component when a
+    value is under an hour, so we right-align the colon-separated parts.
+    """
+    parts = value.split(':')
+    sec, _, ms = parts[-1].partition('.')
+    hours = int(parts[-3]) if len(parts) >= 3 else 0
+    minutes = int(parts[-2]) if len(parts) >= 2 else 0
+    return hours * 3600000 + minutes * 60000 + int(sec) * 1000 + int(ms or 0)
+
+
 def push_influx(ctx, laps, monitor_mode, competitor_name=None, car_info=None,
                 class_name=None, class_positions=None, start_epoc=None):
     """Push lap data to InfluxDB."""
@@ -541,14 +563,8 @@ def push_influx(ctx, laps, monitor_mode, competitor_name=None, car_info=None,
 
     points = []
     for lap in laps:
-        h, m, s = lap['TotalTime'].split(':')
-        s, ms = s.split('.')
-        lap_finish_ms = int(h) * 3600000 + int(m) * 60000 + int(s) * 1000 + int(ms)
-        time_lap_completed_ms = start_epoc_ms + lap_finish_ms
-
-        h, m, s = lap['LapTime'].split(':')
-        s, ms = s.split('.')
-        lap_time_ms = int(h) * 3600000 + int(m) * 60000 + int(s) * 1000 + int(ms)
+        time_lap_completed_ms = start_epoc_ms + _time_to_ms(lap['TotalTime'])
+        lap_time_ms = _time_to_ms(lap['LapTime'])
 
         lap_num = int(lap['Lap'])
 
@@ -705,12 +721,15 @@ def _resolve_class_historical(car_number, session_details):
     return class_name, class_positions
 
 
-def _resolve_class_live(client, race_id, car_number):
-    """Return (class_name, class_position) for the tracked car using current session state."""
-    response = client.live.get_session(race_id)
-    if not response['Successful']:
+def _resolve_class_live(session_response, car_number):
+    """Return (class_name, class_position) for the tracked car from a live session.
+
+    Takes the response from ``client.live.get_session`` so the caller can fetch the
+    session once and reuse it.
+    """
+    if not session_response['Successful']:
         return None, None
-    session = response['Session']
+    session = session_response['Session']
     classes = session['Classes']
     competitors = session['Competitors']
 

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -160,6 +160,18 @@ class TestRunBackfill:
             failures = _mod.run_backfill(self._races(), default_car='252', overrides={})
         assert failures == []
 
+    def test_passes_skip_if_complete_by_default(self):
+        with patch.object(_mod.subprocess, 'run') as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            _mod.run_backfill(self._races()[:1], default_car='252', overrides={})
+        assert '--skip-if-complete' in mock_run.call_args.args[0]
+
+    def test_omits_skip_if_complete_when_forced(self):
+        with patch.object(_mod.subprocess, 'run') as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            _mod.run_backfill(self._races()[:1], default_car='252', overrides={}, force=True)
+        assert '--skip-if-complete' not in mock_run.call_args.args[0]
+
 
 class TestBuildPairs:
     def test_builds_pairs_from_races(self):
@@ -307,4 +319,12 @@ class TestArgParsing:
     def test_validate_defaults_to_false(self):
         args = _mod._build_parser().parse_args([])
         assert args.validate is False
+
+    def test_force_flag_accepted(self):
+        args = _mod._build_parser().parse_args(['--force'])
+        assert args.force is True
+
+    def test_force_defaults_to_false(self):
+        args = _mod._build_parser().parse_args([])
+        assert args.force is False
 

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -371,6 +371,165 @@ class TestPushInfluxClassInfo:
         _mod.push_influx(ctx, self._laps(), False)
         assert write_api.write.call_args.kwargs['bucket'] == 'laps'
 
+    def test_schema_version_field_present(self):
+        ctx, write_api = self._ctx()
+        _mod.push_influx(ctx, self._laps(), False)
+        assert f'schema_version={_mod.SCHEMA_VERSION}i' in self._record(write_api)
+
+
+class TestSkipIfCompleteArg:
+    def test_default_is_false(self):
+        args = _mod._build_parser().parse_args(['12345', '42'])
+        assert args.skip_if_complete is False
+
+    def test_flag_sets_true(self):
+        args = _mod._build_parser().parse_args(['12345', '42', '--skip-if-complete'])
+        assert args.skip_if_complete is True
+
+
+class TestOldRaceSkip:
+    def _session_details(self):
+        return {
+            'Successful': True,
+            'Session': {
+                'ID': 1, 'RaceID': 999, 'Name': 'S1', 'SessionStartDateEpoc': 0,
+                'Categories': {'1': {'ID': '1', 'Name': 'A'}},
+                'SortedCompetitors': [{
+                    'Number': '42', 'Category': '1', 'ID': 1, 'SessionID': 1,
+                    'RaceID': 999, 'FirstName': 'Jane', 'LastName': 'Doe',
+                    'Position': '1', 'Laps': '1', 'LastLapTime': '',
+                    'BestPosition': '1', 'BestLap': '1',
+                    'BestLapTime': '0:01:30.000', 'TotalTime': '0:01:30.000',
+                    'Transponder': '', 'Nationality': '', 'AdditionalData': '',
+                    'LapTimes': [
+                        {'Lap': '1', 'LapTime': '0:01:30.000', 'Position': '1',
+                         'FlagStatus': 0, 'TotalTime': '0:01:30.000'},
+                    ],
+                }],
+            },
+        }
+
+    def _ctx(self):
+        ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
+        ctx.query_api = MagicMock()
+        ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
+        ctx.client.results.session_details.return_value = self._session_details()
+        return ctx
+
+    def test_skips_writes_when_complete_and_current(self):
+        ctx = self._ctx()
+        opts = _mod.RaceOptions(network_mode=True, skip_if_complete=True)
+        with patch.object(_mod, 'existing_lap_counts', return_value=(1, 1)):
+            with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
+                with patch.object(_mod, 'push_influx') as mock_push:
+                    with patch.object(_mod, 'push_influx_race') as mock_race:
+                        with patch.object(_mod, 'delete_existing_laps') as mock_del:
+                            with patch.object(_mod, 'print_rankings'):
+                                _mod.old_race(ctx, opts)
+        mock_push.assert_not_called()
+        mock_race.assert_not_called()
+        mock_del.assert_not_called()
+
+    def test_logs_skip_message_when_complete(self, caplog):
+        ctx = self._ctx()
+        opts = _mod.RaceOptions(network_mode=True, skip_if_complete=True)
+        with patch.object(_mod, 'existing_lap_counts', return_value=(1, 1)):
+            with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
+                with patch.object(_mod, 'push_influx'):
+                    with patch.object(_mod, 'push_influx_race'):
+                        with patch.object(_mod, 'print_rankings'):
+                            with caplog.at_level(logging.INFO):
+                                _mod.old_race(ctx, opts)
+        assert any('SKIP' in r.message and '999' in r.message for r in caplog.records)
+
+    def test_writes_when_laps_incomplete(self):
+        ctx = self._ctx()
+        opts = _mod.RaceOptions(network_mode=True, skip_if_complete=True)
+        with patch.object(_mod, 'existing_lap_counts', return_value=(0, 0)):
+            with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
+                with patch.object(_mod, 'push_influx') as mock_push:
+                    with patch.object(_mod, 'push_influx_race'):
+                        with patch.object(_mod, 'print_rankings'):
+                            _mod.old_race(ctx, opts)
+        mock_push.assert_called_once()
+
+    def test_writes_when_laps_stale_schema(self):
+        ctx = self._ctx()
+        opts = _mod.RaceOptions(network_mode=True, skip_if_complete=True)
+        with patch.object(_mod, 'existing_lap_counts', return_value=(1, 0)):
+            with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
+                with patch.object(_mod, 'push_influx') as mock_push:
+                    with patch.object(_mod, 'push_influx_race'):
+                        with patch.object(_mod, 'print_rankings'):
+                            _mod.old_race(ctx, opts)
+        mock_push.assert_called_once()
+
+    def test_does_not_query_counts_when_skip_disabled(self):
+        ctx = self._ctx()
+        opts = _mod.RaceOptions(network_mode=True, skip_if_complete=False)
+        with patch.object(_mod, 'existing_lap_counts') as mock_counts:
+            with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
+                with patch.object(_mod, 'push_influx') as mock_push:
+                    with patch.object(_mod, 'push_influx_race'):
+                        with patch.object(_mod, 'print_rankings'):
+                            _mod.old_race(ctx, opts)
+        mock_counts.assert_not_called()
+        mock_push.assert_called_once()
+
+
+class TestExistingLapCounts:
+    def _query_api(self, lap_no_count=0, current_count=0):
+        """Mock query_api returning lap_no count for the first query and
+        current-schema_version count for the second."""
+        responses = iter([lap_no_count, current_count])
+
+        def fake_query(flux):
+            count = next(responses)
+            table = MagicMock()
+            if count is None:
+                table.records = []
+            else:
+                rec = MagicMock()
+                rec.get_value.return_value = count
+                table.records = [rec]
+            return [table]
+
+        api = MagicMock()
+        api.query.side_effect = fake_query
+        return api
+
+    def _ctx(self, query_api):
+        ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
+        ctx.query_api = query_api
+        return ctx
+
+    def test_returns_total_and_current_counts(self):
+        ctx = self._ctx(self._query_api(lap_no_count=10, current_count=10))
+        assert _mod.existing_lap_counts(ctx) == (10, 10)
+
+    def test_current_less_than_total_when_some_laps_unstamped(self):
+        ctx = self._ctx(self._query_api(lap_no_count=10, current_count=4))
+        assert _mod.existing_lap_counts(ctx) == (10, 4)
+
+    def test_returns_zero_when_no_laps(self):
+        ctx = self._ctx(self._query_api(lap_no_count=None, current_count=None))
+        assert _mod.existing_lap_counts(ctx) == (0, 0)
+
+    def test_total_query_filters_lap_no_field(self):
+        ctx = self._ctx(self._query_api(lap_no_count=1, current_count=1))
+        _mod.existing_lap_counts(ctx)
+        total_flux = ctx.query_api.query.call_args_list[0].args[0]
+        assert '_field == "lap_no"' in total_flux
+        assert 'race_id == "999"' in total_flux
+        assert 'car_number == "42"' in total_flux
+
+    def test_current_query_filters_on_schema_version_value(self):
+        ctx = self._ctx(self._query_api(lap_no_count=1, current_count=1))
+        _mod.existing_lap_counts(ctx)
+        current_flux = ctx.query_api.query.call_args_list[1].args[0]
+        assert '_field == "schema_version"' in current_flux
+        assert f'_value == {_mod.SCHEMA_VERSION}' in current_flux
+
 
 class TestOldRaceClassWiring:
     def _session_details(self, car_number='42', cat_id='1', cat_name='A'):

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -449,7 +449,7 @@ class TestOldRaceSkip:
                             with patch.object(_mod, 'print_rankings'):
                                 _mod.old_race(ctx, opts)
         mock_push.assert_not_called()
-        mock_race.assert_not_called()
+        mock_race.assert_called_once()
         mock_del.assert_not_called()
 
     def test_logs_skip_message_when_complete(self, caplog):

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -252,6 +252,15 @@ class TestTimeToMs:
     def test_missing_milliseconds(self):
         assert _mod._time_to_ms('45:30') == 45 * 60000 + 30 * 1000
 
+    def test_unparseable_value_returns_zero(self):
+        assert _mod._time_to_ms('3$H') == 0
+
+    def test_unparseable_value_logs_warning(self, caplog):
+        import logging
+        with caplog.at_level(logging.WARNING):
+            _mod._time_to_ms('3$H')
+        assert '3$H' in caplog.text
+
 
 class TestPushInfluxClassInfo:
     def _laps(self):

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -162,7 +162,7 @@ class TestResolveClassHistorical:
 
 
 class TestResolveClassLive:
-    def _make_client(self, car_number, class_id, car_position, others=None):
+    def _make_session(self, car_number, class_id, car_position, others=None):
         """others: list of (car_number, class_id, position)."""
         competitors = {
             'r1': {
@@ -181,8 +181,7 @@ class TestResolveClassLive:
                 'Laps': '', 'TotalTime': '', 'BestPosition': '',
                 'BestLap': '', 'BestLapTime': '', 'LastLapTime': '',
             }
-        client = MagicMock()
-        client.live.get_session.return_value = {
+        return {
             'Successful': True,
             'Session': {
                 'RunNumber': '', 'SessionName': '', 'TrackName': '',
@@ -192,53 +191,66 @@ class TestResolveClassLive:
                 'Competitors': competitors,
             },
         }
-        return client
 
     def test_returns_class_name(self):
-        client = self._make_client('42', 'classA', 3)
-        client.live.get_session.return_value['Session']['Classes']['classA']['Description'] = 'A'
-        class_name, _ = _mod._resolve_class_live(client, '999', '42')
+        session = self._make_session('42', 'classA', 3)
+        session['Session']['Classes']['classA']['Description'] = 'A'
+        class_name, _ = _mod._resolve_class_live(session, '42')
         assert class_name == 'A'
 
     def test_only_car_in_class_is_position_1(self):
-        client = self._make_client('42', 'classA', 3)
-        _, class_pos = _mod._resolve_class_live(client, '999', '42')
+        session = self._make_session('42', 'classA', 3)
+        _, class_pos = _mod._resolve_class_live(session, '42')
         assert class_pos == 1
 
     def test_tracked_car_ahead_in_class(self):
-        client = self._make_client('42', 'classA', 3, others=[('99', 'classA', 5)])
-        _, class_pos = _mod._resolve_class_live(client, '999', '42')
+        session = self._make_session('42', 'classA', 3, others=[('99', 'classA', 5)])
+        _, class_pos = _mod._resolve_class_live(session, '42')
         assert class_pos == 1
 
     def test_tracked_car_behind_in_class(self):
-        client = self._make_client('42', 'classA', 5, others=[('99', 'classA', 1)])
-        _, class_pos = _mod._resolve_class_live(client, '999', '42')
+        session = self._make_session('42', 'classA', 5, others=[('99', 'classA', 1)])
+        _, class_pos = _mod._resolve_class_live(session, '42')
         assert class_pos == 2
 
     def test_different_class_not_counted(self):
-        client = self._make_client('42', 'classA', 5, others=[('99', 'classB', 1)])
-        _, class_pos = _mod._resolve_class_live(client, '999', '42')
+        session = self._make_session('42', 'classA', 5, others=[('99', 'classB', 1)])
+        _, class_pos = _mod._resolve_class_live(session, '42')
         assert class_pos == 1
 
     def test_car_not_found_returns_none_none(self):
-        client = self._make_client('42', 'classA', 3)
-        class_name, class_pos = _mod._resolve_class_live(client, '999', '99')
+        session = self._make_session('42', 'classA', 3)
+        class_name, class_pos = _mod._resolve_class_live(session, '99')
         assert class_name is None
         assert class_pos is None
 
     def test_api_failure_returns_none_none(self):
-        client = MagicMock()
-        client.live.get_session.return_value = {'Successful': False}
-        class_name, class_pos = _mod._resolve_class_live(client, '999', '42')
+        class_name, class_pos = _mod._resolve_class_live({'Successful': False}, '42')
         assert class_name is None
         assert class_pos is None
 
     def test_class_name_special_chars_preserved(self):
-        client = self._make_client('42', 'classA', 1)
-        client.live.get_session.return_value['Session']['Classes']['classA']['Description'] = (
-            'GT3,Pro=Am')
-        class_name, _ = _mod._resolve_class_live(client, '999', '42')
+        session = self._make_session('42', 'classA', 1)
+        session['Session']['Classes']['classA']['Description'] = 'GT3,Pro=Am'
+        class_name, _ = _mod._resolve_class_live(session, '42')
         assert class_name == 'GT3,Pro=Am'
+
+
+class TestTimeToMs:
+    def test_three_part_with_hours(self):
+        assert _mod._time_to_ms('1:23:45.678') == 1 * 3600000 + 23 * 60000 + 45 * 1000 + 678
+
+    def test_three_part_zero_padded_hours(self):
+        assert _mod._time_to_ms('0:01:30.000') == 90000
+
+    def test_two_part_under_an_hour(self):
+        assert _mod._time_to_ms('45:30.000') == 45 * 60000 + 30 * 1000
+
+    def test_two_part_single_digit_minute(self):
+        assert _mod._time_to_ms('1:30.000') == 90000
+
+    def test_missing_milliseconds(self):
+        assert _mod._time_to_ms('45:30') == 45 * 60000 + 30 * 1000
 
 
 class TestPushInfluxClassInfo:
@@ -375,6 +387,16 @@ class TestPushInfluxClassInfo:
         ctx, write_api = self._ctx()
         _mod.push_influx(ctx, self._laps(), False)
         assert f'schema_version={_mod.SCHEMA_VERSION}i' in self._record(write_api)
+
+    def test_handles_times_without_hours_component(self):
+        ctx, write_api = self._ctx()  # start_epoc=0
+        laps = [{'Lap': '1', 'LapTime': '1:30.000', 'Position': '1',
+                 'FlagStatus': 'Green', 'TotalTime': '45:30.000'}]
+        _mod.push_influx(ctx, laps, False)
+        record = self._record(write_api)
+        assert 'lap_time=90000i' in record
+        # TotalTime 45:30.000 = 2730000 ms; start_epoc=0 → timestamp 2730000
+        assert record.endswith('2730000')
 
 
 class TestSkipIfCompleteArg:
@@ -529,6 +551,97 @@ class TestExistingLapCounts:
         current_flux = ctx.query_api.query.call_args_list[1].args[0]
         assert '_field == "schema_version"' in current_flux
         assert f'_value == {_mod.SCHEMA_VERSION}' in current_flux
+
+
+class TestOldRacePrintsClass:
+    def _session_details(self):
+        return {
+            'Successful': True,
+            'Session': {
+                'ID': 1, 'RaceID': 999, 'Name': 'S1', 'SessionStartDateEpoc': 0,
+                'Categories': {'1': {'ID': '1', 'Name': 'B-Class'}},
+                'SortedCompetitors': [{
+                    'Number': '42', 'Category': '1', 'ID': 1, 'SessionID': 1,
+                    'RaceID': 999, 'FirstName': 'Jane', 'LastName': 'Doe',
+                    'Position': '1', 'Laps': '1', 'LastLapTime': '',
+                    'BestPosition': '1', 'BestLap': '1',
+                    'BestLapTime': '0:01:30.000', 'TotalTime': '0:01:30.000',
+                    'Transponder': 'T123', 'Nationality': '', 'AdditionalData': '',
+                    'LapTimes': [
+                        {'Lap': '1', 'LapTime': '0:01:30.000', 'Position': '1',
+                         'FlagStatus': 0, 'TotalTime': '0:01:30.000'},
+                    ],
+                }],
+            },
+        }
+
+    def test_prints_class_name(self, capsys):
+        ctx = _mod.RaceContext('999', '42', MagicMock(), None, 0)
+        opts = _mod.RaceOptions(network_mode=False)
+        ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
+        ctx.client.results.session_details.return_value = self._session_details()
+        with patch.object(_mod, 'print_rankings'):
+            _mod.old_race(ctx, opts)
+        assert 'Class: B-Class' in capsys.readouterr().out
+
+
+class TestLiveRace:
+    def _session_response(self, class_desc='A'):
+        return {
+            'Successful': True,
+            'Session': {
+                'RunNumber': '', 'SessionName': '', 'TrackName': '', 'TrackLength': '',
+                'CurrentTime': '', 'SessionTime': '', 'TimeToGo': '', 'LapsToGo': '',
+                'FlagStatus': '', 'SortMode': '',
+                'Classes': {'classA': {'ClassID': 'classA', 'Description': class_desc}},
+                'Competitors': {
+                    'r1': {
+                        'RacerID': 'r1', 'Number': '42', 'ClassID': 'classA',
+                        'Position': '1', 'Transponder': 'T123', 'FirstName': 'Jane',
+                        'LastName': 'Doe', 'Nationality': '', 'AdditionalData': '',
+                        'Laps': '1', 'TotalTime': '', 'BestPosition': '1',
+                        'BestLap': '1', 'BestLapTime': '', 'LastLapTime': '',
+                    },
+                },
+            },
+        }
+
+    def _racer_response(self):
+        return {
+            'Successful': True,
+            'Details': {
+                'Laps': [{'Lap': '1', 'LapTime': '0:01:30.000', 'Position': '1',
+                          'FlagStatus': 0, 'TotalTime': '0:01:30.000'}],
+                'Competitor': {
+                    'Number': '42', 'FirstName': 'Jane', 'LastName': 'Doe',
+                    'Transponder': 'T123', 'ClassID': 'classA', 'AdditionalData': '',
+                    'Position': '1', 'Laps': '1', 'BestPosition': '1', 'BestLap': '1',
+                    'BestLapTime': '0:01:30.000', 'TotalTime': '0:01:30.000',
+                },
+            },
+        }
+
+    def _ctx(self):
+        ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
+        ctx.client.live.get_session.return_value = self._session_response()
+        ctx.client.live.get_racer.return_value = self._racer_response()
+        return ctx
+
+    def test_prints_class_name(self, capsys):
+        ctx = self._ctx()
+        opts = _mod.RaceOptions(network_mode=False)
+        with patch.object(_mod, 'print_rankings'):
+            _mod.live_race(ctx, opts)
+        assert 'Class: A' in capsys.readouterr().out
+
+    def test_network_mode_calls_get_session_once(self):
+        ctx = self._ctx()
+        opts = _mod.RaceOptions(network_mode=True)
+        with patch.object(_mod, 'print_rankings'):
+            with patch.object(_mod, 'push_influx'):
+                with patch.object(_mod, 'push_influx_race'):
+                    _mod.live_race(ctx, opts)
+        assert ctx.client.live.get_session.call_count == 1
 
 
 class TestOldRaceClassWiring:
@@ -840,7 +953,8 @@ class TestLiveClassWiring:
                 with patch.object(_mod, 'push_influx_race'):
                     with patch.object(_mod, 'print_rankings'):
                         _mod.live_race(ctx, opts)
-        mock_resolve.assert_called_once_with(ctx.client, ctx.race_id, ctx.car_number)
+        mock_resolve.assert_called_once_with(
+            ctx.client.live.get_session.return_value, ctx.car_number)
 
     def test_live_race_passes_class_name_to_push_influx(self):
         ctx = self._make_ctx()
@@ -988,7 +1102,8 @@ class TestLiveClassWiring:
                 with patch.object(_mod, 'push_influx'):
                     with patch.object(_mod, 'push_influx_race'):
                         _mod.monitor_routine(ctx, existing_laps, opts, _stop_event=mock_stop)
-        mock_resolve.assert_called_once_with(ctx.client, ctx.race_id, ctx.car_number)
+        mock_resolve.assert_called_once_with(
+            ctx.client.live.get_session.return_value, ctx.car_number)
 
     def test_live_race_passes_competitor_name_to_push_influx(self):
         ctx = self._make_ctx()


### PR DESCRIPTION
## What

Four backfill/laps improvements:

1. **Skip already-backfilled races** — re-running `backfill.py` no longer redoes work that's already present and current.
2. **Fix sub-hour time parsing** — a real bug that was crashing the historical backfill.
3. **Handle garbage lap times from API** — some laps return invalid values (e.g. `'3$H'`); now caught gracefully.
4. **Show car class in output** (+ a small live-mode cleanup).

## 1. Skip already-backfilled races

- **Version stamp** — new `SCHEMA_VERSION` constant in `laps.py` (with docs on when/why to bump). `push_influx` stamps every lap point with `schema_version`.
- **Skip criterion (both required):** the car's Influx lap count equals RaceMonitor's reported total (complete) **and** every existing lap carries the current `SCHEMA_VERSION` (current). Partial writes or stale pre-normalization data fail the check and are re-backfilled.
- **`laps.py --skip-if-complete`** — `old_race` gathers all sessions first, runs the check, and returns early with a `SKIP:` log line before any delete/write when complete + current. Race metadata (`races` bucket) is still refreshed on the skip path so older races whose metadata predates the `races` bucket are backfilled correctly.
- **`backfill.py`** passes `--skip-if-complete` by default; new `--force` bypasses it (e.g. to migrate all historical races after bumping `SCHEMA_VERSION`).
- Lowers `DEFAULT_START_YEAR` to 2017.

Bumping `SCHEMA_VERSION` doubles as a migration tool: the next run re-backfills every race under the new schema.

## 2. Fix sub-hour time parsing

RaceMonitor omits the leading hours field when a `TotalTime`/`LapTime` is under an hour (e.g. `45:30.000`), but `push_influx` assumed a fixed `H:MM:SS.mmm` shape and crashed with `ValueError: not enough values to unpack`. Extracted a tolerant `_time_to_ms` helper that right-aligns the colon-separated parts and treats the fractional seconds as optional, used for both fields.

## 3. Handle garbage lap times from API

Some laps return values that don't match any known time format (e.g. `'3$H'`). `_time_to_ms` now catches `ValueError`/`AttributeError`, logs a warning with the raw value, and returns 0 ms so the lap is still counted and the import doesn't crash.

## 4. Class display + live cleanup

- `old_race` and `live_race` now print the car's class (read from the session's Categories map, available without lap times).
- `_resolve_class_live` now takes the already-fetched `get_session` response instead of fetching it again, so `live_race` calls `get_session` once instead of twice. `monitor_routine` still fetches fresh per lap (positions change as the race runs).

## Notes

- Known follow-up (deferred): the "car not registered" scan is slow under RaceMonitor's 6 req/min limit; absence-caching is a separate future change.
- Backfill must be run with the `race` dependency group so the `laps.py` subprocess has pandas: `uv run --group race python backfill.py …`.

## Testing

`uv run pytest` — 197 passed; `uv run ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)