### PR TITLE
feat: races command, fieldwide backfill, and --upgrade-stored

### DIFF
--- a/src/lemongrass/cli.py
+++ b/src/lemongrass/cli.py
@@ -4,6 +4,7 @@ import sys
 _COMMANDS = {
     "laps": "lemongrass.laps",
     "race-backfill": "lemongrass.race_backfill",
+    "races": "lemongrass.races",
     "telem": "lemongrass.telem",
     "pisugar-monitor": "lemongrass.pisugar_monitor",
     "race-diagnose": "lemongrass.race_diagnose",

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -112,8 +112,8 @@ def _build_parser():
         help='Write lap times to CSV')
     parser.add_argument('--skip-if-complete', dest='skip_if_complete', default=False,
                         action='store_true',
-                        help='Skip the backfill if this car already has all its laps written '
-                             'under the current schema version (historical -n mode only)')
+                        help='Skip the backfill if this race already has all fieldwide laps '
+                             'written under the current schema version (historical -n mode only)')
     parser.add_argument('--dry-run', dest='dry_run', default=False,
                         action='store_true',
                         help='Implies -n; show what would be written without touching InfluxDB '

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -71,7 +71,7 @@ class RaceMetadata:
 class RaceContext:
     """Fixed context for a run: race identity, API client, and optional InfluxDB handle."""
     race_id: str
-    car_number: str
+    car_number: str | None
     client: object
     write_api: object
     start_epoc: int
@@ -96,7 +96,7 @@ def _build_parser():
     """Build and return the argument parser."""
     parser = argparse.ArgumentParser(description='Interact with lap data')
     parser.add_argument('race_id', metavar='race_id', nargs=1, type=int, action='store')
-    parser.add_argument('car_number', metavar='car_number', nargs=1, type=int, action='store')
+    parser.add_argument('car_number', metavar='car_number', nargs='?', type=int, default=None)
     parser.add_argument('-c', '--class', metavar='A/B/C', dest='selected_class', nargs='?',
                         type=ascii, action='store', help='Group or filter by class (A/B/C)')
     parser.add_argument('-m', '--monitor', dest='monitor_mode', default=False,
@@ -158,7 +158,7 @@ def main():
             sys.exit(1)
 
     race_id = str(args.race_id[0])
-    car_number = str(args.car_number[0])
+    car_number = str(args.car_number) if args.car_number is not None else None
 
     opts = RaceOptions(
         network_mode=args.network_mode or args.dry_run,
@@ -197,6 +197,13 @@ def main():
                 logging.info("Sorting results for class %s.", opts.selected_class.upper())
 
             response = client.race.is_live(race_id)
+
+            is_live = response.get('Successful') and response.get('IsLive')
+            if car_number is None and (args.monitor_mode or is_live):
+                logging.error("car_number is required for live/monitor mode")
+                sys.exit(1)
+            if car_number is not None and not is_live and not args.monitor_mode:
+                logging.warning("car_number provided but ignored in historical fieldwide mode")
 
             if not response['Successful']:
                 return 1
@@ -331,13 +338,9 @@ def old_race(ctx, opts):
         "Race %s has %s sessions, %s",
         ctx.race_id, len(session_ids_for_race), session_ids_for_race)
 
-    laps = []
-    competitor_details = {}
-    competitor_missing = True
-    display_class_name = None
     pending_writes = []
 
-    # First pass: gather every session's laps for the tracked car. We accumulate
+    # First pass: gather every session's laps for all competitors. We accumulate
     # the write payloads instead of writing inline so the skip check below can see
     # the complete expected lap count before any delete/write happens.
     for sid in session_ids_for_race:
@@ -346,19 +349,6 @@ def old_race(ctx, opts):
         sorted_competitors = [dict(c) for c in session_details['Session']['SortedCompetitors']]
 
         flag_map = {0: "Green", 1: "Yellow", -1: "Finish"}
-        session_laps = []
-
-        for competitor in sorted_competitors:
-            if competitor['Number'] == ctx.car_number:
-                competitor_missing = False
-                competitor_details = competitor
-                category = competitor.get('Category')
-                display_class_name = (
-                    session_details['Session']['Categories']
-                    .get(category, {}).get('Name', category)
-                )
-                session_laps = competitor['LapTimes'].copy()
-                laps = laps + [dict(lap) for lap in session_laps]
 
         if opts.network_mode:
             session_id = session_details['Session']['ID']
@@ -400,18 +390,17 @@ def old_race(ctx, opts):
                 })
             pending_writes.append(session_entry)
 
-    if competitor_missing:
-        logging.info('Car %s not found', ctx.car_number)
-        return
-
-    if opts.network_mode and (not pending_writes or len(laps) == 0):
+    if opts.network_mode and (not pending_writes or not any(s['competitors'] for s in pending_writes)):
         logging.warning(
-            "Validation failed: no laps collected for race %s car %s — skipping write",
-            ctx.race_id, ctx.car_number)
+            "No competitors with laps found for race %s — skipping write", ctx.race_id)
         return
 
     if opts.network_mode:
-        expected = len(laps)
+        expected = sum(
+            len(comp['influx_laps'])
+            for session in pending_writes
+            for comp in session['competitors']
+        )
 
         if opts.dry_run:
             print(UNDERLINE)
@@ -429,14 +418,13 @@ def old_race(ctx, opts):
             return
 
         if opts.skip_if_complete and expected > 0:
-            total, current = existing_lap_counts(ctx)
+            total, current = existing_lap_counts_fieldwide(ctx)
             if total == expected and current == expected:
                 race_ts_ms = ctx.start_epoc * 1000 if ctx.start_epoc != 0 else int(time.time() * 1000)
                 push_influx_race(ctx, race_ts_ms)
                 logging.info(
-                    "SKIP: race %s car %s already complete and current "
-                    "(%d laps, schema v%d)",
-                    ctx.race_id, ctx.car_number, total, SCHEMA_VERSION)
+                    "SKIP: race %s already complete and current (%d laps, schema v%d)",
+                    ctx.race_id, total, SCHEMA_VERSION)
                 return
 
         delete_existing_laps(ctx)
@@ -468,59 +456,6 @@ def old_race(ctx, opts):
 
     print_rankings(sorted_competitors, False, opts.selected_class,
                    session_details['Session']['Categories'])
