### PR TITLE
chore: add missing PyPI metadata and fix CI warnings

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          uv-version: "0.11.21"
+          version: "0.11.21"
           python-version: ${{ matrix.python-version }}
 
       - name: Check lockfile is up to date

--- a/.github/workflows/python-syntax.yml
+++ b/.github/workflows/python-syntax.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          uv-version: "0.11.21"
+          version: "0.11.21"
 
       - name: Check syntax and style
         run: uv run --with ruff ruff check .

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          uv-version: "0.11.21"
+          version: "0.11.21"
           python-version: "3.14"
 
       - run: uv build

--- a/.github/workflows/uv-lock-check.yml
+++ b/.github/workflows/uv-lock-check.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          uv-version: "0.11.21"
+          version: "0.11.21"
 
       - name: Sync lock file (release-please PRs)
         run: |
@@ -44,7 +44,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          uv-version: "0.11.21"
+          version: "0.11.21"
 
       - name: Verify lock file is up to date
         run: uv lock --check

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.11.21-python3.14-trixie@sha256:05abd865132ddbe8b607b7063514f8debacbc98e60a01823a8abdacbdd61e0d7 AS builder
 WORKDIR /app
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
-COPY pyproject.toml uv.lock ./
+COPY pyproject.toml uv.lock README.md LICENSE ./
 COPY src/ src/
 RUN uv sync --frozen --no-dev --no-editable
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,36 @@
 [project]
 name = "lemongrass"
 version = "2.0.0"
+description = "Telemetry stack for 24 Hours of Lemons"
+readme = "README.md"
 requires-python = ">=3.10"
+authors = [{name = "WOT-Lemons"}]
+license = "MIT"
+license-files = ["LICENSE"]
+keywords = ["race monitor", "racing", "motorsport", "telemetry", "obd2", "obd"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: End Users/Desktop",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Utilities",
+]
 dependencies = [
     "influxdb-client~=1.47",
     "obd~=0.7",
     "pandas~=2.3",
     "race-monitor>=0.5.1,<1",
 ]
+
+[project.urls]
+Source = "https://github.com/WOT-Lemons/Lemongrass"
+"Bug Tracker" = "https://github.com/WOT-Lemons/Lemongrass/issues"
+Changelog = "https://github.com/WOT-Lemons/Lemongrass/blob/main/CHANGELOG.md"
 
 [build-system]
 requires = ["uv-build>=0.11.21,<0.12"]


### PR DESCRIPTION
## Summary

- Adds `description`, `readme`, `authors`, `license`, `license-files`, `keywords`, `classifiers`, and `[project.urls]` to `pyproject.toml`, modeled after race-monitor-py
- Copies `README.md` and `LICENSE` into the Docker builder stage (required by `uv sync --no-editable` now that they are referenced in `pyproject.toml`)
- Renames deprecated `uv-version` input to `version` in all `astral-sh/setup-uv` workflow steps

## Test plan

- [ ] Verify PyPI project page shows description, keywords, classifiers, and URLs after next release
- [ ] Confirm no more "Unexpected input 'uv-version'" warnings in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)