### PR TITLE
fix(deps): promote pandas and obd to core dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 COPY pyproject.toml uv.lock ./
 COPY src/ src/
-RUN uv sync --frozen --no-dev --no-editable --group race --group pi
+RUN uv sync --frozen --no-dev --no-editable
 
 FROM python:3.14-slim-trixie@sha256:44dd04494ee8f3b538294360e7c4b3acb87c8268e4d0a4828a6500b1eff50061
 WORKDIR /app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,8 @@ version = "2.0.0"
 requires-python = ">=3.10"
 dependencies = [
     "influxdb-client~=1.47",
+    "obd~=0.7",
+    "pandas~=2.3",
     "race-monitor>=0.5.1,<1",
 ]
 
@@ -19,6 +21,4 @@ line-length = 100
 exclude = [".git", "__pycache__", "build", "dist", ".venv"]
 
 [dependency-groups]
-pi = ["obd~=0.7"]
-race = ["pandas~=2.3"]
 dev = ["pytest>=8"]

--- a/uv.lock
+++ b/uv.lock
@@ -44,7 +44,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -151,6 +151,8 @@ version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "influxdb-client" },
+    { name = "obd" },
+    { name = "pandas" },
     { name = "race-monitor" },
 ]
 
@@ -158,23 +160,17 @@ dependencies = [
 dev = [
     { name = "pytest" },
 ]
-pi = [
-    { name = "obd" },
-]
-race = [
-    { name = "pandas" },
-]
 
 [package.metadata]
 requires-dist = [
     { name = "influxdb-client", specifier = "~=1.47" },
+    { name = "obd", specifier = "~=0.7" },
+    { name = "pandas", specifier = "~=2.3" },
     { name = "race-monitor", specifier = ">=0.5.1,<1" },
 ]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=8" }]
-pi = [{ name = "obd", specifier = "~=0.7" }]
-race = [{ name = "pandas", specifier = "~=2.3" }]
 
 [[package]]
 name = "numpy"


### PR DESCRIPTION
## Summary

- Moves `pandas` and `obd` from optional dependency groups (`race`, `pi`) into main `[project]` dependencies so they're installed everywhere by default
- Removes the now-redundant `--group race --group pi` flags from the Dockerfile `uv sync` call
- Fixes `ModuleNotFoundError: No module named 'pandas'` when running `uvx lemongrass laps`

## Test plan

- [x] `uvx lemongrass laps <raceid> <carno>` runs without import errors
- [x] Docker image builds successfully
- [x] `uv run pytest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)