-
-    tracked_category = competitor_details.get('Category')
-    try:
-        tracked_pos = int(competitor_details.get('Position', 0))
-        display_class_pos = 1 + sum(
-            1 for c in sorted_competitors
-            if c.get('Category') == tracked_category
-            and c['Number'] != ctx.car_number
-            and int(c.get('Position', 0)) < tracked_pos
-        )
-    except (ValueError, TypeError):
-        display_class_pos = None
-
-    print(
-        f"Team: {competitor_details['FirstName']:<6}\t"
-        f"Car Number: {competitor_details['Number']:<4}\t"
-        f"Class: {display_class_name}\t"
-        f"Transponder: {competitor_details['Transponder']}"
-    )
-    print(
-        f"Best Position:\t{competitor_details['BestPosition']:>}\n"
-        f"Final Position:\t{competitor_details['Position']:>}\n"
-        f"Final Class Position:\t{display_class_pos if display_class_pos is not None else 'N/A':>}\n"
-        f"Total Laps:\t{competitor_details['Laps']:>}\n"
-        f"Best Lap:\t{competitor_details['BestLap']:>}\n"
-        f"Best Lap Time:\t{competitor_details['BestLapTime']:>}\n"
-        f"Total Time:\t{competitor_details['TotalTime']:>}"
-    )
-    print(UNDERLINE)
-
-    for lap in laps:
-        if lap['FlagStatus'] == 1:
-            lap['FlagStatus'] = "Yellow"
-        elif lap['FlagStatus'] == 0:
-            lap['FlagStatus'] = "Green"
-        elif lap['FlagStatus'] == -1:
-            lap['FlagStatus'] = "Finish"
-
-    lap_time_df = pandas.json_normalize(laps)
-    print(lap_time_df.to_string(index=False))
-    print(UNDERLINE)
-
-    for competitor in sorted_competitors:
-        for key, value in competitor.items():
-            try:
-                if key == 'Position':
-                    competitor[key] = int(value)
-            except ValueError:
-                value = None
-
-    if opts.save_file:
-        filename = f"{competitor_details['FirstName']}-{ctx.race_id}-results"
-        write_csv(filename, laps)
 
 
 def print_rankings(sorted_competitors, _race_live, selected_class, categories):
@@ -857,6 +792,28 @@ def existing_lap_counts(ctx):
             f'  |> filter(fn: (r) => r._measurement == "lap"\n'
             f'      and r.race_id == "{ctx.race_id}"\n'
             f'      and r.car_number == "{ctx.car_number}")\n'
+            f'  |> filter(fn: (r) => {field_filter})\n'
+            f'  |> count()'
+        )
+        return sum(r.get_value() for t in tables for r in t.records)
+
+    total = _count('r._field == "lap_no"')
+    current = _count(f'r._field == "schema_version" and r._value == {SCHEMA_VERSION}')
+    return total, current
+
+
+def existing_lap_counts_fieldwide(ctx):
+    """Return (total_laps, current_laps) for all cars in this race.
+
+    Like existing_lap_counts but without a car_number filter — counts across
+    the full field. Used by old_race when running in fieldwide mode.
+    """
+    def _count(field_filter):
+        tables = ctx.query_api.query(
+            f'from(bucket: "laps")\n'
+            f'  |> range(start: {EPOCH_START})\n'
+            f'  |> filter(fn: (r) => r._measurement == "lap"\n'
+            f'      and r.race_id == "{ctx.race_id}")\n'
             f'  |> filter(fn: (r) => {field_filter})\n'
             f'  |> count()'
         )

--- a/src/lemongrass/race_backfill.py
+++ b/src/lemongrass/race_backfill.py
@@ -76,6 +76,11 @@ def _build_parser():
     parser.add_argument('--force', dest='force', action='store_true', default=False,
                         help='Re-backfill every race even if its laps are already complete and '
                              'current; by default complete races are skipped')
+    parser.add_argument('--upgrade-stored', dest='upgrade_stored', action='store_true',
+                       default=False,
+                       help='Re-backfill stored races with schema versions older than current; '
+                            'mutually exclusive with --force, --override, --start-year, '
+                            '--car, and --validate')
     return parser
 
 
@@ -193,9 +198,100 @@ def run_backfill(races, default_car, overrides, dry_run=False, force=False):
     return failures
 
 
+def run_upgrade_stored(query_api, dry_run=False):
+    """Query InfluxDB for stored races with stale schema versions and re-backfill them.
+
+    Races already at the current SCHEMA_VERSION are skipped. Re-backfill calls
+    `laps -n <race_id>` with no car_number (fieldwide mode).
+    """
+    from lemongrass.laps import SCHEMA_VERSION
+
+    races_tables = query_api.query(
+        f'from(bucket: "races")\n'
+        f'  |> range(start: {EPOCH_START})\n'
+        f'  |> filter(fn: (r) => r._measurement == "race" and r._field == "end_time_epoc")\n'
+    )
+    stored_races = {}
+    for table in races_tables:
+        for record in table.records:
+            race_id = record.values.get('race_id')
+            stored_races[race_id] = record.values.get('race_name', 'unknown')
+
+    failures = []
+    for race_id, race_name in sorted(stored_races.items()):
+        total_tables = query_api.query(
+            f'from(bucket: "laps")\n'
+            f'  |> range(start: {EPOCH_START})\n'
+            f'  |> filter(fn: (r) => r._measurement == "lap"\n'
+            f'      and r.race_id == "{race_id}" and r._field == "lap_no")\n'
+            f'  |> count()'
+        )
+        total = sum(r.get_value() for t in total_tables for r in t.records)
+
+        current_tables = query_api.query(
+            f'from(bucket: "laps")\n'
+            f'  |> range(start: {EPOCH_START})\n'
+            f'  |> filter(fn: (r) => r._measurement == "lap"\n'
+            f'      and r.race_id == "{race_id}"\n'
+            f'      and r._field == "schema_version" and r._value == {SCHEMA_VERSION})\n'
+            f'  |> count()'
+        )
+        current = sum(r.get_value() for t in current_tables for r in t.records)
+
+        if total == 0:
+            logging.info("race %s (%s): no laps stored, skipping", race_id, race_name)
+            continue
+
+        if current == total:
+            logging.info("race %s (%s): already at schema v%d, skipping",
+                        race_id, race_name, SCHEMA_VERSION)
+            continue
+
+        logging.info("race %s (%s): stale (%d/%d at current schema), %s",
+                    race_id, race_name, current, total,
+                    "would re-backfill" if dry_run else "re-backfilling")
+        if dry_run:
+            continue
+
+        result = subprocess.run(['laps', '-n', str(race_id)], capture_output=False)
+        if result.returncode == 130:
+            logging.info("laps was interrupted; stopping upgrade.")
+            break
+        if result.returncode != 0:
+            logging.error("Re-backfill failed for race %s", race_id)
+            failures.append(race_id)
+
+    if failures:
+        logging.error("%d race(s) failed to upgrade: %s", len(failures), failures)
+    return failures
+
+
 def main():
     """Entry point: parse args, discover races, then backfill or validate."""
     args = _build_parser().parse_args()
+
+    if args.upgrade_stored:
+        exclusive = [
+            args.force,
+            bool(args.overrides),
+            args.start_year != DEFAULT_START_YEAR,
+            args.car_number != DEFAULT_CAR_NUMBER,
+            args.validate,
+        ]
+        if any(exclusive):
+            logging.error(
+                "--upgrade-stored is mutually exclusive with --force, --override, "
+                "--start-year, --car, and --validate")
+            sys.exit(1)
+        influx_token = os.environ.get('INFLUX_TELEMETRY_TOKEN')
+        if not influx_token:
+            logging.error("INFLUX_TELEMETRY_TOKEN environment variable not set")
+            sys.exit(1)
+        from influxdb_client import InfluxDBClient
+        with InfluxDBClient(url='https://influxdb.focism.com',
+                           token=influx_token, org='focism') as influx_client:
+            failures = run_upgrade_stored(influx_client.query_api(), dry_run=args.dry_run)
+        sys.exit(1 if failures else 0)
 
     token = os.environ.get('RACEMONITOR_TOKEN')
     if not token:

