### PR TITLE
fix(docker): install lemongrass as non-editable wheel in final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 COPY pyproject.toml uv.lock ./
 COPY src/ src/
-RUN uv sync --frozen --no-dev --group race --group pi
+RUN uv sync --frozen --no-dev --no-editable --group race --group pi
 
 FROM python:3.14-slim-trixie@sha256:44dd04494ee8f3b538294360e7c4b3acb87c8268e4d0a4828a6500b1eff50061
 WORKDIR /app


### PR DESCRIPTION
## Summary

- `uv sync` without `--no-editable` installs the local `lemongrass` package as an editable install — a `.pth` file in the venv pointing to `/app/src/`
- The multi-stage Dockerfile only copies `.venv` into the final image, not `src/`, so the editable reference is broken at runtime
- All console scripts (`telem`, `pisugar-monitor`, etc.) fail with `ModuleNotFoundError: No module named 'lemongrass'`

## Fix

Added `--no-editable` to `uv sync` so the package is built as a proper wheel and installed into `.venv/lib/.../site-packages/`, making the venv fully self-contained.

## Test plan

- [ ] Build the image locally and verify `docker run ... pisugar-monitor` starts without import errors
- [ ] Verify `telem` command also works

🤖 Generated with [Claude Code](https://claude.com/claude-code)