### PR TITLE
feat!: consolidate CLI to lemongrass dispatcher and add PyPI publishing

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,7 +3,7 @@ name: Build and Push Image
 on:
   push:
     tags:
-      - 'v*'
+      - 'v*'  # every release tag produces a new image; no paths filter is intentional
   pull_request:
     branches:
       - main

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,17 +2,8 @@ name: Build and Push Image
 
 on:
   push:
-    branches:
-      - main
     tags:
       - 'v*'
-    paths:
-      - Dockerfile
-      - .dockerignore
-      - pyproject.toml
-      - uv.lock
-      - src/lemongrass/**
-      - .github/workflows/docker-build.yml
   pull_request:
     branches:
       - main
@@ -48,7 +39,7 @@ jobs:
         type=semver,pattern={{version}}
         type=semver,pattern={{major}}.{{minor}}
         type=semver,pattern={{major}}
-        type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+        type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
     secrets:
       registry-auths: |
         - registry: ghcr.io

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -13,10 +13,15 @@ on:
 jobs:
   test:
     runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Check lockfile is up to date
         run: uv lock --check

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,10 +4,14 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   release-please:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
     steps:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
@@ -16,5 +20,27 @@ jobs:
           private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
 
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: [release-please]
+    if: |
+      always() && (
+        needs.release-please.result == 'success' && needs.release-please.outputs.release_created == 'true' ||
+        github.event_name == 'workflow_dispatch'
+      )
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - run: uv build
+
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,8 +38,11 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        # GITHUB_SHA is the release commit on push; no explicit ref needed
 
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          python-version: "3.14"
 
       - run: uv build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,4 @@ WORKDIR /app
 COPY --from=builder /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
 # No ENTRYPOINT/CMD — the runtime command is supplied by docker-compose (external repo).
-# Use the installed console script names: `laps`, `race-backfill`, `telem`, or `pisugar-monitor`
-# (not the old `python <script>.py` style).
+# Use `lemongrass <command>` — e.g. `lemongrass laps`, `lemongrass telem`, `lemongrass race-backfill`.

--- a/README.md
+++ b/README.md
@@ -61,10 +61,17 @@ pip install lemongrass
 lemongrass laps RACE_ID CAR_NUMBER -m -n
 ```
 
-**uv** — if you have the repo cloned and [uv](https://docs.astral.sh/uv/) installed, source your `.env` first (step 2 above) and run:
+**uv** — install from PyPI as a tool and source your `.env` first (step 2 above):
 
 ```shell
-uv run lemongrass laps RACE_ID CAR_NUMBER -m -n
+uv tool install lemongrass
+lemongrass laps RACE_ID CAR_NUMBER -m -n
+```
+
+Or run ephemerally without installing:
+
+```shell
+uvx lemongrass laps RACE_ID CAR_NUMBER -m -n
 ```
 
 Real example:
@@ -164,7 +171,7 @@ lemongrass laps RACE_ID CAR_NUMBER
 **uv:**
 
 ```shell
-uv run lemongrass laps RACE_ID CAR_NUMBER
+lemongrass laps RACE_ID CAR_NUMBER
 ```
 
 Real example:
@@ -252,3 +259,15 @@ Lap      LapTime Position FlagStatus    TotalTime
 351 00:02:21.065        1     Finish 14:36:02.587
 --------------------------------------------------------------------------------
 ```
+
+## Upgrading from v1.x
+
+As of v2.0.0, the individual entry points (`laps`, `telem`, `race-backfill`, `pisugar-monitor`, `race-diagnose`) were replaced by a single `lemongrass` command. If you have the old package installed, update and prefix commands with `lemongrass`:
+
+| Before | After |
+|--------|-------|
+| `laps RACE_ID CAR_NUMBER` | `lemongrass laps RACE_ID CAR_NUMBER` |
+| `telem` | `lemongrass telem` |
+| `race-backfill` | `lemongrass race-backfill` |
+| `pisugar-monitor` | `lemongrass pisugar-monitor` |
+| `race-diagnose` | `lemongrass race-diagnose` |

--- a/README.md
+++ b/README.md
@@ -51,19 +51,26 @@ docker pull ghcr.io/wot-lemons/lemongrass:latest
 **Docker** — pass your credentials via an env file (see `.env.sample`). To pin to a specific version instead of `latest`, replace the tag (e.g. `1.2.3`). Available tags are listed at `ghcr.io/wot-lemons/lemongrass`.
 
 ```shell
-docker run --rm -it --env-file .env ghcr.io/wot-lemons/lemongrass:latest laps RACE_ID CAR_NUMBER -m -n
+docker run --rm -it --env-file .env ghcr.io/wot-lemons/lemongrass:latest lemongrass laps RACE_ID CAR_NUMBER -m -n
+```
+
+**pip** — install from PyPI and source your `.env` first (step 2 above):
+
+```shell
+pip install lemongrass
+lemongrass laps RACE_ID CAR_NUMBER -m -n
 ```
 
 **uv** — if you have the repo cloned and [uv](https://docs.astral.sh/uv/) installed, source your `.env` first (step 2 above) and run:
 
 ```shell
-uv run laps RACE_ID CAR_NUMBER -m -n
+uv run lemongrass laps RACE_ID CAR_NUMBER -m -n
 ```
 
 Real example:
 
 ```shell
-docker run --rm -it --env-file .env ghcr.io/wot-lemons/lemongrass:latest laps 166811 13 -m -n
+docker run --rm -it --env-file .env ghcr.io/wot-lemons/lemongrass:latest lemongrass laps 166811 13 -m -n
 ```
 
 ```plain
@@ -145,19 +152,25 @@ You can retrieve info for a completed race too.
 docker run --rm -it \
   --env-file .env \
   ghcr.io/wot-lemons/lemongrass:latest \
-  laps RACE_ID CAR_NUMBER
+  lemongrass laps RACE_ID CAR_NUMBER
+```
+
+**pip:**
+
+```shell
+lemongrass laps RACE_ID CAR_NUMBER
 ```
 
 **uv:**
 
 ```shell
-uv run laps RACE_ID CAR_NUMBER
+uv run lemongrass laps RACE_ID CAR_NUMBER
 ```
 
 Real example:
 
 ```shell
-docker run --rm -it --env-file .env ghcr.io/wot-lemons/lemongrass:latest laps 166429 852
+docker run --rm -it --env-file .env ghcr.io/wot-lemons/lemongrass:latest lemongrass laps 166429 852
 ```
 
 ```plain

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,7 @@ requires = ["uv-build>=0.11.21,<0.12"]
 build-backend = "uv_build"
 
 [project.scripts]
-laps            = "lemongrass.laps:main"
-race-backfill   = "lemongrass.race_backfill:main"
-telem           = "lemongrass.telem:main"
-pisugar-monitor = "lemongrass.pisugar_monitor:main"
-race-diagnose   = "lemongrass.race_diagnose:main"
+lemongrass = "lemongrass.cli:main"
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "lemongrass"
 version = "1.0.2"
-requires-python = ">=3.14"
+requires-python = ">=3.10"
 dependencies = [
     "influxdb-client~=1.47",
     "race-monitor>=0.5.1,<1",

--- a/src/lemongrass/cli.py
+++ b/src/lemongrass/cli.py
@@ -11,6 +11,11 @@ _COMMANDS = {
 
 
 def main():
+    if len(sys.argv) >= 2 and sys.argv[1] in ("-h", "--help"):
+        print("Usage: lemongrass <command> [args]")
+        print(f"Commands: {', '.join(_COMMANDS)}")
+        sys.exit(0)
+
     if len(sys.argv) < 2 or sys.argv[1] not in _COMMANDS:
         print("Usage: lemongrass <command> [args]")
         print(f"Commands: {', '.join(_COMMANDS)}")

--- a/src/lemongrass/cli.py
+++ b/src/lemongrass/cli.py
@@ -1,0 +1,21 @@
+import importlib
+import sys
+
+_COMMANDS = {
+    "laps": "lemongrass.laps",
+    "race-backfill": "lemongrass.race_backfill",
+    "telem": "lemongrass.telem",
+    "pisugar-monitor": "lemongrass.pisugar_monitor",
+    "race-diagnose": "lemongrass.race_diagnose",
+}
+
+
+def main():
+    if len(sys.argv) < 2 or sys.argv[1] not in _COMMANDS:
+        print("Usage: lemongrass <command> [args]")
+        print(f"Commands: {', '.join(_COMMANDS)}")
+        sys.exit(1)
+
+    cmd = sys.argv.pop(1)
+    sys.argv[0] = f"lemongrass-{cmd}"
+    importlib.import_module(_COMMANDS[cmd]).main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,47 @@
+import sys
+from unittest.mock import patch, MagicMock
+import pytest
+
+import lemongrass.cli as cli
+
+
+class TestDispatcher:
+    def test_no_args_exits_nonzero(self):
+        with patch.object(sys, 'argv', ['lemongrass']):
+            with pytest.raises(SystemExit) as exc:
+                cli.main()
+        assert exc.value.code != 0
+
+    def test_unknown_command_exits_nonzero(self):
+        with patch.object(sys, 'argv', ['lemongrass', 'notacommand']):
+            with pytest.raises(SystemExit) as exc:
+                cli.main()
+        assert exc.value.code != 0
+
+    def test_routes_to_laps(self):
+        mock_main = MagicMock()
+        with patch.object(sys, 'argv', ['lemongrass', 'laps', '--help']):
+            with patch('lemongrass.laps.main', mock_main):
+                cli.main()
+        mock_main.assert_called_once()
+
+    def test_routes_to_telem(self):
+        mock_main = MagicMock()
+        with patch.object(sys, 'argv', ['lemongrass', 'telem']):
+            with patch('lemongrass.telem.main', mock_main):
+                cli.main()
+        mock_main.assert_called_once()
+
+    def test_shifts_argv_for_subcommand(self):
+        """Subcommand sees its own args at sys.argv[1], not the subcommand name."""
+        captured = {}
+
+        def capture_main():
+            captured['argv'] = sys.argv[:]
+
+        with patch.object(sys, 'argv', ['lemongrass', 'race-diagnose', 'R001', '42']):
+            with patch('lemongrass.race_diagnose.main', capture_main):
+                cli.main()
+
+        assert captured['argv'][1] == 'R001'
+        assert captured['argv'][2] == '42'


### PR DESCRIPTION
## Summary

- **Breaking:** Replaces five individual entry points (\`laps\`, \`race-backfill\`, \`telem\`, \`pisugar-monitor\`, \`race-diagnose\`) with a single \`lemongrass <command>\` CLI. All docker-compose service commands and scripts must be updated to use the \`lemongrass <command>\` form.
- Publishes \`lemongrass\` to PyPI on each release via OIDC trusted publisher — users can now \`pip install lemongrass\`, \`uv tool install lemongrass\`, or \`uvx lemongrass\`
- Docker publishing cleaned up: builds on PRs and release tags only, drops main-branch builds, \`latest\` now tracks the most recent release tag instead of main
- Test matrix expanded to Python 3.10–3.14; \`requires-python\` lowered to \`>=3.10\`
- \`lemongrass --help\` now exits 0 (was falling through to error path)

## Migration

Any \`docker-compose.yml\` or script using the old command names must be updated:

| Before | After |
|--------|-------|
| \`laps RACE_ID CAR_NUMBER\` | \`lemongrass laps RACE_ID CAR_NUMBER\` |
| \`telem\` | \`lemongrass telem\` |
| \`race-backfill ...\` | \`lemongrass race-backfill ...\` |
| \`pisugar-monitor\` | \`lemongrass pisugar-monitor\` |
| \`race-diagnose RACE_ID CAR\` | \`lemongrass race-diagnose RACE_ID CAR\` |

## Setup notes

- PyPI trusted publisher configured on PyPI.org for this repo + \`release-please.yml\` + \`pypi\` environment
- \`pypi\` GitHub environment created with required reviewers — gates both release and manual (\`workflow_dispatch\`) publishes

## Test plan

- [ ] CI passes on this PR (Docker build pushes \`pr-N\` image, tests pass across Python 3.10–3.14)
- [ ] After merge: release-please does not trigger a PyPI publish (only triggers when a release is created)
- [ ] On next release: PyPI publish job pauses for reviewer approval, then publishes to PyPI
- [ ] On next release: Docker image tagged with semver + \`latest\`
- [ ] External docker-compose updated to use \`lemongrass <command>\` form

🤖 Generated with [Claude Code](https://claude.com/claude-code)