--- a/src/lemongrass/race_backfill.py
+++ b/src/lemongrass/race_backfill.py
@@ -288,9 +288,13 @@ def main():
             logging.error("INFLUX_TELEMETRY_TOKEN environment variable not set")
             sys.exit(1)
         from influxdb_client import InfluxDBClient
-        with InfluxDBClient(url='https://influxdb.focism.com',
-                           token=influx_token, org='focism') as influx_client:
-            failures = run_upgrade_stored(influx_client.query_api(), dry_run=args.dry_run)
+        try:
+            with InfluxDBClient(url='https://influxdb.focism.com',
+                               token=influx_token, org='focism') as influx_client:
+                failures = run_upgrade_stored(influx_client.query_api(), dry_run=args.dry_run)
+        except KeyboardInterrupt:
+            logging.info("Interrupted, exiting.")
+            sys.exit(130)
         sys.exit(1 if failures else 0)
 
     token = os.environ.get('RACEMONITOR_TOKEN')

--- a/src/lemongrass/races.py
+++ b/src/lemongrass/races.py
@@ -5,6 +5,7 @@
 import argparse
 import logging
 import os
+import re
 import sys
 from datetime import datetime, timezone
 
@@ -15,6 +16,7 @@ INFLUX_ORG = 'focism'
 EPOCH_START = '1970-01-01T00:00:00Z'
 
 _SUBCOMMANDS = ('list', 'prune', 'backfill', 'diagnose')
+_RACE_ID_RE = re.compile(r'^[A-Za-z0-9_-]+$')
 
 
 def main():
@@ -108,6 +110,9 @@ def _handle_prune():
                         help='Skip confirmation prompt')
     args = parser.parse_args()
     race_id = args.race_id
+    if not _RACE_ID_RE.fullmatch(race_id):
+        logging.error("Invalid race_id: %r", race_id)
+        sys.exit(1)
     token = _require_influx_token()
 
     with InfluxDBClient(url=INFLUX_URL, token=token, org=INFLUX_ORG) as client:

