### PR TITLE
ci(cleanup): prune orphaned attestation manifests

### DIFF
--- a/.github/workflows/package-cleanup.yml
+++ b/.github/workflows/package-cleanup.yml
@@ -55,7 +55,7 @@ jobs:
           # Delete sha256-<hex> tagged attestation indexes whose subject is no longer present.
           # Runs before the untagged cleanup so the freed inner SBOM blobs are caught in that pass.
           gh api /orgs/wot-lemons/packages/container/${{ matrix.package }}/versions --paginate \
-            --jq '.[] | select(.metadata.container.tags[]? | startswith("sha256-")) | "\(.id) \(.metadata.container.tags[] | select(startswith("sha256-")))"' | \
+            --jq '.[] | select(any(.metadata.container.tags[]?; test("^sha256-[0-9a-f]{64}$"))) | "\(.id) \(first(.metadata.container.tags[] | select(test("^sha256-[0-9a-f]{64}$"))))"' | \
           while read -r version_id tag; do
             subject="sha256:${tag#sha256-}"
             if echo "$all_digests" | grep -qF "$subject"; then

--- a/.github/workflows/package-cleanup.yml
+++ b/.github/workflows/package-cleanup.yml
@@ -42,6 +42,30 @@ jobs:
       matrix:
         package: [lemongrass]
     steps:
+      - name: Delete orphaned ${{ matrix.package }} attestation manifests
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Collect all currently-known version digests
+          all_digests=$(gh api /orgs/wot-lemons/packages/container/${{ matrix.package }}/versions --paginate \
+            --jq '[.[] | .name] | .[]')
+
+          # Delete sha256-<hex> tagged attestation indexes whose subject is no longer present.
+          # Runs before the untagged cleanup so the freed inner SBOM blobs are caught in that pass.
+          gh api /orgs/wot-lemons/packages/container/${{ matrix.package }}/versions --paginate \
+            --jq '.[] | select(.metadata.container.tags[]? | startswith("sha256-")) | "\(.id) \(.metadata.container.tags[] | select(startswith("sha256-")))"' | \
+          while read -r version_id tag; do
+            subject="sha256:${tag#sha256-}"
+            if echo "$all_digests" | grep -qF "$subject"; then
+              echo "Keeping ${{ matrix.package }} attestation $tag (subject exists)"
+            else
+              gh api --method DELETE "/orgs/wot-lemons/packages/container/${{ matrix.package }}/versions/$version_id"
+              echo "Deleted orphaned ${{ matrix.package }} attestation $tag (subject $subject gone)"
+            fi
+          done
+
       - name: Delete untagged ${{ matrix.package }} versions
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

`sha256-<hex>` tagged attestation indexes accumulate indefinitely when their subject platform manifest is replaced by a newer build. Because they are tagged, the untagged cleanup never touches them — and because they are inspected during that cleanup, their inner SBOM blobs are also kept alive unnecessarily.

This adds a new step (run **before** the untagged cleanup) that:
1. Collects all currently-known version digests
2. Finds every `sha256-<hex>` tagged version whose subject (`sha256:<hex>`) is no longer present
3. Deletes it — which frees its inner SBOM blob to be caught by the following untagged cleanup pass in the same run

## Test plan

- [ ] Trigger `workflow_dispatch` on the cleanup workflow and confirm orphaned attestation indexes (and their SBOM blobs) are deleted while current ones are kept

🤖 Generated with [Claude Code](https://claude.com/claude-code)