### PR TITLE
feat(laps): write full-field laps for all competitors in historical backfill

### DIFF
--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -48,6 +48,8 @@ EPOCH_START = '1970-01-01T00:00:00Z'
 # backfill to bring all historical races up to the current schema.
 SCHEMA_VERSION = 1
 
+_WRITE_BATCH_SIZE = 5000
+
 
 @dataclass
 class RaceMetadata:
@@ -592,8 +594,14 @@ def _time_to_ms(value):
         return 0
 
 
+def _write_points_chunked(write_api, points, batch_size=_WRITE_BATCH_SIZE):
+    for i in range(0, len(points), batch_size):
+        write_api.write(bucket='laps', record=points[i:i + batch_size])
+
+
 def push_influx(ctx, laps, monitor_mode, competitor_name=None, car_info=None,
-                class_name=None, class_positions=None, start_epoc=None):
+                class_name=None, class_positions=None, start_epoc=None,
+                car_number=None):
     """Push lap data to InfluxDB."""
     logging.debug("Entering network mode.")
     effective_epoc = start_epoc if start_epoc is not None else ctx.start_epoc
@@ -607,6 +615,7 @@ def push_influx(ctx, laps, monitor_mode, competitor_name=None, car_info=None,
         logging.info("Writing laps to influx...")
 
     points = []
+    effective_car_number = car_number if car_number is not None else ctx.car_number
     for lap in laps:
         time_lap_completed_ms = start_epoc_ms + _time_to_ms(lap['TotalTime'])
         lap_time_ms = _time_to_ms(lap['LapTime'])
@@ -619,7 +628,7 @@ def push_influx(ctx, laps, monitor_mode, competitor_name=None, car_info=None,
             .tag("competitor_name", competitor_name)
             .tag("car_info", car_info)
             .tag("class", class_name)
-            .tag("car_number", ctx.car_number)
+            .tag("car_number", effective_car_number)
             .field("lap_no", lap_num)
             .field("lap_time", lap_time_ms)
             .field("position", int(lap['Position']))
@@ -642,7 +651,7 @@ def push_influx(ctx, laps, monitor_mode, competitor_name=None, car_info=None,
         # backfill path deletes-and-replaces a car's laps wholesale, so the
         # recovery for a failed write is to re-run, not to retry in-place.
         try:
-            ctx.write_api.write(bucket='laps', record=points)
+            _write_points_chunked(ctx.write_api, points)
             logging.debug("Wrote %d laps to influx.", len(points))
             if not monitor_mode:
                 logging.info('All lap data written successfully')

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -390,7 +390,13 @@ def old_race(ctx, opts):
                     ctx.race_id, ctx.car_number, total, SCHEMA_VERSION)
                 return
 
-        # Second pass: delete-and-replace the car's laps, then write each session.
+        # Second pass: delete-and-replace the full race, then write all competitors.
+        # The delete covers the entire race (not just one car), so a mid-loop write
+        # failure leaves a partial field until re-backfill. Skipping push_influx_race
+        # on failure keeps the race un-stamped so the next run retries — but note that
+        # skip_if_complete uses only the tracked car's lap count as a completeness proxy.
+        # If the tracked car wrote successfully before a later failure, a future run could
+        # see it as complete and skip the race, leaving other competitors' data missing.
         deleted = False
         all_writes_ok = True
         for write in pending_writes:
@@ -675,9 +681,9 @@ def push_influx(ctx, laps, monitor_mode, competitor_name=None, car_info=None,
         points.append(point)
 
     if points:
-        # One atomic write per session/backfill call. No re-queue on failure
-        # (unlike telem.py's flush loop): this is a one-shot push, and the
-        # backfill path deletes-and-replaces a car's laps wholesale, so the
+        # One push per push_influx call, chunked internally by _write_points_chunked.
+        # No re-queue on failure (unlike telem.py's flush loop): this is a one-shot
+        # push and the backfill path deletes-and-replaces the full race, so the
         # recovery for a failed write is to re-run, not to retry in-place.
         try:
             _write_points_chunked(ctx.write_api, points)

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -350,6 +350,11 @@ def old_race(ctx, opts):
                 if not comp_laps:
                     continue
                 comp_number = competitor['Number']
+                try:
+                    int(comp_number)
+                except (ValueError, TypeError):
+                    logging.debug("Skipping non-integer competitor number %r", comp_number)
+                    continue
                 comp_name = (
                     f"{competitor.get('FirstName', '')} {competitor.get('LastName', '')}".strip()
                     or None
@@ -410,30 +415,26 @@ def old_race(ctx, opts):
         # skip_if_complete uses only the tracked car's lap count as a completeness proxy.
         # If the tracked car wrote successfully before a later failure, a future run could
         # see it as complete and skip the race, leaving other competitors' data missing.
-        deleted = False
-        all_writes_ok = True
+        all_points = []
         for write in pending_writes:
-            if not deleted:
-                delete_existing_laps(ctx)
-                deleted = True
-            ok = push_influx(
-                ctx, write['influx_laps'], False,
-                competitor_name=write['competitor_name'],
-                car_info=write['car_info'],
-                class_name=write['class_name'], class_positions=write['class_positions'],
-                start_epoc=write['start_epoc'],
-                car_number=write['car_number'])
-            if not ok:
-                all_writes_ok = False
+            all_points.extend(_build_lap_points(
+                ctx, write['influx_laps'], write['competitor_name'], write['car_info'],
+                write['class_name'], write['class_positions'], write['start_epoc'],
+                write['car_number']))
+
+        delete_existing_laps(ctx)
+        logging.info(
+            "Writing %d laps for %d competitors...", len(all_points), len(pending_writes))
 
         race_ts_ms = ctx.start_epoc * 1000 if ctx.start_epoc != 0 else int(time.time() * 1000)
-        if all_writes_ok:
+        try:
+            _write_points_chunked(ctx.write_api, all_points)
+            logging.info("All lap data written successfully")
             push_influx_race(ctx, race_ts_ms)
-        else:
+        except Exception as e:
+            logging.error("Writing laps failed for race %s: %s", ctx.race_id, e)
             logging.warning(
-                "One or more lap writes failed for race %s — skipping race stamp so next "
-                "run will re-backfill",
-                ctx.race_id)
+                "Skipping race stamp so next run will re-backfill")
 
     print_rankings(sorted_competitors, False, opts.selected_class,
                    session_details['Session']['Categories'])
@@ -651,36 +652,25 @@ def _write_points_chunked(write_api, points, batch_size=_WRITE_BATCH_SIZE):
             logging.info("Batch %d of %d written successfully", batch_num, total)
 
 
-def push_influx(ctx, laps, monitor_mode, competitor_name=None, car_info=None,
-                class_name=None, class_positions=None, start_epoc=None,
-                car_number=None):
-    """Push lap data to InfluxDB."""
-    logging.debug("Entering network mode.")
+def _build_lap_points(ctx, laps, competitor_name, car_info, class_name, class_positions,
+                      start_epoc, car_number):
+    """Build InfluxDB Point objects for one competitor's laps."""
     effective_epoc = start_epoc if start_epoc is not None else ctx.start_epoc
     if effective_epoc == 0:
         logging.warning("Start epoch is 0; lap timestamps will be anchored to Unix epoch")
-    logging.debug("Start epoch in seconds: %s", effective_epoc)
     start_epoc_ms = effective_epoc * 1000
-    logging.debug("Start epoch in milliseconds: %s", start_epoc_ms)
-
-    if not monitor_mode:
-        logging.info("Writing laps to influx...")
-
     points = []
-    effective_car_number = car_number if car_number is not None else ctx.car_number
     for lap in laps:
         time_lap_completed_ms = start_epoc_ms + _time_to_ms(lap['TotalTime'])
         lap_time_ms = _time_to_ms(lap['LapTime'])
-
         lap_num = int(lap['Lap'])
-
         point = (
             Point("lap")
             .tag("race_id", ctx.race_id)
             .tag("competitor_name", competitor_name)
             .tag("car_info", car_info)
             .tag("class", class_name)
-            .tag("car_number", effective_car_number)
+            .tag("car_number", car_number)
             .field("lap_no", lap_num)
             .field("lap_time", lap_time_ms)
             .field("position", int(lap['Position']))
@@ -688,20 +678,30 @@ def push_influx(ctx, laps, monitor_mode, competitor_name=None, car_info=None,
             .field("schema_version", SCHEMA_VERSION)
             .time(time_lap_completed_ms, WritePrecision.MS)
         )
-
         if class_positions is not None:
             class_pos = class_positions.get(lap_num)
             if class_pos is not None:
                 point = point.field("class_position", class_pos)
-
         logging.debug(point.to_line_protocol())
         points.append(point)
+    return points
+
+
+def push_influx(ctx, laps, monitor_mode, competitor_name=None, car_info=None,
+                class_name=None, class_positions=None, start_epoc=None,
+                car_number=None):
+    """Push lap data to InfluxDB."""
+    logging.debug("Entering network mode.")
+    effective_car_number = car_number if car_number is not None else ctx.car_number
+
+    if not monitor_mode:
+        logging.info("Writing laps to influx...")
+
+    points = _build_lap_points(
+        ctx, laps, competitor_name, car_info, class_name, class_positions,
+        start_epoc, effective_car_number)
 
     if points:
-        # One push per push_influx call, chunked internally by _write_points_chunked.
-        # No re-queue on failure (unlike telem.py's flush loop): this is a one-shot
-        # push and the backfill path deletes-and-replaces the full race, so the
-        # recovery for a failed write is to re-run, not to retry in-place.
         try:
             _write_points_chunked(ctx.write_api, points)
             logging.debug("Wrote %d laps to influx.", len(points))

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -716,15 +716,12 @@ def existing_lap_counts(ctx):
 
 
 def delete_existing_laps(ctx):
-    """Delete all lap points for the tracked car so a backfill can replace them."""
+    """Delete all lap points for this race so a backfill can replace them."""
     try:
         ctx.delete_api.delete(
             start='1970-01-01T00:00:00Z',
             stop=datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
-            predicate=(
-                f'_measurement="lap" AND race_id="{ctx.race_id}" '
-                f'AND car_number="{ctx.car_number}"'
-            ),
+            predicate=f'_measurement="lap" AND race_id="{ctx.race_id}"',
             bucket='laps',
         )
     except Exception as e:

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -109,8 +109,8 @@ def _build_parser():
                              'under the current schema version (historical -n mode only)')
     parser.add_argument('--dry-run', dest='dry_run', default=False,
                         action='store_true',
-                        help='Show what would be written without touching InfluxDB; '
-                             'implies -n (historical mode only)')
+                        help='Implies -n; show what would be written without touching InfluxDB '
+                             '(historical mode only)')
     parser.add_argument('-v', '--verbose', help="Set debug logging", action='store_true')
     parser.add_argument(
         '--interval',

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -46,7 +46,7 @@ EPOCH_START = '1970-01-01T00:00:00Z'
 # them, rewriting historical data under the new schema. That "rewrite everything"
 # behavior is itself a useful migration tool — bump the version and re-run the
 # backfill to bring all historical races up to the current schema.
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 _WRITE_BATCH_SIZE = 5000
 
@@ -320,7 +320,9 @@ def old_race(ctx, opts):
         session_details = ctx.client.results.session_details(session_id, include_lap_times=True)
         sorted_competitors = [dict(c) for c in session_details['Session']['SortedCompetitors']]
 
+        flag_map = {0: "Green", 1: "Yellow", -1: "Finish"}
         session_laps = []
+
         for competitor in sorted_competitors:
             if competitor['Number'] == ctx.car_number:
                 competitor_missing = False
@@ -338,24 +340,41 @@ def old_race(ctx, opts):
                 session_laps = competitor['LapTimes'].copy()
                 laps = laps + [dict(lap) for lap in session_laps]
 
-        if opts.network_mode and session_laps:
-            flag_map = {0: "Green", 1: "Yellow", -1: "Finish"}
-            influx_laps = [
-                {**lap, 'FlagStatus': flag_map.get(lap['FlagStatus'], str(lap['FlagStatus']))}
-                for lap in session_laps
-            ]
-            class_name, class_positions = _resolve_class_historical(ctx.car_number, session_details)
-            pending_writes.append({
-                'influx_laps': influx_laps,
-                'competitor_name': competitor_name,
-                'car_info': car_info,
-                'class_name': class_name,
-                'class_positions': class_positions,
-                'start_epoc': session_details['Session'].get('SessionStartDateEpoc'),
-            })
+        if opts.network_mode:
+            start_epoc = session_details['Session'].get('SessionStartDateEpoc')
+            for competitor in sorted_competitors:
+                comp_laps = competitor.get('LapTimes', [])
+                if not comp_laps:
+                    continue
+                comp_number = competitor['Number']
+                comp_name = (
+                    f"{competitor.get('FirstName', '')} {competitor.get('LastName', '')}".strip()
+                    or None
+                )
+                comp_car_info = competitor.get('AdditionalData') or None
+                influx_laps = [
+                    {**lap, 'FlagStatus': flag_map.get(lap['FlagStatus'], str(lap['FlagStatus']))}
+                    for lap in comp_laps
+                ]
+                class_name, class_positions = _resolve_class_historical(comp_number, session_details)
+                pending_writes.append({
+                    'influx_laps': influx_laps,
+                    'competitor_name': comp_name,
+                    'car_info': comp_car_info,
+                    'class_name': class_name,
+                    'class_positions': class_positions,
+                    'start_epoc': start_epoc,
+                    'car_number': comp_number,
+                })
 
     if competitor_missing:
         logging.info('Car %s not found', ctx.car_number)
+        return
+
+    if opts.network_mode and (not pending_writes or len(laps) == 0):
+        logging.warning(
+            "Validation failed: no laps collected for race %s car %s — skipping write",
+            ctx.race_id, ctx.car_number)
         return
 
     if opts.network_mode:
@@ -382,7 +401,8 @@ def old_race(ctx, opts):
                 competitor_name=write['competitor_name'],
                 car_info=write['car_info'],
                 class_name=write['class_name'], class_positions=write['class_positions'],
-                start_epoc=write['start_epoc'])
+                start_epoc=write['start_epoc'],
+                car_number=write['car_number'])
 
         race_ts_ms = ctx.start_epoc * 1000 if ctx.start_epoc != 0 else int(time.time() * 1000)
         push_influx_race(ctx, race_ts_ms)

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -317,8 +317,6 @@ def old_race(ctx, opts):
     laps = []
     competitor_details = {}
     competitor_missing = True
-    competitor_name = None
-    car_info = None
     display_class_name = None
     pending_writes = []
 
@@ -337,11 +335,6 @@ def old_race(ctx, opts):
             if competitor['Number'] == ctx.car_number:
                 competitor_missing = False
                 competitor_details = competitor
-                competitor_name = (
-                    f"{competitor.get('FirstName', '')} {competitor.get('LastName', '')}".strip()
-                    or None
-                )
-                car_info = competitor.get('AdditionalData') or None
                 category = competitor.get('Category')
                 display_class_name = (
                     session_details['Session']['Categories']

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -82,6 +82,7 @@ class RaceOptions:
     selected_class: str | None = None
     interval: int = 30
     skip_if_complete: bool = False
+    dry_run: bool = False
 
 
 def _build_parser():
@@ -106,6 +107,10 @@ def _build_parser():
                         action='store_true',
                         help='Skip the backfill if this car already has all its laps written '
                              'under the current schema version (historical -n mode only)')
+    parser.add_argument('--dry-run', dest='dry_run', default=False,
+                        action='store_true',
+                        help='Show what would be written without touching InfluxDB; '
+                             'implies -n (historical mode only)')
     parser.add_argument('-v', '--verbose', help="Set debug logging", action='store_true')
     parser.add_argument(
         '--interval',
@@ -139,7 +144,7 @@ def main():
         sys.exit(1)
 
     influx_token = None
-    if args.network_mode:
+    if args.network_mode and not args.dry_run:
         influx_token = os.environ.get('INFLUX_TELEMETRY_TOKEN')
         if not influx_token:
             logging.error("INFLUX_TELEMETRY_TOKEN environment variable not set")
@@ -149,12 +154,13 @@ def main():
     car_number = str(args.car_number[0])
 
     opts = RaceOptions(
-        network_mode=args.network_mode,
+        network_mode=args.network_mode or args.dry_run,
         monitor_mode=args.monitor_mode,
         save_file=args.save_file,
         selected_class=args.selected_class,
         interval=args.interval,
         skip_if_complete=args.skip_if_complete,
+        dry_run=args.dry_run,
     )
 
     try:
@@ -189,6 +195,10 @@ def main():
                 return 1
 
             if not opts.network_mode:
+                return _run_race(
+                    RaceContext(race_id, car_number, client, None, start_epoc, metadata=metadata), opts, response)
+
+            if opts.dry_run:
                 return _run_race(
                     RaceContext(race_id, car_number, client, None, start_epoc, metadata=metadata), opts, response)
 
@@ -379,6 +389,16 @@ def old_race(ctx, opts):
 
     if opts.network_mode:
         expected = len(laps)
+
+        if opts.dry_run:
+            print(UNDERLINE)
+            total_laps = sum(len(w['influx_laps']) for w in pending_writes)
+            for write in pending_writes:
+                print(f"  would write {len(write['influx_laps'])} laps for car {write['car_number']}")
+            print(f"  {len(pending_writes)} competitor(s), {total_laps} laps total")
+            print(UNDERLINE)
+            return
+
         if opts.skip_if_complete and expected > 0:
             total, current = existing_lap_counts(ctx)
             if total == expected and current == expected:

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -646,9 +646,9 @@ def _write_points_chunked(write_api, points, batch_size=_WRITE_BATCH_SIZE):
     chunks = range(0, len(points), batch_size)
     total = len(chunks)
     for batch_num, i in enumerate(chunks, 1):
-        if total > 1:
-            logging.info("Writing batch %d of %d", batch_num, total)
         write_api.write(bucket='laps', record=points[i:i + batch_size])
+        if total > 1:
+            logging.info("Batch %d of %d written successfully", batch_num, total)
 
 
 def push_influx(ctx, laps, monitor_mode, competitor_name=None, car_info=None,

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -392,20 +392,29 @@ def old_race(ctx, opts):
 
         # Second pass: delete-and-replace the car's laps, then write each session.
         deleted = False
+        all_writes_ok = True
         for write in pending_writes:
             if not deleted:
                 delete_existing_laps(ctx)
                 deleted = True
-            push_influx(
+            ok = push_influx(
                 ctx, write['influx_laps'], False,
                 competitor_name=write['competitor_name'],
                 car_info=write['car_info'],
                 class_name=write['class_name'], class_positions=write['class_positions'],
                 start_epoc=write['start_epoc'],
                 car_number=write['car_number'])
+            if not ok:
+                all_writes_ok = False
 
         race_ts_ms = ctx.start_epoc * 1000 if ctx.start_epoc != 0 else int(time.time() * 1000)
-        push_influx_race(ctx, race_ts_ms)
+        if all_writes_ok:
+            push_influx_race(ctx, race_ts_ms)
+        else:
+            logging.warning(
+                "One or more lap writes failed for race %s — skipping race stamp so next "
+                "run will re-backfill",
+                ctx.race_id)
 
     print_rankings(sorted_competitors, False, opts.selected_class,
                    session_details['Session']['Categories'])
@@ -677,8 +686,11 @@ def push_influx(ctx, laps, monitor_mode, competitor_name=None, car_info=None,
                 logging.info('All lap data written successfully')
         except Exception as e:
             logging.error("Writing %d laps failed: %s", len(points), e)
+            print(UNDERLINE)
+            return False
 
     print(UNDERLINE)
+    return True
 
 
 def push_influx_race(ctx, timestamp_ms):
@@ -711,7 +723,11 @@ def push_influx_race(ctx, timestamp_ms):
 def existing_lap_counts(ctx):
     """Return (total_laps, current_laps) for the tracked car's laps in this race.
 
-    total_laps  — number of lap points written for the car.
+    Returns the count of existing laps for the tracked car. Used as a completeness
+    proxy — if the tracked car's laps are present and current, the race is considered
+    complete (the full field is not verified).
+
+    total_laps  — number of lap points written for the tracked car.
     current_laps — number of those laps stamped with the current SCHEMA_VERSION.
 
     A race is safe to skip only when both equal RaceMonitor's reported lap total:
@@ -749,7 +765,7 @@ def delete_existing_laps(ctx):
 
 
 def _resolve_class_historical(car_number, session_details):
-    """Return (class_name, {lap_num: class_position}) for the tracked car."""
+    """Return (class_name, {lap_num: class_position}) for the given car_number."""
     session = session_details['Session']
     competitors = session['SortedCompetitors']
     categories = session['Categories']

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -643,7 +643,11 @@ def _time_to_ms(value):
 
 
 def _write_points_chunked(write_api, points, batch_size=_WRITE_BATCH_SIZE):
-    for i in range(0, len(points), batch_size):
+    chunks = range(0, len(points), batch_size)
+    total = len(chunks)
+    for batch_num, i in enumerate(chunks, 1):
+        if total > 1:
+            logging.info("Writing batch %d of %d", batch_num, total)
         write_api.write(bucket='laps', record=points[i:i + batch_size])
 
 

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -1442,13 +1442,13 @@ class TestDeleteExistingLaps:
         ctx.delete_api = delete_api
         return ctx, delete_api
 
-    def test_predicate_targets_measurement_race_and_car(self):
+    def test_predicate_targets_measurement_and_race(self):
         ctx, delete_api = self._ctx()
         _mod.delete_existing_laps(ctx)
         predicate = delete_api.delete.call_args.kwargs['predicate']
         assert '_measurement="lap"' in predicate
         assert 'race_id="999"' in predicate
-        assert 'car_number="42"' in predicate
+        assert 'car_number' not in predicate
 
     def test_targets_laps_bucket(self):
         ctx, delete_api = self._ctx()

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -1,6 +1,6 @@
 import logging
 import threading
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock, call, mock_open, patch
 
 import lemongrass.laps as _mod
 
@@ -398,6 +398,13 @@ class TestPushInfluxClassInfo:
         assert 'lap_time=90000i' in record
         # TotalTime 45:30.000 = 2730000 ms; start_epoc=0 → timestamp 2730000
         assert record.endswith('2730000')
+
+    def test_explicit_car_number_overrides_ctx(self):
+        ctx, write_api = self._ctx()  # ctx.car_number = '42'
+        _mod.push_influx(ctx, self._laps(), False, car_number='99')
+        record = self._record(write_api)
+        assert 'car_number=99' in record
+        assert 'car_number=42' not in record
 
 
 class TestSkipIfCompleteArg:
@@ -1453,3 +1460,24 @@ class TestDeleteExistingLaps:
         delete_api.delete.side_effect = Exception("network error")
         _mod.delete_existing_laps(ctx)  # must not raise
         assert "Deleting existing laps failed" in caplog.text
+
+
+class TestWritePointsChunked:
+    def test_single_chunk_when_below_batch_size(self):
+        write_api = MagicMock()
+        points = [MagicMock() for _ in range(10)]
+        _mod._write_points_chunked(write_api, points, batch_size=5000)
+        write_api.write.assert_called_once_with(bucket='laps', record=points)
+
+    def test_splits_into_two_chunks_at_boundary(self):
+        write_api = MagicMock()
+        points = [MagicMock() for _ in range(6)]
+        _mod._write_points_chunked(write_api, points, batch_size=5)
+        assert write_api.write.call_count == 2
+        assert write_api.write.call_args_list[0] == call(bucket='laps', record=points[:5])
+        assert write_api.write.call_args_list[1] == call(bucket='laps', record=points[5:])
+
+    def test_empty_points_makes_no_calls(self):
+        write_api = MagicMock()
+        _mod._write_points_chunked(write_api, [], batch_size=5000)
+        write_api.write.assert_not_called()

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -477,34 +477,31 @@ class TestOldRaceSkip:
         opts = _mod.RaceOptions(network_mode=True, skip_if_complete=True)
         with patch.object(_mod, 'existing_lap_counts', return_value=(0, 0)):
             with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
-                with patch.object(_mod, 'push_influx') as mock_push:
-                    with patch.object(_mod, 'push_influx_race'):
-                        with patch.object(_mod, 'print_rankings'):
-                            _mod.old_race(ctx, opts)
-        mock_push.assert_called_once()
+                with patch.object(_mod, 'push_influx_race'):
+                    with patch.object(_mod, 'print_rankings'):
+                        _mod.old_race(ctx, opts)
+        assert ctx.write_api.write.called
 
     def test_writes_when_laps_stale_schema(self):
         ctx = self._ctx()
         opts = _mod.RaceOptions(network_mode=True, skip_if_complete=True)
         with patch.object(_mod, 'existing_lap_counts', return_value=(1, 0)):
             with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
-                with patch.object(_mod, 'push_influx') as mock_push:
-                    with patch.object(_mod, 'push_influx_race'):
-                        with patch.object(_mod, 'print_rankings'):
-                            _mod.old_race(ctx, opts)
-        mock_push.assert_called_once()
+                with patch.object(_mod, 'push_influx_race'):
+                    with patch.object(_mod, 'print_rankings'):
+                        _mod.old_race(ctx, opts)
+        assert ctx.write_api.write.called
 
     def test_does_not_query_counts_when_skip_disabled(self):
         ctx = self._ctx()
         opts = _mod.RaceOptions(network_mode=True, skip_if_complete=False)
         with patch.object(_mod, 'existing_lap_counts') as mock_counts:
             with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
-                with patch.object(_mod, 'push_influx') as mock_push:
-                    with patch.object(_mod, 'push_influx_race'):
-                        with patch.object(_mod, 'print_rankings'):
-                            _mod.old_race(ctx, opts)
+                with patch.object(_mod, 'push_influx_race'):
+                    with patch.object(_mod, 'print_rankings'):
+                        _mod.old_race(ctx, opts)
         mock_counts.assert_not_called()
-        mock_push.assert_called_once()
+        assert ctx.write_api.write.called
 
 
 class TestExistingLapCounts:
@@ -691,20 +688,19 @@ class TestOldRaceClassWiring:
                         _mod.old_race(ctx, opts)
         mock_resolve.assert_any_call('42', self._session_details())
 
-    def test_passes_class_name_to_push_influx(self):
+    def test_passes_class_name_to_build_lap_points(self):
         ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
         opts = _mod.RaceOptions(network_mode=True)
         ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
         ctx.client.results.session_details.return_value = self._session_details()
         with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
-            with patch.object(_mod, 'push_influx') as mock_push:
+            with patch.object(_mod, '_build_lap_points', return_value=[]) as mock_build:
                 with patch.object(_mod, 'push_influx_race'):
                     with patch.object(_mod, 'print_rankings'):
                         _mod.old_race(ctx, opts)
-        _, kwargs = mock_push.call_args
-        assert kwargs.get('class_name') == 'A'
+        assert mock_build.call_args.args[4] == 'A'
 
-    def test_passes_session_start_epoc_to_push_influx(self):
+    def test_passes_session_start_epoc_to_build_lap_points(self):
         # ctx.start_epoc=9999 is intentionally different from SessionStartDateEpoc=5555
         ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 9999)
         opts = _mod.RaceOptions(network_mode=True)
@@ -713,12 +709,11 @@ class TestOldRaceClassWiring:
         ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
         ctx.client.results.session_details.return_value = session
         with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
-            with patch.object(_mod, 'push_influx') as mock_push:
+            with patch.object(_mod, '_build_lap_points', return_value=[]) as mock_build:
                 with patch.object(_mod, 'push_influx_race'):
                     with patch.object(_mod, 'print_rankings'):
                         _mod.old_race(ctx, opts)
-        _, kwargs = mock_push.call_args
-        assert kwargs.get('start_epoc') == 5555
+        assert mock_build.call_args.args[6] == 5555
 
     def test_handles_missing_session_start_epoc_key(self):
         ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
@@ -728,12 +723,11 @@ class TestOldRaceClassWiring:
         ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
         ctx.client.results.session_details.return_value = session
         with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
-            with patch.object(_mod, 'push_influx') as mock_push:
+            with patch.object(_mod, '_build_lap_points', return_value=[]) as mock_build:
                 with patch.object(_mod, 'push_influx_race'):
                     with patch.object(_mod, 'print_rankings'):
                         _mod.old_race(ctx, opts)
-        _, kwargs = mock_push.call_args
-        assert kwargs.get('start_epoc') is None
+        assert mock_build.call_args.args[6] is None
 
     def test_no_network_mode_skips_resolve(self):
         ctx = _mod.RaceContext('999', '42', MagicMock(), None, 0)
@@ -745,20 +739,19 @@ class TestOldRaceClassWiring:
                 _mod.old_race(ctx, opts)
         mock_resolve.assert_not_called()
 
-    def test_passes_competitor_name_to_push_influx(self):
+    def test_passes_competitor_name_to_build_lap_points(self):
         ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
         opts = _mod.RaceOptions(network_mode=True)
         ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
         ctx.client.results.session_details.return_value = self._session_details()
         with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
-            with patch.object(_mod, 'push_influx') as mock_push:
+            with patch.object(_mod, '_build_lap_points', return_value=[]) as mock_build:
                 with patch.object(_mod, 'push_influx_race'):
                     with patch.object(_mod, 'print_rankings'):
                         _mod.old_race(ctx, opts)
-        _, kwargs = mock_push.call_args
-        assert kwargs.get('competitor_name') == 'Jane Doe'
+        assert mock_build.call_args.args[2] == 'Jane Doe'
 
-    def test_passes_car_info_to_push_influx(self):
+    def test_passes_car_info_to_build_lap_points(self):
         ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
         opts = _mod.RaceOptions(network_mode=True)
         session = self._session_details()
@@ -766,12 +759,11 @@ class TestOldRaceClassWiring:
         ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
         ctx.client.results.session_details.return_value = session
         with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
-            with patch.object(_mod, 'push_influx') as mock_push:
+            with patch.object(_mod, '_build_lap_points', return_value=[]) as mock_build:
                 with patch.object(_mod, 'push_influx_race'):
                     with patch.object(_mod, 'print_rankings'):
                         _mod.old_race(ctx, opts)
-        _, kwargs = mock_push.call_args
-        assert kwargs.get('car_info') == '2005/Toy/Celica'
+        assert mock_build.call_args.args[3] == '2005/Toy/Celica'
 
     def test_competitor_name_none_when_both_name_fields_empty(self):
         ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
@@ -782,12 +774,11 @@ class TestOldRaceClassWiring:
         ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
         ctx.client.results.session_details.return_value = session
         with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
-            with patch.object(_mod, 'push_influx') as mock_push:
+            with patch.object(_mod, '_build_lap_points', return_value=[]) as mock_build:
                 with patch.object(_mod, 'push_influx_race'):
                     with patch.object(_mod, 'print_rankings'):
                         _mod.old_race(ctx, opts)
-        _, kwargs = mock_push.call_args
-        assert kwargs.get('competitor_name') is None
+        assert mock_build.call_args.args[2] is None
 
     def test_old_race_calls_push_influx_race_once_across_multiple_sessions(self):
         ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 1000)
@@ -854,15 +845,15 @@ class TestOldRaceClassWiring:
         order = []
         with patch.object(_mod, 'delete_existing_laps',
                           side_effect=lambda c: order.append('delete')) as mock_del:
-            with patch.object(_mod, 'push_influx',
-                              side_effect=lambda *a, **k: order.append('push')):
+            with patch.object(_mod, '_write_points_chunked',
+                              side_effect=lambda *a, **k: order.append('write')):
                 with patch.object(_mod, 'push_influx_race'):
                     with patch.object(_mod, 'print_rankings'):
                         with patch.object(_mod, '_resolve_class_historical',
                                           return_value=('A', {1: 1})):
                             _mod.old_race(ctx, opts)
         mock_del.assert_called_once_with(ctx)
-        assert order == ['delete', 'push']
+        assert order == ['delete', 'write']
 
     def test_delete_fires_once_across_multiple_sessions(self):
         ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
@@ -882,7 +873,7 @@ class TestOldRaceClassWiring:
 
     def test_delete_fires_once_regardless_of_session_order(self):
         # Car 42 absent from session 1 (car 99 only), present in session 2.
-        # Full-field writes: session 1's car 99 data and session 2's car 42 data both written.
+        # Full-field writes: both sessions' competitors collected and written together.
         ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
         ctx.delete_api = MagicMock()
         opts = _mod.RaceOptions(network_mode=True)
@@ -893,14 +884,14 @@ class TestOldRaceClassWiring:
             self._session_details(car_number='42'),
         ]
         with patch.object(_mod, 'delete_existing_laps') as mock_del:
-            with patch.object(_mod, 'push_influx') as mock_push:
+            with patch.object(_mod, '_build_lap_points', return_value=[]) as mock_build:
                 with patch.object(_mod, 'push_influx_race'):
                     with patch.object(_mod, 'print_rankings'):
                         with patch.object(_mod, '_resolve_class_historical',
                                           return_value=('A', {1: 1})):
                             _mod.old_race(ctx, opts)
         mock_del.assert_called_once_with(ctx)
-        assert mock_push.call_count == 2
+        assert mock_build.call_count == 2
 
     def test_no_delete_when_competitor_missing(self):
         ctx = _mod.RaceContext('999', '77', MagicMock(), MagicMock(), 0)
@@ -1502,23 +1493,22 @@ class TestOldRaceFullField:
         ctx = self._ctx(self._session_details_two_cars())
         opts = _mod.RaceOptions(network_mode=True)
         with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
-            with patch.object(_mod, 'push_influx') as mock_push:
+            with patch.object(_mod, '_build_lap_points', return_value=[]) as mock_build:
                 with patch.object(_mod, 'push_influx_race'):
                     with patch.object(_mod, 'delete_existing_laps'):
                         with patch.object(_mod, 'print_rankings'):
                             _mod.old_race(ctx, opts)
-        assert mock_push.call_count == 2
-        pushed_car_numbers = {c.kwargs['car_number'] for c in mock_push.call_args_list}
-        assert pushed_car_numbers == {'42', '99'}
+        assert mock_build.call_count == 2
+        built_car_numbers = {c.args[7] for c in mock_build.call_args_list}
+        assert built_car_numbers == {'42', '99'}
 
     def test_does_not_write_if_tracked_car_absent(self):
         ctx = self._ctx(self._session_details_two_cars(), car_number='77')
         opts = _mod.RaceOptions(network_mode=True)
-        with patch.object(_mod, 'push_influx') as mock_push:
-            with patch.object(_mod, 'delete_existing_laps') as mock_del:
-                with patch.object(_mod, 'push_influx_race'):
-                    _mod.old_race(ctx, opts)
-        mock_push.assert_not_called()
+        with patch.object(_mod, 'delete_existing_laps') as mock_del:
+            with patch.object(_mod, 'push_influx_race'):
+                _mod.old_race(ctx, opts)
+        assert not ctx.write_api.write.called
         mock_del.assert_not_called()
 
     def test_resolve_class_called_per_competitor(self):
@@ -1527,36 +1517,61 @@ class TestOldRaceFullField:
         with patch.object(
             _mod, '_resolve_class_historical', return_value=('A', {1: 1})
         ) as mock_resolve:
-            with patch.object(_mod, 'push_influx'):
-                with patch.object(_mod, 'push_influx_race'):
-                    with patch.object(_mod, 'delete_existing_laps'):
-                        with patch.object(_mod, 'print_rankings'):
-                            _mod.old_race(ctx, opts)
+            with patch.object(_mod, 'push_influx_race'):
+                with patch.object(_mod, 'delete_existing_laps'):
+                    with patch.object(_mod, 'print_rankings'):
+                        _mod.old_race(ctx, opts)
         assert mock_resolve.call_count == 2
         assert {c.args[0] for c in mock_resolve.call_args_list} == {'42', '99'}
 
-    def test_push_influx_receives_explicit_car_number(self):
+    def test_build_lap_points_receives_explicit_car_number(self):
         ctx = self._ctx(self._session_details_two_cars())
         opts = _mod.RaceOptions(network_mode=True)
         with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
-            with patch.object(_mod, 'push_influx') as mock_push:
+            with patch.object(_mod, '_build_lap_points', return_value=[]) as mock_build:
                 with patch.object(_mod, 'push_influx_race'):
                     with patch.object(_mod, 'delete_existing_laps'):
                         with patch.object(_mod, 'print_rankings'):
                             _mod.old_race(ctx, opts)
-        for c in mock_push.call_args_list:
-            assert c.kwargs.get('car_number') is not None
+        for c in mock_build.call_args_list:
+            assert c.args[7] is not None
 
     def test_race_not_stamped_when_write_fails(self):
         ctx = self._ctx(self._session_details_two_cars())
         opts = _mod.RaceOptions(network_mode=True)
         with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
-            with patch.object(_mod, 'push_influx', return_value=False):
+            with patch.object(_mod, '_write_points_chunked', side_effect=Exception('write error')):
                 with patch.object(_mod, 'push_influx_race') as mock_stamp:
                     with patch.object(_mod, 'delete_existing_laps'):
                         with patch.object(_mod, 'print_rankings'):
                             _mod.old_race(ctx, opts)
         mock_stamp.assert_not_called()
+
+    def test_non_integer_car_number_skipped(self):
+        """Competitors with non-integer car numbers (e.g. 'SC') are not written."""
+        sc_competitor = self._make_competitor('SC', 99, '0')
+        session = {
+            'Successful': True,
+            'Session': {
+                'ID': 1, 'RaceID': 999, 'Name': 'S1', 'SessionStartDateEpoc': 0,
+                'Categories': {'1': {'ID': '1', 'Name': 'A'}},
+                'SortedCompetitors': [
+                    self._make_competitor('42', 1, '1'),
+                    sc_competitor,
+                ],
+            },
+        }
+        ctx = self._ctx(session)
+        opts = _mod.RaceOptions(network_mode=True)
+        with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
+            with patch.object(_mod, '_build_lap_points', return_value=[]) as mock_build:
+                with patch.object(_mod, 'push_influx_race'):
+                    with patch.object(_mod, 'delete_existing_laps'):
+                        with patch.object(_mod, 'print_rankings'):
+                            _mod.old_race(ctx, opts)
+        built_car_numbers = {c.args[7] for c in mock_build.call_args_list}
+        assert 'SC' not in built_car_numbers
+        assert '42' in built_car_numbers
 
     def test_validation_aborts_when_no_laps_collected(self):
         """Tracked car found but has zero laps — do not touch InfluxDB."""
@@ -1572,12 +1587,11 @@ class TestOldRaceFullField:
         }
         ctx = self._ctx(session)
         opts = _mod.RaceOptions(network_mode=True)
-        with patch.object(_mod, 'push_influx') as mock_push:
-            with patch.object(_mod, 'delete_existing_laps') as mock_del:
-                with patch.object(_mod, 'push_influx_race'):
-                    with patch.object(_mod, 'print_rankings'):
-                        _mod.old_race(ctx, opts)
-        mock_push.assert_not_called()
+        with patch.object(_mod, 'delete_existing_laps') as mock_del:
+            with patch.object(_mod, 'push_influx_race'):
+                with patch.object(_mod, 'print_rankings'):
+                    _mod.old_race(ctx, opts)
+        assert not ctx.write_api.write.called
         mock_del.assert_not_called()
 
 

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -1600,3 +1600,57 @@ class TestWritePointsChunked:
         write_api = MagicMock()
         _mod._write_points_chunked(write_api, [], batch_size=5000)
         write_api.write.assert_not_called()
+
+
+class TestDryRun:
+    def _ctx(self):
+        ctx = _mod.RaceContext('999', '42', MagicMock(), None, 0)
+        ctx.delete_api = None
+        ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
+        ctx.client.results.session_details.return_value = {
+            'Successful': True,
+            'Session': {
+                'ID': 1, 'RaceID': 999, 'Name': 'S1', 'SessionStartDateEpoc': 0,
+                'Categories': {'1': {'ID': '1', 'Name': 'A'}},
+                'SortedCompetitors': [
+                    {
+                        'Number': '42', 'Category': '1', 'ID': 1, 'SessionID': 1,
+                        'RaceID': 999, 'FirstName': 'Driver', 'LastName': '42',
+                        'Position': '1', 'Laps': '2', 'LastLapTime': '',
+                        'BestPosition': '1', 'BestLap': '1',
+                        'BestLapTime': '0:01:30.000', 'TotalTime': '0:03:00.000',
+                        'Transponder': '', 'Nationality': '', 'AdditionalData': '',
+                        'LapTimes': [
+                            {'Lap': '1', 'LapTime': '0:01:30.000', 'Position': '1',
+                             'FlagStatus': 0, 'TotalTime': '0:01:30.000'},
+                            {'Lap': '2', 'LapTime': '0:01:30.000', 'Position': '1',
+                             'FlagStatus': 0, 'TotalTime': '0:03:00.000'},
+                        ],
+                    },
+                ],
+            },
+        }
+        return ctx
+
+    def test_does_not_call_push_influx_or_delete(self):
+        ctx = self._ctx()
+        opts = _mod.RaceOptions(network_mode=True, dry_run=True)
+        with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1, 2: 1})):
+            with patch.object(_mod, 'push_influx') as mock_push:
+                with patch.object(_mod, 'delete_existing_laps') as mock_del:
+                    with patch.object(_mod, 'push_influx_race') as mock_stamp:
+                        with patch.object(_mod, 'print_rankings'):
+                            _mod.old_race(ctx, opts)
+        mock_push.assert_not_called()
+        mock_del.assert_not_called()
+        mock_stamp.assert_not_called()
+
+    def test_prints_lap_summary(self, capsys):
+        ctx = self._ctx()
+        opts = _mod.RaceOptions(network_mode=True, dry_run=True)
+        with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1, 2: 1})):
+            with patch.object(_mod, 'print_rankings'):
+                _mod.old_race(ctx, opts)
+        out = capsys.readouterr().out
+        assert 'car 42' in out
+        assert '2 laps' in out

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -1547,6 +1547,17 @@ class TestOldRaceFullField:
         for c in mock_push.call_args_list:
             assert c.kwargs.get('car_number') is not None
 
+    def test_race_not_stamped_when_write_fails(self):
+        ctx = self._ctx(self._session_details_two_cars())
+        opts = _mod.RaceOptions(network_mode=True)
+        with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
+            with patch.object(_mod, 'push_influx', return_value=False):
+                with patch.object(_mod, 'push_influx_race') as mock_stamp:
+                    with patch.object(_mod, 'delete_existing_laps'):
+                        with patch.object(_mod, 'print_rankings'):
+                            _mod.old_race(ctx, opts)
+        mock_stamp.assert_not_called()
+
     def test_validation_aborts_when_no_laps_collected(self):
         """Tracked car found but has zero laps — do not touch InfluxDB."""
         competitor_no_laps = self._make_competitor('42', 1, '1')

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -689,7 +689,7 @@ class TestOldRaceClassWiring:
                 with patch.object(_mod, 'push_influx_race'):
                     with patch.object(_mod, 'print_rankings'):
                         _mod.old_race(ctx, opts)
-        mock_resolve.assert_called_once_with('42', self._session_details())
+        mock_resolve.assert_any_call('42', self._session_details())
 
     def test_passes_class_name_to_push_influx(self):
         ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
@@ -880,9 +880,9 @@ class TestOldRaceClassWiring:
                             _mod.old_race(ctx, opts)
         mock_del.assert_called_once_with(ctx)
 
-    def test_delete_fires_on_first_session_that_has_the_car(self):
-        # Car 42 is absent from session 1 (which holds car 99) and present in
-        # session 2. The delete must fire while processing session 2, not before.
+    def test_delete_fires_once_regardless_of_session_order(self):
+        # Car 42 absent from session 1 (car 99 only), present in session 2.
+        # Full-field writes: session 1's car 99 data and session 2's car 42 data both written.
         ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
         ctx.delete_api = MagicMock()
         opts = _mod.RaceOptions(network_mode=True)
@@ -899,9 +899,8 @@ class TestOldRaceClassWiring:
                         with patch.object(_mod, '_resolve_class_historical',
                                           return_value=('A', {1: 1})):
                             _mod.old_race(ctx, opts)
-        # Only session 2 yields laps, so exactly one delete and one push occur.
         mock_del.assert_called_once_with(ctx)
-        mock_push.assert_called_once()
+        assert mock_push.call_count == 2
 
     def test_no_delete_when_competitor_missing(self):
         ctx = _mod.RaceContext('999', '77', MagicMock(), MagicMock(), 0)
@@ -1460,6 +1459,115 @@ class TestDeleteExistingLaps:
         delete_api.delete.side_effect = Exception("network error")
         _mod.delete_existing_laps(ctx)  # must not raise
         assert "Deleting existing laps failed" in caplog.text
+
+
+class TestOldRaceFullField:
+    def _make_competitor(self, number, comp_id, position):
+        return {
+            'Number': number, 'Category': '1',
+            'ID': comp_id, 'SessionID': 1, 'RaceID': 999,
+            'FirstName': 'Driver', 'LastName': number,
+            'Position': position, 'Laps': '1', 'LastLapTime': '',
+            'BestPosition': position, 'BestLap': '1',
+            'BestLapTime': '0:01:30.000', 'TotalTime': '0:01:30.000',
+            'Transponder': '', 'Nationality': '', 'AdditionalData': '',
+            'LapTimes': [
+                {'Lap': '1', 'LapTime': '0:01:30.000', 'Position': position,
+                 'FlagStatus': 0, 'TotalTime': '0:01:30.000'},
+            ],
+        }
+
+    def _session_details_two_cars(self):
+        """Session with tracked car 42 and competitor 99."""
+        return {
+            'Successful': True,
+            'Session': {
+                'ID': 1, 'RaceID': 999, 'Name': 'S1', 'SessionStartDateEpoc': 0,
+                'Categories': {'1': {'ID': '1', 'Name': 'A'}},
+                'SortedCompetitors': [
+                    self._make_competitor('42', 1, '1'),
+                    self._make_competitor('99', 2, '2'),
+                ],
+            },
+        }
+
+    def _ctx(self, session_details, car_number='42'):
+        ctx = _mod.RaceContext('999', car_number, MagicMock(), MagicMock(), 0)
+        ctx.delete_api = MagicMock()
+        ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
+        ctx.client.results.session_details.return_value = session_details
+        return ctx
+
+    def test_writes_all_competitors_not_just_tracked(self):
+        ctx = self._ctx(self._session_details_two_cars())
+        opts = _mod.RaceOptions(network_mode=True)
+        with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
+            with patch.object(_mod, 'push_influx') as mock_push:
+                with patch.object(_mod, 'push_influx_race'):
+                    with patch.object(_mod, 'delete_existing_laps'):
+                        with patch.object(_mod, 'print_rankings'):
+                            _mod.old_race(ctx, opts)
+        assert mock_push.call_count == 2
+        pushed_car_numbers = {c.kwargs['car_number'] for c in mock_push.call_args_list}
+        assert pushed_car_numbers == {'42', '99'}
+
+    def test_does_not_write_if_tracked_car_absent(self):
+        ctx = self._ctx(self._session_details_two_cars(), car_number='77')
+        opts = _mod.RaceOptions(network_mode=True)
+        with patch.object(_mod, 'push_influx') as mock_push:
+            with patch.object(_mod, 'delete_existing_laps') as mock_del:
+                with patch.object(_mod, 'push_influx_race'):
+                    _mod.old_race(ctx, opts)
+        mock_push.assert_not_called()
+        mock_del.assert_not_called()
+
+    def test_resolve_class_called_per_competitor(self):
+        ctx = self._ctx(self._session_details_two_cars())
+        opts = _mod.RaceOptions(network_mode=True)
+        with patch.object(
+            _mod, '_resolve_class_historical', return_value=('A', {1: 1})
+        ) as mock_resolve:
+            with patch.object(_mod, 'push_influx'):
+                with patch.object(_mod, 'push_influx_race'):
+                    with patch.object(_mod, 'delete_existing_laps'):
+                        with patch.object(_mod, 'print_rankings'):
+                            _mod.old_race(ctx, opts)
+        assert mock_resolve.call_count == 2
+        assert {c.args[0] for c in mock_resolve.call_args_list} == {'42', '99'}
+
+    def test_push_influx_receives_explicit_car_number(self):
+        ctx = self._ctx(self._session_details_two_cars())
+        opts = _mod.RaceOptions(network_mode=True)
+        with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
+            with patch.object(_mod, 'push_influx') as mock_push:
+                with patch.object(_mod, 'push_influx_race'):
+                    with patch.object(_mod, 'delete_existing_laps'):
+                        with patch.object(_mod, 'print_rankings'):
+                            _mod.old_race(ctx, opts)
+        for c in mock_push.call_args_list:
+            assert c.kwargs.get('car_number') is not None
+
+    def test_validation_aborts_when_no_laps_collected(self):
+        """Tracked car found but has zero laps — do not touch InfluxDB."""
+        competitor_no_laps = self._make_competitor('42', 1, '1')
+        competitor_no_laps['LapTimes'] = []
+        session = {
+            'Successful': True,
+            'Session': {
+                'ID': 1, 'RaceID': 999, 'Name': 'S1', 'SessionStartDateEpoc': 0,
+                'Categories': {'1': {'ID': '1', 'Name': 'A'}},
+                'SortedCompetitors': [competitor_no_laps],
+            },
+        }
+        ctx = self._ctx(session)
+        opts = _mod.RaceOptions(network_mode=True)
+        with patch.object(_mod, 'push_influx') as mock_push:
+            with patch.object(_mod, 'delete_existing_laps') as mock_del:
+                with patch.object(_mod, 'push_influx_race'):
+                    with patch.object(_mod, 'print_rankings'):
+                        _mod.old_race(ctx, opts)
+        mock_push.assert_not_called()
+        mock_del.assert_not_called()
 
 
 class TestWritePointsChunked:


### PR DESCRIPTION
## Summary

- Extends `old_race()` to write every competitor's lap data to InfluxDB during historical backfill, not just the tracked car's — adding a new tracked car to a historical race now requires zero additional API calls
- Widens `delete_existing_laps` to clear all competitors' laps for a race (previously filtered by `car_number`)
- Extracts `_build_lap_points` from `push_influx` to build Point objects independently of writing; `old_race` accumulates the full field into one list and writes once via `_write_points_chunked`, so batch-progress logs reflect the complete dataset (e.g. "Batch 3 of 9") rather than firing per-competitor
- Filters out non-integer car numbers (e.g. "SC" safety car) before writing — prevents Grafana Flux `int(v: r.car_number)` from failing and blanking the competitor dropdown
- Adds in-memory validation: tracked car must be present and have laps before any InfluxDB mutation
- Bumps `SCHEMA_VERSION` to 2, triggering re-backfill of all existing races on next `race-backfill` run
- Adds `_write_points_chunked` for large-batch safety (`_WRITE_BATCH_SIZE = 5000`)
- Adds `--dry-run` flag: implies `-n`, shows per-competitor lap counts without touching InfluxDB
- Write failures are caught as exceptions; race stamp is skipped on failure so the next run re-backfills

## Usage

```bash
uv run laps --dry-run <race_id> <car_number>
```

## Test plan

- [ ] `uv run pytest` — 215 tests, all passing
- [ ] `TestOldRaceFullField`: all-competitors write, absent-car gate, SC-filter, per-competitor class resolution, explicit `car_number` arg, zero-laps abort, write-failure stamp abort
- [ ] `TestDeleteExistingLaps`: confirms no `car_number` in delete predicate
- [ ] `TestWritePointsChunked`: below batch size, split at boundary, empty list
- [ ] `TestDryRun`: no writes/deletes/stamp, prints lap summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)