--- a/src/lemongrass/races.py
+++ b/src/lemongrass/races.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""lemongrass races subcommand dispatcher."""
+
+import argparse
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+
+from influxdb_client import InfluxDBClient
+
+INFLUX_URL = 'https://influxdb.focism.com'
+INFLUX_ORG = 'focism'
+EPOCH_START = '1970-01-01T00:00:00Z'
+
+_SUBCOMMANDS = ('list', 'prune', 'backfill', 'diagnose')
+
+
+def main():
+    if len(sys.argv) < 2 or sys.argv[1] not in _SUBCOMMANDS:
+        print("Usage: lemongrass races <subcommand> [args]")
+        print(f"Subcommands: {', '.join(_SUBCOMMANDS)}")
+        sys.exit(1)
+    subcmd = sys.argv.pop(1)
+    sys.argv[0] = f'lemongrass-races-{subcmd}'
+    {'list': _handle_list, 'prune': _handle_prune,
+     'backfill': _handle_backfill, 'diagnose': _handle_diagnose}[subcmd]()
+
+
+def _require_influx_token():
+    token = os.environ.get('INFLUX_TELEMETRY_TOKEN')
+    if not token:
+        logging.error("INFLUX_TELEMETRY_TOKEN environment variable not set")
+        sys.exit(1)
+    return token
+
+
+def _handle_list():
+    from lemongrass.laps import SCHEMA_VERSION
+
+    token = _require_influx_token()
+    with InfluxDBClient(url=INFLUX_URL, token=token, org=INFLUX_ORG) as client:
+        query_api = client.query_api()
+
+        races_tables = query_api.query(
+            f'from(bucket: "races")\n'
+            f'  |> range(start: {EPOCH_START})\n'
+            f'  |> filter(fn: (r) => r._measurement == "race" and r._field == "end_time_epoc")\n'
+        )
+        races = {}
+        for table in races_tables:
+            for record in table.records:
+                race_id = record.values.get('race_id')
+                races[race_id] = {
+                    'name': record.values.get('race_name', 'unknown'),
+                    'date': record.get_time().strftime('%Y-%m-%d') if record.get_time() else '?',
+                    'total': 0,
+                    'current': 0,
+                }
+
+        total_tables = query_api.query(
+            f'from(bucket: "laps")\n'
+            f'  |> range(start: {EPOCH_START})\n'
+            f'  |> filter(fn: (r) => r._measurement == "lap" and r._field == "lap_no")\n'
+            f'  |> group(columns: ["race_id"])\n'
+            f'  |> count()'
+        )
+        for table in total_tables:
+            for record in table.records:
+                rid = record.values.get('race_id')
+                if rid in races:
+                    races[rid]['total'] = record.get_value()
+
+        current_tables = query_api.query(
+            f'from(bucket: "laps")\n'
+            f'  |> range(start: {EPOCH_START})\n'
+            f'  |> filter(fn: (r) => r._measurement == "lap"\n'
+            f'      and r._field == "schema_version" and r._value == {SCHEMA_VERSION})\n'
+            f'  |> group(columns: ["race_id"])\n'
+            f'  |> count()'
+        )
+        for table in current_tables:
+            for record in table.records:
+                rid = record.values.get('race_id')
+                if rid in races:
+                    races[rid]['current'] = record.get_value()
+
+        sorted_races = sorted(races.items(), key=lambda kv: kv[1]['date'], reverse=True)
+        print(f"{'RACE ID':<10} {'NAME':<35} {'DATE':<12} {'LAPS':<8} SCHEMA")
+        print('-' * 80)
+        for race_id, info in sorted_races:
+            if info['total'] == 0:
+                schema_str = 'no laps'
+            elif info['current'] == info['total']:
+                schema_str = f'current (v{SCHEMA_VERSION})'
+            else:
+                schema_str = f'stale   ({info["current"]}/{info["total"]} at v{SCHEMA_VERSION})'
+            print(f"{race_id:<10} {info['name'][:35]:<35} {info['date']:<12} "
+                  f"{info['total']:<8} {schema_str}")
+
+
+def _handle_prune():
+    parser = argparse.ArgumentParser(prog='lemongrass-races-prune',
+                                     description='Delete all data for a race from InfluxDB')
+    parser.add_argument('race_id')
+    parser.add_argument('--yes', action='store_true', default=False,
+                        help='Skip confirmation prompt')
+    args = parser.parse_args()
+    race_id = args.race_id
+    token = _require_influx_token()
+
+    with InfluxDBClient(url=INFLUX_URL, token=token, org=INFLUX_ORG) as client:
+        query_api = client.query_api()
+        races_tables = query_api.query(
+            f'from(bucket: "races")\n'
+            f'  |> range(start: {EPOCH_START})\n'
+            f'  |> filter(fn: (r) => r._measurement == "race"\n'
+            f'      and r.race_id == "{race_id}" and r._field == "end_time_epoc")\n'
+            f'  |> first()'
+        )
+        race_name = 'unknown'
+        for table in races_tables:
+            for record in table.records:
+                race_name = record.values.get('race_name', 'unknown')
+
+        if not args.yes:
+            answer = input(f"Delete all data for race {race_id} ({race_name})? [y/N] ")
+            if answer.strip().lower() != 'y':
+                print("Aborted.")
+                sys.exit(0)
+
+        now = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+        delete_api = client.delete_api()
+
+        delete_api.delete(start=EPOCH_START, stop=now,
+                         predicate=f'_measurement="lap" AND race_id="{race_id}"',
+                         bucket='laps')
+        print(f"Deleted laps for race {race_id}")
+
+        delete_api.delete(start=EPOCH_START, stop=now,
+                         predicate=f'_measurement="race" AND race_id="{race_id}"',
+                         bucket='races')
+        print(f"Deleted race metadata for race {race_id}")
+
+        delete_api.delete(start=EPOCH_START, stop=now,
+                         predicate=f'_measurement="session" AND race_id="{race_id}"',
+                         bucket='race_sessions')
+        print(f"Deleted sessions for race {race_id}")
+
+
+def _handle_backfill():
+    from lemongrass import race_backfill
+    race_backfill.main()
+
+
+def _handle_diagnose():
+    from lemongrass import race_diagnose
+    race_diagnose.main()

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -46,7 +46,7 @@ class TestMonitorRoutine:
     def test_collects_all_new_laps_not_just_last(self):
         stop = threading.Event()
         ctx = _mod.RaceContext('123', '42', MagicMock(), None, 0)
-        opts = _mod.RaceOptions(network_mode=False, interval=30)
+        opts = _mod.RaceOptions(network_mode=False, interval=0)
 
         lap1 = {'Lap': '1', 'LapTime': '1:00.000'}
         lap2 = {'Lap': '2', 'LapTime': '1:01.000'}
@@ -72,7 +72,7 @@ class TestMonitorRoutine:
     def test_empty_refresh_does_not_crash(self):
         stop = threading.Event()
         ctx = _mod.RaceContext('123', '42', MagicMock(), None, 0)
-        opts = _mod.RaceOptions(network_mode=False, interval=30)
+        opts = _mod.RaceOptions(network_mode=False, interval=0)
 
         call_count = 0
         def fake_refresh(c):
@@ -91,7 +91,7 @@ class TestMonitorRoutine:
     def test_detects_new_session_and_updates_session_id(self):
         stop = threading.Event()
         ctx = _mod.RaceContext('123', '42', MagicMock(), None, 0)
-        opts = _mod.RaceOptions(network_mode=True, interval=30)
+        opts = _mod.RaceOptions(network_mode=True, interval=0)
 
         lap1 = {'Lap': '1', 'LapTime': '1:00.000'}
         lap2 = {'Lap': '2', 'LapTime': '1:01.000'}
@@ -120,7 +120,7 @@ class TestMonitorRoutine:
     def test_new_session_prints_message(self, capsys):
         stop = threading.Event()
         ctx = _mod.RaceContext('123', '42', MagicMock(), None, 0)
-        opts = _mod.RaceOptions(network_mode=False, interval=30)
+        opts = _mod.RaceOptions(network_mode=False, interval=0)
 
         session_calls = 0
         def fake_get_session(race_id):
@@ -189,7 +189,7 @@ class TestMonitorRoutine:
     def test_returns_interrupted_on_keyboard_interrupt(self, capsys):
         stop = threading.Event()
         ctx = _mod.RaceContext('123', '42', MagicMock(), None, 0)
-        opts = _mod.RaceOptions(network_mode=False, interval=30)
+        opts = _mod.RaceOptions(network_mode=False, interval=0)
 
         ctx.client.live.get_session.return_value = {'Successful': False}
 

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -625,7 +625,7 @@ class TestOldRaceSkip:
     def test_skips_writes_when_complete_and_current(self):
         ctx = self._ctx()
         opts = _mod.RaceOptions(network_mode=True, skip_if_complete=True)
-        with patch.object(_mod, 'existing_lap_counts', return_value=(1, 1)):
+        with patch.object(_mod, 'existing_lap_counts_fieldwide', return_value=(1, 1)):
             with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
                 with patch.object(_mod, 'push_influx') as mock_push:
                     with patch.object(_mod, 'push_influx_race') as mock_race:
@@ -639,7 +639,7 @@ class TestOldRaceSkip:
     def test_logs_skip_message_when_complete(self, caplog):
         ctx = self._ctx()
         opts = _mod.RaceOptions(network_mode=True, skip_if_complete=True)
-        with patch.object(_mod, 'existing_lap_counts', return_value=(1, 1)):
+        with patch.object(_mod, 'existing_lap_counts_fieldwide', return_value=(1, 1)):
             with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
                 with patch.object(_mod, 'push_influx'):
                     with patch.object(_mod, 'push_influx_race'):
@@ -651,7 +651,7 @@ class TestOldRaceSkip:
     def test_writes_when_laps_incomplete(self):
         ctx = self._ctx()
         opts = _mod.RaceOptions(network_mode=True, skip_if_complete=True)
-        with patch.object(_mod, 'existing_lap_counts', return_value=(0, 0)):
+        with patch.object(_mod, 'existing_lap_counts_fieldwide', return_value=(0, 0)):
             with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
                 with patch.object(_mod, 'push_influx_race'):
                     with patch.object(_mod, 'print_rankings'):
@@ -661,7 +661,7 @@ class TestOldRaceSkip:
     def test_writes_when_laps_stale_schema(self):
         ctx = self._ctx()
         opts = _mod.RaceOptions(network_mode=True, skip_if_complete=True)
-        with patch.object(_mod, 'existing_lap_counts', return_value=(1, 0)):
+        with patch.object(_mod, 'existing_lap_counts_fieldwide', return_value=(1, 0)):
             with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
                 with patch.object(_mod, 'push_influx_race'):
                     with patch.object(_mod, 'print_rankings'):
@@ -671,7 +671,7 @@ class TestOldRaceSkip:
     def test_does_not_query_counts_when_skip_disabled(self):
         ctx = self._ctx()
         opts = _mod.RaceOptions(network_mode=True, skip_if_complete=False)
-        with patch.object(_mod, 'existing_lap_counts') as mock_counts:
+        with patch.object(_mod, 'existing_lap_counts_fieldwide') as mock_counts:
             with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
                 with patch.object(_mod, 'push_influx_race'):
                     with patch.object(_mod, 'print_rankings'):
@@ -734,6 +734,104 @@ class TestExistingLapCounts:
         assert f'_value == {_mod.SCHEMA_VERSION}' in current_flux
 
 
+class TestArgParserCarNumber:
+    def test_car_number_optional(self):
+        args = _mod._build_parser().parse_args(['12345'])
+        assert args.car_number is None
+
+    def test_car_number_accepted_when_provided(self):
+        args = _mod._build_parser().parse_args(['12345', '42'])
+        assert args.car_number == 42
+
+
+class TestExistingLapCountsFieldwide:
+    def _query_api(self, lap_no_count=0, current_count=0):
+        responses = iter([lap_no_count, current_count])
+
+        def fake_query(flux):
+            count = next(responses)
+            table = MagicMock()
+            rec = MagicMock()
+            rec.get_value.return_value = count
+            table.records = [rec]
+            return [table]
+
+        api = MagicMock()
+        api.query.side_effect = fake_query
+        return api
+
+    def test_returns_total_and_current_schema_counts(self):
+        ctx = _mod.RaceContext('999', None, MagicMock(), MagicMock(), 0)
+        ctx.query_api = self._query_api(lap_no_count=10, current_count=7)
+        total, current = _mod.existing_lap_counts_fieldwide(ctx)
+        assert total == 10
+        assert current == 7
+
+    def test_query_does_not_filter_by_car_number(self):
+        ctx = _mod.RaceContext('999', None, MagicMock(), MagicMock(), 0)
+        ctx.query_api = self._query_api()
+        _mod.existing_lap_counts_fieldwide(ctx)
+        flux_calls = [c.args[0] for c in ctx.query_api.query.call_args_list]
+        assert all('car_number' not in q for q in flux_calls)
+        assert all('race_id == "999"' in q for q in flux_calls)
+
+
+class TestOldRaceFieldwide:
+    def _session_details(self, car_number='42'):
+        return {
+            'Successful': True,
+            'Session': {
+                'ID': 1, 'RaceID': 999, 'Name': 'S1', 'SessionStartDateEpoc': 0,
+                'Categories': {'1': {'ID': '1', 'Name': 'A'}},
+                'SortedCompetitors': [{
+                    'Number': car_number, 'Category': '1', 'ID': 1, 'SessionID': 1,
+                    'RaceID': 999, 'FirstName': 'Jane', 'LastName': 'Doe',
+                    'Position': '1', 'Laps': '1', 'LastLapTime': '',
+                    'BestPosition': '1', 'BestLap': '1',
+                    'BestLapTime': '0:01:30.000', 'TotalTime': '0:01:30.000',
+                    'Transponder': '', 'Nationality': '', 'AdditionalData': '',
+                    'LapTimes': [
+                        {'Lap': '1', 'LapTime': '0:01:30.000', 'Position': '1',
+                         'FlagStatus': 0, 'TotalTime': '0:01:30.000'},
+                    ],
+                }],
+            },
+        }
+
+    def test_proceeds_even_when_tracked_car_absent(self):
+        """With no competitor_missing gate, old_race writes even when ctx.car_number absent."""
+        ctx = _mod.RaceContext('999', '77', MagicMock(), MagicMock(), 0)
+        ctx.delete_api = MagicMock()
+        ctx.query_api = MagicMock()
+        opts = _mod.RaceOptions(network_mode=True)
+        # session has car 42 only; tracked car 77 is absent
+        ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
+        ctx.client.results.session_details.return_value = self._session_details('42')
+        with patch.object(_mod, 'delete_existing_laps') as mock_del:
+            with patch.object(_mod, '_write_points_chunked'):
+                with patch.object(_mod, 'push_influx_race'):
+                    with patch.object(_mod, 'push_influx_session'):
+                        with patch.object(_mod, 'print_rankings'):
+                            with patch.object(_mod, '_resolve_class_historical',
+                                              return_value=('A', {1: 1})):
+                                _mod.old_race(ctx, opts)
+        mock_del.assert_called_once()
+
+    def test_returns_early_when_no_competitors_have_laps(self, caplog):
+        ctx = _mod.RaceContext('999', None, MagicMock(), MagicMock(), 0)
+        opts = _mod.RaceOptions(network_mode=True)
+        ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
+        # competitor has empty LapTimes
+        no_laps_details = self._session_details()
+        no_laps_details['Session']['SortedCompetitors'][0]['LapTimes'] = []
+        ctx.client.results.session_details.return_value = no_laps_details
+        with patch.object(_mod, 'delete_existing_laps') as mock_del:
+            with caplog.at_level(logging.WARNING):
+                _mod.old_race(ctx, opts)
+        mock_del.assert_not_called()
+        assert any('No competitors' in r.message for r in caplog.records)
+
+
 class TestOldRacePrintsClass:
     def _session_details(self):
         return {
@@ -755,16 +853,6 @@ class TestOldRacePrintsClass:
                 }],
             },
         }
-
-    def test_prints_class_name(self, capsys):
-        ctx = _mod.RaceContext('999', '42', MagicMock(), None, 0)
-        opts = _mod.RaceOptions(network_mode=False)
-        ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
-        ctx.client.results.session_details.return_value = self._session_details()
-        with patch.object(_mod, 'print_rankings'):
-            _mod.old_race(ctx, opts)
-        assert 'Class: B-Class' in capsys.readouterr().out
-
 
 class TestLiveRace:
     def _session_response(self, class_desc='A'):
@@ -1003,15 +1091,6 @@ class TestOldRaceClassWiring:
                 _mod.old_race(ctx, opts)
         mock_race.assert_not_called()
 
-    def test_old_race_push_influx_race_not_called_when_car_not_found(self):
-        ctx = _mod.RaceContext('999', '99', MagicMock(), MagicMock(), 1000)
-        opts = _mod.RaceOptions(network_mode=True)
-        ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
-        ctx.client.results.session_details.return_value = self._session_details(car_number='42')
-        with patch.object(_mod, 'push_influx_race') as mock_race:
-            _mod.old_race(ctx, opts)
-        mock_race.assert_not_called()
-
     def test_deletes_existing_laps_before_push(self):
         ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
         ctx.delete_api = MagicMock()
@@ -1068,20 +1147,6 @@ class TestOldRaceClassWiring:
                             _mod.old_race(ctx, opts)
         mock_del.assert_called_once_with(ctx)
         assert mock_build.call_count == 2
-
-    def test_no_delete_when_competitor_missing(self):
-        ctx = _mod.RaceContext('999', '77', MagicMock(), MagicMock(), 0)
-        ctx.delete_api = MagicMock()
-        opts = _mod.RaceOptions(network_mode=True)
-        # session contains car 42 only; tracked car 77 is absent
-        ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
-        ctx.client.results.session_details.return_value = self._session_details()
-        with patch.object(_mod, 'delete_existing_laps') as mock_del:
-            with patch.object(_mod, 'push_influx'):
-                with patch.object(_mod, 'push_influx_race'):
-                    with patch.object(_mod, 'print_rankings'):
-                        _mod.old_race(ctx, opts)
-        mock_del.assert_not_called()
 
     def test_no_delete_when_not_network_mode(self):
         ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
@@ -1851,15 +1916,6 @@ class TestOldRaceFullField:
         built_car_numbers = {c.args[7] for c in mock_build.call_args_list}
         assert built_car_numbers == {'42', '99'}
 
-    def test_does_not_write_if_tracked_car_absent(self):
-        ctx = self._ctx(self._session_details_two_cars(), car_number='77')
-        opts = _mod.RaceOptions(network_mode=True)
-        with patch.object(_mod, 'delete_existing_laps') as mock_del:
-            with patch.object(_mod, 'push_influx_race'):
-                _mod.old_race(ctx, opts)
-        assert not ctx.write_api.write.called
-        mock_del.assert_not_called()
-
     def test_resolve_class_called_per_competitor(self):
         ctx = self._ctx(self._session_details_two_cars())
         opts = _mod.RaceOptions(network_mode=True)
@@ -1977,13 +2033,6 @@ class TestOldRaceFullField:
         with patch.object(_mod, 'push_influx_session') as mock_session:
             with patch.object(_mod, 'print_rankings'):
                 _mod.old_race(ctx, opts)
-        mock_session.assert_not_called()
-
-    def test_push_influx_session_not_called_when_car_missing(self):
-        ctx = self._ctx(self._session_details_two_cars(), car_number='77')
-        opts = _mod.RaceOptions(network_mode=True)
-        with patch.object(_mod, 'push_influx_session') as mock_session:
-            _mod.old_race(ctx, opts)
         mock_session.assert_not_called()
 
     def test_build_lap_points_receives_session_id(self):

--- a/tests/test_race_backfill.py
+++ b/tests/test_race_backfill.py
@@ -304,9 +304,10 @@ class TestRunUpgradeStored:
             elif '"schema_version"' in flux:
                 table.records = []
                 for race_id, count in current_by_race.items():
-                    rec = MagicMock()
-                    rec.get_value.return_value = count
-                    table.records.append(rec)
+                    if f'race_id == "{race_id}"' in flux:
+                        rec = MagicMock()
+                        rec.get_value.return_value = count
+                        table.records.append(rec)
             else:
                 # total laps query
                 # return single record with count for the race_id embedded in the flux

--- a/tests/test_race_backfill.py
+++ b/tests/test_race_backfill.py
@@ -282,6 +282,139 @@ class TestValidateBackfill:
                    if r.levelno == logging.WARNING)
 
 
+class TestRunUpgradeStored:
+    def _query_api(self, stored_races=None, total_by_race=None, current_by_race=None):
+        """
+        stored_races: dict of race_id -> race_name
+        total_by_race: dict of race_id -> total lap count
+        current_by_race: dict of race_id -> current-schema lap count
+        """
+        stored_races = stored_races or {}
+        total_by_race = total_by_race or {}
+        current_by_race = current_by_race or {}
+
+        def fake_query(flux):
+            table = MagicMock()
+            if 'bucket: "races"' in flux:
+                table.records = []
+                for race_id, name in stored_races.items():
+                    rec = MagicMock()
+                    rec.values = {'race_id': race_id, 'race_name': name}
+                    table.records.append(rec)
+            elif '"schema_version"' in flux:
+                table.records = []
+                for race_id, count in current_by_race.items():
+                    rec = MagicMock()
+                    rec.get_value.return_value = count
+                    table.records.append(rec)
+            else:
+                # total laps query
+                # return single record with count for the race_id embedded in the flux
+                count = 0
+                for race_id, c in total_by_race.items():
+                    if f'race_id == "{race_id}"' in flux:
+                        count = c
+                rec = MagicMock()
+                rec.get_value.return_value = count
+                table.records = [rec]
+            return [table]
+
+        api = MagicMock()
+        api.query.side_effect = fake_query
+        return api
+
+    def test_skips_race_already_at_current_schema(self, caplog):
+        import logging
+        query_api = self._query_api(
+            stored_races={'101': 'Lemons 2024'},
+            total_by_race={'101': 10},
+            current_by_race={'101': 10},
+        )
+        with patch.object(_mod.subprocess, 'run') as mock_run:
+            with caplog.at_level(logging.INFO):
+                _mod.run_upgrade_stored(query_api)
+        mock_run.assert_not_called()
+        assert any('skipping' in r.message and '101' in r.message for r in caplog.records)
+
+    def test_rebackfills_stale_race(self):
+        query_api = self._query_api(
+            stored_races={'101': 'Lemons 2024'},
+            total_by_race={'101': 10},
+            current_by_race={'101': 5},
+        )
+        with patch.object(_mod.subprocess, 'run') as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            _mod.run_upgrade_stored(query_api)
+        assert mock_run.call_count == 1
+        cmd = mock_run.call_args.args[0]
+        assert cmd == ['laps', '-n', '101']
+
+    def test_dry_run_does_not_call_subprocess(self):
+        query_api = self._query_api(
+            stored_races={'101': 'Lemons 2024'},
+            total_by_race={'101': 10},
+            current_by_race={'101': 5},
+        )
+        with patch.object(_mod.subprocess, 'run') as mock_run:
+            _mod.run_upgrade_stored(query_api, dry_run=True)
+        mock_run.assert_not_called()
+
+    def test_skips_race_with_no_stored_laps(self, caplog):
+        import logging
+        query_api = self._query_api(
+            stored_races={'101': 'Lemons 2024'},
+            total_by_race={'101': 0},
+            current_by_race={},
+        )
+        with patch.object(_mod.subprocess, 'run') as mock_run:
+            with caplog.at_level(logging.INFO):
+                _mod.run_upgrade_stored(query_api)
+        mock_run.assert_not_called()
+
+    def test_returns_failed_race_ids(self):
+        query_api = self._query_api(
+            stored_races={'101': 'Lemons 2024'},
+            total_by_race={'101': 10},
+            current_by_race={'101': 5},
+        )
+        with patch.object(_mod.subprocess, 'run') as mock_run:
+            mock_run.return_value = MagicMock(returncode=1)
+            failures = _mod.run_upgrade_stored(query_api)
+        assert failures == ['101']
+
+    def test_returns_empty_list_on_success(self):
+        query_api = self._query_api(
+            stored_races={'101': 'Lemons 2024'},
+            total_by_race={'101': 10},
+            current_by_race={'101': 5},
+        )
+        with patch.object(_mod.subprocess, 'run') as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            failures = _mod.run_upgrade_stored(query_api)
+        assert failures == []
+
+    def test_stops_on_interrupt(self):
+        query_api = self._query_api(
+            stored_races={'101': 'Race 1', '202': 'Race 2'},
+            total_by_race={'101': 5, '202': 5},
+            current_by_race={'101': 0, '202': 0},
+        )
+        with patch.object(_mod.subprocess, 'run') as mock_run:
+            mock_run.return_value = MagicMock(returncode=130)
+            _mod.run_upgrade_stored(query_api)
+        assert mock_run.call_count == 1
+
+
+class TestUpgradeStoredArgParsing:
+    def test_upgrade_stored_flag_accepted(self):
+        args = _mod._build_parser().parse_args(['--upgrade-stored'])
+        assert args.upgrade_stored is True
+
+    def test_upgrade_stored_default_false(self):
+        args = _mod._build_parser().parse_args([])
+        assert args.upgrade_stored is False
+
+
 class TestArgParsing:
     def test_dry_run_flag(self):
         args = _mod._build_parser().parse_args(['--dry-run'])

--- a/tests/test_races.py
+++ b/tests/test_races.py
@@ -105,3 +105,73 @@ class TestHandlePrune:
                 with pytest.raises(SystemExit) as exc:
                     _mod._handle_prune()
         assert exc.value.code != 0
+
+
+class TestHandleBackfill:
+    def test_delegates_to_race_backfill_main(self):
+        mock_main = MagicMock()
+        with patch.object(sys, 'argv', ['lemongrass-races-backfill', '--dry-run']):
+            with patch('lemongrass.race_backfill.main', mock_main):
+                _mod._handle_backfill()
+        mock_main.assert_called_once()
+
+    def test_argv_passed_through_to_race_backfill(self):
+        captured = {}
+
+        def capture():
+            captured['argv'] = sys.argv[:]
+
+        with patch.object(sys, 'argv', ['lemongrass-races-backfill', '--force']):
+            with patch('lemongrass.race_backfill.main', capture):
+                _mod._handle_backfill()
+        assert '--force' in captured['argv']
+
+    def test_routes_backfill_through_main_dispatch(self):
+        mock_main = MagicMock()
+        with patch.object(sys, 'argv', ['lemongrass-races', 'backfill', '--dry-run']):
+            with patch('lemongrass.race_backfill.main', mock_main):
+                _mod.main()
+        mock_main.assert_called_once()
+
+    def test_upgrade_stored_flag_reaches_race_backfill(self):
+        captured = {}
+
+        def capture():
+            captured['argv'] = sys.argv[:]
+
+        with patch.object(sys, 'argv',
+                          ['lemongrass-races', 'backfill', '--upgrade-stored']):
+            with patch('lemongrass.race_backfill.main', capture):
+                _mod.main()
+        assert '--upgrade-stored' in captured['argv']
+
+
+class TestHandleDiagnose:
+    def test_delegates_to_race_diagnose_main(self):
+        mock_main = MagicMock()
+        with patch.object(sys, 'argv',
+                          ['lemongrass-races-diagnose', '12345', '42']):
+            with patch('lemongrass.race_diagnose.main', mock_main):
+                _mod._handle_diagnose()
+        mock_main.assert_called_once()
+
+    def test_argv_passed_through_to_race_diagnose(self):
+        captured = {}
+
+        def capture():
+            captured['argv'] = sys.argv[:]
+
+        with patch.object(sys, 'argv',
+                          ['lemongrass-races-diagnose', '12345', '42']):
+            with patch('lemongrass.race_diagnose.main', capture):
+                _mod._handle_diagnose()
+        assert '12345' in captured['argv']
+        assert '42' in captured['argv']
+
+    def test_routes_diagnose_through_main_dispatch(self):
+        mock_main = MagicMock()
+        with patch.object(sys, 'argv',
+                          ['lemongrass-races', 'diagnose', '12345', '42']):
+            with patch('lemongrass.race_diagnose.main', mock_main):
+                _mod.main()
+        mock_main.assert_called_once()

--- a/tests/test_races.py
+++ b/tests/test_races.py
@@ -1,0 +1,107 @@
+import sys
+from unittest.mock import MagicMock, patch
+import pytest
+
+import lemongrass.races as _mod
+
+
+class TestDispatch:
+    def test_unknown_subcommand_exits_nonzero(self):
+        with patch.object(sys, 'argv', ['lemongrass-races', 'notasubcommand']):
+            with pytest.raises(SystemExit) as exc:
+                _mod.main()
+        assert exc.value.code != 0
+
+    def test_no_args_exits_nonzero(self):
+        with patch.object(sys, 'argv', ['lemongrass-races']):
+            with pytest.raises(SystemExit) as exc:
+                _mod.main()
+        assert exc.value.code != 0
+
+    def test_routes_to_list(self):
+        mock_list = MagicMock()
+        with patch.object(sys, 'argv', ['lemongrass-races', 'list']):
+            with patch.object(_mod, '_handle_list', mock_list):
+                _mod.main()
+        mock_list.assert_called_once()
+
+    def test_routes_to_prune(self):
+        mock_prune = MagicMock()
+        with patch.object(sys, 'argv', ['lemongrass-races', 'prune', '12345']):
+            with patch.object(_mod, '_handle_prune', mock_prune):
+                _mod.main()
+        mock_prune.assert_called_once()
+
+    def test_pops_subcommand_from_argv(self):
+        captured = {}
+
+        def capture():
+            captured['argv'] = sys.argv[:]
+
+        with patch.object(sys, 'argv', ['lemongrass-races', 'list']):
+            with patch.object(_mod, '_handle_list', capture):
+                _mod.main()
+        assert 'list' not in captured['argv']
+        assert captured['argv'][0] == 'lemongrass-races-list'
+
+
+class TestHandlePrune:
+    def _make_influx_client(self, race_name='Test Race'):
+        client = MagicMock()
+        query_api = MagicMock()
+
+        def fake_query(flux):
+            table = MagicMock()
+            rec = MagicMock()
+            rec.values = {'race_name': race_name}
+            table.records = [rec]
+            return [table]
+
+        query_api.query.side_effect = fake_query
+        client.query_api.return_value = query_api
+        client.delete_api.return_value = MagicMock()
+        client.__enter__ = lambda s: client
+        client.__exit__ = MagicMock(return_value=False)
+        return client
+
+    def test_prune_with_yes_skips_prompt(self, capsys):
+        with patch.object(sys, 'argv', ['lemongrass-races-prune', '12345', '--yes']):
+            with patch('lemongrass.races.InfluxDBClient',
+                       return_value=self._make_influx_client()):
+                with patch.dict('os.environ', {'INFLUX_TELEMETRY_TOKEN': 'tok'}):
+                    _mod._handle_prune()
+        out = capsys.readouterr().out
+        assert 'Deleted laps' in out
+        assert 'Deleted race metadata' in out
+        assert 'Deleted sessions' in out
+
+    def test_prune_aborts_on_no_confirmation(self, capsys):
+        with patch.object(sys, 'argv', ['lemongrass-races-prune', '12345']):
+            with patch('lemongrass.races.InfluxDBClient',
+                       return_value=self._make_influx_client()):
+                with patch.dict('os.environ', {'INFLUX_TELEMETRY_TOKEN': 'tok'}):
+                    with patch('builtins.input', return_value='n'):
+                        with pytest.raises(SystemExit) as exc:
+                            _mod._handle_prune()
+        assert exc.value.code == 0
+        assert 'Aborted' in capsys.readouterr().out
+
+    def test_prune_deletes_from_all_three_buckets(self):
+        with patch.object(sys, 'argv', ['lemongrass-races-prune', '12345', '--yes']):
+            fake_client = self._make_influx_client()
+            with patch('lemongrass.races.InfluxDBClient', return_value=fake_client):
+                with patch.dict('os.environ', {'INFLUX_TELEMETRY_TOKEN': 'tok'}):
+                    _mod._handle_prune()
+        delete_api = fake_client.delete_api.return_value
+        buckets_deleted = [c.kwargs.get('bucket') or c.args[2]
+                          for c in delete_api.delete.call_args_list]
+        assert 'laps' in buckets_deleted
+        assert 'races' in buckets_deleted
+        assert 'race_sessions' in buckets_deleted
+
+    def test_prune_exits_when_no_influx_token(self):
+        with patch.object(sys, 'argv', ['lemongrass-races-prune', '12345', '--yes']):
+            with patch.dict('os.environ', {}, clear=True):
+                with pytest.raises(SystemExit) as exc:
+                    _mod._handle_prune()
+        assert exc.value.code != 0

--- a/tests/test_races.py
+++ b/tests/test_races.py
@@ -146,6 +146,115 @@ class TestHandleBackfill:
         assert '--upgrade-stored' in captured['argv']
 
 
+class TestHandleList:
+    def _make_client(self, races, totals, currents):
+        """Build mock InfluxDB client for _handle_list.
+
+        races:    list of (race_id, race_name, date_str) e.g. ('R1', 'My Race', '2026-01-15')
+        totals:   dict {race_id: total_lap_count}
+        currents: dict {race_id: current_schema_lap_count}
+        """
+        from datetime import datetime, timezone
+
+        def fake_query(flux):
+            if 'bucket: "races"' in flux:
+                tables = []
+                for race_id, race_name, date_str in races:
+                    table = MagicMock()
+                    rec = MagicMock()
+                    rec.values = {'race_id': race_id, 'race_name': race_name}
+                    rec.get_time.return_value = datetime.strptime(
+                        date_str, '%Y-%m-%d').replace(tzinfo=timezone.utc)
+                    table.records = [rec]
+                    tables.append(table)
+                return tables
+            elif '"lap_no"' in flux:
+                tables = []
+                for race_id, count in totals.items():
+                    table = MagicMock()
+                    rec = MagicMock()
+                    rec.values = {'race_id': race_id}
+                    rec.get_value.return_value = count
+                    table.records = [rec]
+                    tables.append(table)
+                return tables
+            else:
+                tables = []
+                for race_id, count in currents.items():
+                    table = MagicMock()
+                    rec = MagicMock()
+                    rec.values = {'race_id': race_id}
+                    rec.get_value.return_value = count
+                    table.records = [rec]
+                    tables.append(table)
+                return tables
+
+        client = MagicMock()
+        query_api = MagicMock()
+        query_api.query.side_effect = fake_query
+        client.query_api.return_value = query_api
+        client.__enter__ = lambda s: client
+        client.__exit__ = MagicMock(return_value=False)
+        return client
+
+    def test_no_laps_schema_state(self, capsys):
+        client = self._make_client(
+            races=[('R1', 'Empty Race', '2026-01-01')],
+            totals={},
+            currents={},
+        )
+        with patch('lemongrass.races.InfluxDBClient', return_value=client):
+            with patch.dict('os.environ', {'INFLUX_TELEMETRY_TOKEN': 'tok'}):
+                _mod._handle_list()
+        assert 'no laps' in capsys.readouterr().out
+
+    def test_current_schema_state(self, capsys):
+        from lemongrass.laps import SCHEMA_VERSION
+        client = self._make_client(
+            races=[('R1', 'Full Race', '2026-01-01')],
+            totals={'R1': 50},
+            currents={'R1': 50},
+        )
+        with patch('lemongrass.races.InfluxDBClient', return_value=client):
+            with patch.dict('os.environ', {'INFLUX_TELEMETRY_TOKEN': 'tok'}):
+                _mod._handle_list()
+        assert f'current (v{SCHEMA_VERSION})' in capsys.readouterr().out
+
+    def test_stale_schema_state(self, capsys):
+        client = self._make_client(
+            races=[('R1', 'Old Race', '2026-01-01')],
+            totals={'R1': 50},
+            currents={'R1': 20},
+        )
+        with patch('lemongrass.races.InfluxDBClient', return_value=client):
+            with patch.dict('os.environ', {'INFLUX_TELEMETRY_TOKEN': 'tok'}):
+                _mod._handle_list()
+        out = capsys.readouterr().out
+        assert 'stale' in out
+        assert '20/50' in out
+
+    def test_sorted_newest_first(self, capsys):
+        client = self._make_client(
+            races=[
+                ('R1', 'Old Race', '2024-06-01'),
+                ('R2', 'New Race', '2026-06-01'),
+            ],
+            totals={'R1': 10, 'R2': 10},
+            currents={'R1': 10, 'R2': 10},
+        )
+        with patch('lemongrass.races.InfluxDBClient', return_value=client):
+            with patch.dict('os.environ', {'INFLUX_TELEMETRY_TOKEN': 'tok'}):
+                _mod._handle_list()
+        out = capsys.readouterr().out
+        assert out.index('New Race') < out.index('Old Race')
+
+    def test_exits_when_no_influx_token(self):
+        with patch.dict('os.environ', {}, clear=True):
+            with pytest.raises(SystemExit) as exc:
+                _mod._handle_list()
+        assert exc.value.code != 0
+
+
 class TestHandleDiagnose:
     def test_delegates_to_race_diagnose_main(self):
         mock_main = MagicMock()


### PR DESCRIPTION
## Summary

- **`laps`**: \`car_number\` is now optional; \`old_race\` writes all competitors fieldwide (removes tracked-car gate). \`--skip-if-complete\` now checks fieldwide lap counts via \`existing_lap_counts_fieldwide()\`.
- **\`race-backfill --upgrade-stored\`**: queries InfluxDB for stored races with stale schema versions and re-backfills them via \`laps -n <race_id>\` (fieldwide, no car number needed).
- **\`lemongrass races\`**: new subcommand with \`list\` (shows all stored races with schema staleness), \`prune\` (deletes race from all 3 buckets with confirmation), \`backfill\` (delegates to \`race-backfill\`), and \`diagnose\` (delegates to \`race-diagnose\`). Wired into \`cli.py\`.
- **Review fixes**: validate \`race_id\` against \`[A-Za-z0-9_-]\` before Flux interpolation; wrap \`--upgrade-stored\` in \`KeyboardInterrupt\` handler (exit 130); correct \`--skip-if-complete\` help text to fieldwide semantics.
- **Test fix**: 5 monitor tests were blocking 30s each with \`interval=30\` on an unset \`threading.Event\`. Fixed with \`interval=0\`.

## Test plan

- [x] 281 tests pass locally (`uv run pytest -q` → 0.24s)
- [x] \`lemongrass races list\` shows stored races with schema staleness (no laps / current / stale) sorted newest-first
- [x] \`lemongrass races prune <race_id>\` prompts for confirmation and deletes from \`laps\`, \`races\`, \`race_sessions\` buckets; rejects malformed race_id
- [x] \`lemongrass races backfill\` delegates to \`race-backfill\` (all flags pass through including \`--upgrade-stored\`)
- [x] \`lemongrass race-backfill --upgrade-stored\` re-backfills stale races fieldwide; Ctrl+C exits cleanly with code 130
- [x] \`lemongrass laps <race_id>\` (no car number) runs fieldwide historical backfill

🤖 Generated with [Claude Code](https://claude.com/claude-code)