### PR TITLE
ci: push PR images to GHCR and protect multi-arch sub-manifests from cleanup

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -37,13 +37,14 @@ jobs:
       id-token: write
     with:
       output: image
-      push: ${{ github.event_name != 'pull_request' }}
+      push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       platforms: linux/amd64,linux/arm64
       cache: true
       cache-mode: max
       sbom: true
       meta-images: ghcr.io/wot-lemons/lemongrass
       meta-tags: |
+        type=ref,event=pr
         type=semver,pattern={{version}}
         type=semver,pattern={{major}}.{{minor}}
         type=semver,pattern={{major}}

--- a/.github/workflows/package-cleanup.yml
+++ b/.github/workflows/package-cleanup.yml
@@ -7,6 +7,7 @@ on:
       - main
   schedule:
     - cron: '0 23 * * 0' # weekly on Sunday at 23:00 UTC
+  workflow_dispatch:
 
 jobs:
   cleanup-pr:
@@ -33,7 +34,7 @@ jobs:
           fi
 
   cleanup-scheduled:
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.github/workflows/package-cleanup.yml
+++ b/.github/workflows/package-cleanup.yml
@@ -45,11 +45,32 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
+
+          # Login so buildx imagetools can inspect multi-arch manifests
+          echo "$GH_TOKEN" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+          # Collect all digests referenced by tagged manifest lists (platform images, attestations).
+          # sort -u deduplicates tags so aliases (1.0.0, 1.0, 1, latest) don't trigger redundant calls.
+          referenced_digests=""
+          while IFS= read -r tag; do
+            digests=$(docker buildx imagetools inspect \
+              "ghcr.io/wot-lemons/${{ matrix.package }}:$tag" \
+              --raw | jq -r '.manifests[]?.digest // empty')
+            referenced_digests="$referenced_digests"$'\n'"$digests"
+          done < <(gh api /orgs/wot-lemons/packages/container/${{ matrix.package }}/versions --paginate \
+            --jq '[.[] | .metadata.container.tags[]] | .[]' | sort -u)
+
+          # Delete only untagged versions not referenced by any tagged manifest
           gh api /orgs/wot-lemons/packages/container/${{ matrix.package }}/versions --paginate \
-            --jq '.[] | select(.metadata.container.tags | length == 0) | .id' | \
-          while read version_id; do
-            gh api --method DELETE /orgs/wot-lemons/packages/container/${{ matrix.package }}/versions/$version_id
-            echo "Deleted untagged ${{ matrix.package }} version $version_id"
+            --jq '.[] | select(.metadata.container.tags | length == 0) | "\(.id) \(.name)"' | \
+          while read -r version_id digest; do
+            if echo "$referenced_digests" | grep -qF "$digest"; then
+              echo "Skipping ${{ matrix.package }} $digest (referenced by a tagged manifest)"
+            else
+              gh api --method DELETE "/orgs/wot-lemons/packages/container/${{ matrix.package }}/versions/$version_id"
+              echo "Deleted untagged ${{ matrix.package }} version $version_id ($digest)"
+            fi
           done
 
       - name: Delete ${{ matrix.package }} PR images for closed PRs


### PR DESCRIPTION
## Summary

- **PR images**: adds \`type=ref,event=pr\` to \`meta-tags\` so PRs get a pullable \`pr-N\` image in GHCR again; guards \`push\` with a repo-equality check so fork PRs don't 403
- **Multi-arch protection**: weekly cleanup now inspects each tagged manifest list and skips any untagged version whose digest is still referenced (platform sub-images, SBOM attestations), preventing broken multi-arch pulls
- **Safety hardening**: \`set -euo pipefail\` + removal of \`|| true\` ensures an inspect failure aborts the step rather than emptying the allowlist and bulk-deleting live sub-manifests; \`sort -u\` on the tag list avoids redundant GHCR API calls for multi-alias releases
- **On-demand trigger**: \`workflow_dispatch\` added so the scheduled cleanup can be run manually from the Actions tab

## Test plan

- [ ] Open a draft PR touching a Docker-path file — confirm a \`pr-N\` image appears in GHCR packages
- [ ] Merge or close that PR — confirm \`cleanup-pr\` job deletes the \`pr-N\` image
- [ ] Trigger \`cleanup-scheduled\` manually via Actions tab — confirm tagged images and their sub-manifests remain intact, only truly orphaned untagged versions are removed
- [ ] Open a PR from a fork (or simulate) — confirm build succeeds without attempting a push

🤖 Generated with [Claude Code](https://claude.com/claude-code)