### PR TITLE
ci(docker): fix PR image tags by constructing tag value in caller

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -35,7 +35,7 @@ jobs:
       sbom: true
       meta-images: ghcr.io/wot-lemons/lemongrass
       meta-tags: |
-        type=ref,event=pr
+        type=raw,value=pr-${{ github.event.pull_request.number }},enable=${{ github.event_name == 'pull_request' }}
         type=semver,pattern={{version}}
         type=semver,pattern={{major}}.{{minor}}
         type=semver,pattern={{major}}


### PR DESCRIPTION
## Summary

- `type=ref,event=pr` in `meta-tags` does not generate tags inside the `docker/github-builder` reusable workflow — the metadata-action inside can't introspect the PR event context, causing the `finalize` step to fail with `can't push with no tags specified`
- Replace with `type=raw,value=pr-${{ github.event.pull_request.number }},enable=${{ github.event_name == 'pull_request' }}` so the caller evaluates the PR number before passing the resolved string to the reusable workflow
- PR images still overwrite on each push (same `pr-N` tag across all commits to a PR)

## Test plan

- [x] Confirm this PR's docker build produces a `pr-N` tag in GHCR
- [ ] Confirm a tag push still produces semver + `latest` tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)