### PR TITLE
feat(races): prune multiple races in a single invocation

### DIFF
--- a/src/lemongrass/races.py
+++ b/src/lemongrass/races.py
@@ -113,7 +113,7 @@ def _handle_prune():
 
     invalid_ids = [rid for rid in race_ids if not _RACE_ID_RE.fullmatch(rid)]
     if invalid_ids:
-        print("invalid race ID(s):", " ".join(invalid_ids), file=sys.stderr)
+        print("invalid race ID(s):", ", ".join(f'"{r}"' for r in invalid_ids), file=sys.stderr)
         sys.exit(1)
 
     token = _require_influx_token()
@@ -121,6 +121,7 @@ def _handle_prune():
     with InfluxDBClient(url=INFLUX_URL, token=token, org=INFLUX_ORG) as client:
         query_api = client.query_api()
 
+        # safe: all ids validated against [A-Za-z0-9_-]+ above; no Flux metacharacters possible
         ids_set = '["' + '", "'.join(race_ids) + '"]'
         races_tables = query_api.query(
             f'from(bucket: "races")\n'
@@ -155,11 +156,6 @@ def _handle_prune():
 
         for rid in race_ids:
             delete_api.delete(start=EPOCH_START, stop=now,
-                              predicate=f'_measurement="lap" AND race_id="{rid}"',
-                              bucket='laps')
-            print(f"Deleted laps for race {rid}")
-
-            delete_api.delete(start=EPOCH_START, stop=now,
                               predicate=f'_measurement="race" AND race_id="{rid}"',
                               bucket='races')
             print(f"Deleted race metadata for race {rid}")
@@ -168,6 +164,11 @@ def _handle_prune():
                               predicate=f'_measurement="session" AND race_id="{rid}"',
                               bucket='race_sessions')
             print(f"Deleted sessions for race {rid}")
+
+            delete_api.delete(start=EPOCH_START, stop=now,
+                              predicate=f'_measurement="lap" AND race_id="{rid}"',
+                              bucket='laps')
+            print(f"Deleted laps for race {rid}")
 
 
 def _handle_backfill():

--- a/src/lemongrass/races.py
+++ b/src/lemongrass/races.py
@@ -104,16 +104,20 @@ def _handle_list():
 
 def _handle_prune():
     parser = argparse.ArgumentParser(prog='lemongrass-races-prune',
-                                     description='Delete all data for a race from InfluxDB')
-    parser.add_argument('race_id')
+                                     description='Delete all data for one or more races from InfluxDB')
+    parser.add_argument('race_id', nargs='+')
     parser.add_argument('--yes', action='store_true', default=False,
                         help='Skip confirmation prompt')
     args = parser.parse_args()
-    race_id = args.race_id
-    if not _RACE_ID_RE.fullmatch(race_id):
-        logging.error("Invalid race_id: %r", race_id)
+    race_ids = args.race_id
+
+    invalid_ids = [rid for rid in race_ids if not _RACE_ID_RE.fullmatch(rid)]
+    if invalid_ids:
+        print("invalid race ID(s):", " ".join(invalid_ids), file=sys.stderr)
         sys.exit(1)
+
     token = _require_influx_token()
+    race_id = race_ids[0]  # temporary bridge — removed in Task 2
 
     with InfluxDBClient(url=INFLUX_URL, token=token, org=INFLUX_ORG) as client:
         query_api = client.query_api()

--- a/src/lemongrass/races.py
+++ b/src/lemongrass/races.py
@@ -117,24 +117,35 @@ def _handle_prune():
         sys.exit(1)
 
     token = _require_influx_token()
-    race_id = race_ids[0]  # temporary bridge — removed in Task 2
 
     with InfluxDBClient(url=INFLUX_URL, token=token, org=INFLUX_ORG) as client:
         query_api = client.query_api()
+
+        ids_set = '["' + '", "'.join(race_ids) + '"]'
         races_tables = query_api.query(
             f'from(bucket: "races")\n'
             f'  |> range(start: {EPOCH_START})\n'
-            f'  |> filter(fn: (r) => r._measurement == "race"\n'
-            f'      and r.race_id == "{race_id}" and r._field == "end_time_epoc")\n'
+            f'  |> filter(fn: (r) => r._measurement == "race" and r._field == "end_time_epoc"\n'
+            f'      and contains(value: r.race_id, set: {ids_set}))\n'
+            f'  |> group(columns: ["race_id"])\n'
             f'  |> first()'
         )
-        race_name = 'unknown'
+        race_names = {}
         for table in races_tables:
             for record in table.records:
-                race_name = record.values.get('race_name', 'unknown')
+                rid = record.values.get('race_id')
+                race_names[rid] = record.values.get('race_name', 'unknown')
+
+        not_found = [rid for rid in race_ids if rid not in race_names]
+        if not_found:
+            print("race(s) not found in InfluxDB:", " ".join(not_found), file=sys.stderr)
+            sys.exit(1)
 
         if not args.yes:
-            answer = input(f"Delete all data for race {race_id} ({race_name})? [y/N] ")
+            print(f"About to delete data for {len(race_ids)} race(s):")
+            for rid in race_ids:
+                print(f"  {rid}  {race_names[rid]}")
+            answer = input("Proceed? [y/N] ")
             if answer.strip().lower() != 'y':
                 print("Aborted.")
                 sys.exit(0)
@@ -142,20 +153,21 @@ def _handle_prune():
         now = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
         delete_api = client.delete_api()
 
-        delete_api.delete(start=EPOCH_START, stop=now,
-                         predicate=f'_measurement="lap" AND race_id="{race_id}"',
-                         bucket='laps')
-        print(f"Deleted laps for race {race_id}")
+        for rid in race_ids:
+            delete_api.delete(start=EPOCH_START, stop=now,
+                              predicate=f'_measurement="lap" AND race_id="{rid}"',
+                              bucket='laps')
+            print(f"Deleted laps for race {rid}")
 
-        delete_api.delete(start=EPOCH_START, stop=now,
-                         predicate=f'_measurement="race" AND race_id="{race_id}"',
-                         bucket='races')
-        print(f"Deleted race metadata for race {race_id}")
+            delete_api.delete(start=EPOCH_START, stop=now,
+                              predicate=f'_measurement="race" AND race_id="{rid}"',
+                              bucket='races')
+            print(f"Deleted race metadata for race {rid}")
 
-        delete_api.delete(start=EPOCH_START, stop=now,
-                         predicate=f'_measurement="session" AND race_id="{race_id}"',
-                         bucket='race_sessions')
-        print(f"Deleted sessions for race {race_id}")
+            delete_api.delete(start=EPOCH_START, stop=now,
+                              predicate=f'_measurement="session" AND race_id="{rid}"',
+                              bucket='race_sessions')
+            print(f"Deleted sessions for race {rid}")
 
 
 def _handle_backfill():

--- a/src/lemongrass/races.py
+++ b/src/lemongrass/races.py
@@ -109,7 +109,7 @@ def _handle_prune():
     parser.add_argument('--yes', action='store_true', default=False,
                         help='Skip confirmation prompt')
     args = parser.parse_args()
-    race_ids = args.race_id
+    race_ids = list(dict.fromkeys(args.race_id))
 
     invalid_ids = [rid for rid in race_ids if not _RACE_ID_RE.fullmatch(rid)]
     if invalid_ids:
@@ -154,21 +154,29 @@ def _handle_prune():
         now = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
         delete_api = client.delete_api()
 
+        failed = []
         for rid in race_ids:
-            delete_api.delete(start=EPOCH_START, stop=now,
-                              predicate=f'_measurement="race" AND race_id="{rid}"',
-                              bucket='races')
-            print(f"Deleted race metadata for race {rid}")
+            try:
+                delete_api.delete(start=EPOCH_START, stop=now,
+                                  predicate=f'_measurement="race" AND race_id="{rid}"',
+                                  bucket='races')
+                print(f"Deleted race metadata for race {rid}")
 
-            delete_api.delete(start=EPOCH_START, stop=now,
-                              predicate=f'_measurement="session" AND race_id="{rid}"',
-                              bucket='race_sessions')
-            print(f"Deleted sessions for race {rid}")
+                delete_api.delete(start=EPOCH_START, stop=now,
+                                  predicate=f'_measurement="session" AND race_id="{rid}"',
+                                  bucket='race_sessions')
+                print(f"Deleted sessions for race {rid}")
 
-            delete_api.delete(start=EPOCH_START, stop=now,
-                              predicate=f'_measurement="lap" AND race_id="{rid}"',
-                              bucket='laps')
-            print(f"Deleted laps for race {rid}")
+                delete_api.delete(start=EPOCH_START, stop=now,
+                                  predicate=f'_measurement="lap" AND race_id="{rid}"',
+                                  bucket='laps')
+                print(f"Deleted laps for race {rid}")
+            except Exception as e:
+                print(f"error pruning race {rid}: {e}", file=sys.stderr)
+                failed.append(rid)
+        if failed:
+            print("failed to prune:", " ".join(failed), file=sys.stderr)
+            sys.exit(1)
 
 
 def _handle_backfill():

--- a/tests/test_races.py
+++ b/tests/test_races.py
@@ -46,16 +46,21 @@ class TestDispatch:
 
 
 class TestHandlePrune:
-    def _make_influx_client(self, race_name='Test Race'):
+    def _make_influx_client(self, races=None):
+        if races is None:
+            races = {'12345': 'Test Race'}
         client = MagicMock()
         query_api = MagicMock()
 
         def fake_query(flux):
-            table = MagicMock()
-            rec = MagicMock()
-            rec.values = {'race_name': race_name}
-            table.records = [rec]
-            return [table]
+            tables = []
+            for race_id, race_name in races.items():
+                table = MagicMock()
+                rec = MagicMock()
+                rec.values = {'race_id': race_id, 'race_name': race_name}
+                table.records = [rec]
+                tables.append(table)
+            return tables
 
         query_api.query.side_effect = fake_query
         client.query_api.return_value = query_api
@@ -131,6 +136,74 @@ class TestHandlePrune:
         err = capsys.readouterr().err
         assert 'bad id!' in err
         assert 'also bad!' in err
+
+    def test_prune_aborts_when_race_not_found_in_influx(self, capsys):
+        with patch.object(sys, 'argv',
+                          ['lemongrass-races-prune', '99999', '--yes']):
+            with patch('lemongrass.races.InfluxDBClient',
+                       return_value=self._make_influx_client(races={})):
+                with patch.dict('os.environ', {'INFLUX_TELEMETRY_TOKEN': 'tok'}):
+                    with pytest.raises(SystemExit) as exc:
+                        _mod._handle_prune()
+        assert exc.value.code != 0
+        assert '99999' in capsys.readouterr().err
+
+    def test_prune_reports_all_not_found_ids(self, capsys):
+        with patch.object(sys, 'argv',
+                          ['lemongrass-races-prune', '11111', '22222', '--yes']):
+            with patch('lemongrass.races.InfluxDBClient',
+                       return_value=self._make_influx_client(races={})):
+                with patch.dict('os.environ', {'INFLUX_TELEMETRY_TOKEN': 'tok'}):
+                    with pytest.raises(SystemExit) as exc:
+                        _mod._handle_prune()
+        assert exc.value.code != 0
+        err = capsys.readouterr().err
+        assert '11111' in err
+        assert '22222' in err
+
+    def test_prune_multi_shows_summary_before_confirm(self, capsys):
+        with patch.object(sys, 'argv',
+                          ['lemongrass-races-prune', '12345', '67890']):
+            races = {'12345': 'Le Mans 2026', '67890': 'Sebring 2025'}
+            with patch('lemongrass.races.InfluxDBClient',
+                       return_value=self._make_influx_client(races=races)):
+                with patch.dict('os.environ', {'INFLUX_TELEMETRY_TOKEN': 'tok'}):
+                    with patch('builtins.input', return_value='n'):
+                        with pytest.raises(SystemExit):
+                            _mod._handle_prune()
+        out = capsys.readouterr().out
+        assert '12345' in out
+        assert 'Le Mans 2026' in out
+        assert '67890' in out
+        assert 'Sebring 2025' in out
+
+    def test_prune_multi_deletes_all_races_with_yes(self, capsys):
+        with patch.object(sys, 'argv',
+                          ['lemongrass-races-prune', '12345', '67890', '--yes']):
+            races = {'12345': 'Le Mans 2026', '67890': 'Sebring 2025'}
+            fake_client = self._make_influx_client(races=races)
+            with patch('lemongrass.races.InfluxDBClient', return_value=fake_client):
+                with patch.dict('os.environ', {'INFLUX_TELEMETRY_TOKEN': 'tok'}):
+                    _mod._handle_prune()
+        out = capsys.readouterr().out
+        assert out.count('Deleted laps') == 2
+        assert out.count('Deleted race metadata') == 2
+        assert out.count('Deleted sessions') == 2
+
+    def test_prune_multi_deletes_all_three_buckets_per_race(self):
+        with patch.object(sys, 'argv',
+                          ['lemongrass-races-prune', '12345', '67890', '--yes']):
+            races = {'12345': 'Le Mans 2026', '67890': 'Sebring 2025'}
+            fake_client = self._make_influx_client(races=races)
+            with patch('lemongrass.races.InfluxDBClient', return_value=fake_client):
+                with patch.dict('os.environ', {'INFLUX_TELEMETRY_TOKEN': 'tok'}):
+                    _mod._handle_prune()
+        delete_api = fake_client.delete_api.return_value
+        assert delete_api.delete.call_count == 6  # 3 buckets × 2 races
+        buckets = [c.kwargs.get('bucket') for c in delete_api.delete.call_args_list]
+        assert buckets.count('laps') == 2
+        assert buckets.count('races') == 2
+        assert buckets.count('race_sessions') == 2
 
 
 class TestHandleBackfill:

--- a/tests/test_races.py
+++ b/tests/test_races.py
@@ -118,7 +118,7 @@ class TestHandlePrune:
                     _mod._handle_prune()
         assert exc.value.code != 0
 
-    def test_prune_rejects_multiple_invalid_race_ids(self, capsys):
+    def test_prune_rejects_multiple_invalid_race_ids(self):
         with patch.object(sys, 'argv',
                           ['lemongrass-races-prune', 'bad id!', 'also bad!']):
             with patch.dict('os.environ', {'INFLUX_TELEMETRY_TOKEN': 'tok'}):
@@ -132,10 +132,20 @@ class TestHandlePrune:
             with patch.dict('os.environ', {'INFLUX_TELEMETRY_TOKEN': 'tok'}):
                 with pytest.raises(SystemExit):
                     _mod._handle_prune()
-        # both bad IDs should appear in stderr
         err = capsys.readouterr().err
-        assert 'bad id!' in err
-        assert 'also bad!' in err
+        assert '"bad id!"' in err
+        assert '"also bad!"' in err
+
+    def test_prune_rejects_mix_of_valid_and_invalid_ids(self, capsys):
+        with patch.object(sys, 'argv',
+                          ['lemongrass-races-prune', 'valid-id', 'bad id!']):
+            with patch.dict('os.environ', {'INFLUX_TELEMETRY_TOKEN': 'tok'}):
+                with pytest.raises(SystemExit) as exc:
+                    _mod._handle_prune()
+        assert exc.value.code != 0
+        err = capsys.readouterr().err
+        assert '"bad id!"' in err
+        assert 'valid-id' not in err
 
     def test_prune_aborts_when_race_not_found_in_influx(self, capsys):
         with patch.object(sys, 'argv',

--- a/tests/test_races.py
+++ b/tests/test_races.py
@@ -106,6 +106,32 @@ class TestHandlePrune:
                     _mod._handle_prune()
         assert exc.value.code != 0
 
+    def test_prune_rejects_invalid_race_id(self, capsys):
+        with patch.object(sys, 'argv', ['lemongrass-races-prune', 'bad id!']):
+            with patch.dict('os.environ', {'INFLUX_TELEMETRY_TOKEN': 'tok'}):
+                with pytest.raises(SystemExit) as exc:
+                    _mod._handle_prune()
+        assert exc.value.code != 0
+
+    def test_prune_rejects_multiple_invalid_race_ids(self, capsys):
+        with patch.object(sys, 'argv',
+                          ['lemongrass-races-prune', 'bad id!', 'also bad!']):
+            with patch.dict('os.environ', {'INFLUX_TELEMETRY_TOKEN': 'tok'}):
+                with pytest.raises(SystemExit) as exc:
+                    _mod._handle_prune()
+        assert exc.value.code != 0
+
+    def test_prune_reports_all_invalid_ids(self, capsys):
+        with patch.object(sys, 'argv',
+                          ['lemongrass-races-prune', 'bad id!', 'also bad!']):
+            with patch.dict('os.environ', {'INFLUX_TELEMETRY_TOKEN': 'tok'}):
+                with pytest.raises(SystemExit):
+                    _mod._handle_prune()
+        # both bad IDs should appear in stderr
+        err = capsys.readouterr().err
+        assert 'bad id!' in err
+        assert 'also bad!' in err
+
 
 class TestHandleBackfill:
     def test_delegates_to_race_backfill_main(self):


### PR DESCRIPTION
## Summary

- \`lemongrass races prune\` now accepts multiple race IDs: \`lemongrass races prune <id> [<id> ...]\`
- Duplicate IDs are deduped before processing (preserving order)
- All IDs validated against \`[A-Za-z0-9_-]+\` before any network call; all failures reported together
- Single Flux \`contains()\` query fetches all race names; any not-found IDs reported together before aborting
- One confirmation prompt shows a summary table of all races to be deleted (skipped with \`--yes\`)
- Deletion loops sequentially per race; each race's deletes wrapped in try/except — failures collected and reported at the end with nonzero exit, so remaining races still attempt
- Metadata and sessions deleted before laps so a partial failure leaves invisible orphans rather than ghost races in \`races list\`

## Test plan

- [x] \`uv run pytest tests/test_races.py -v\` — 30 tests pass
- [x] Single race ID still works (backward compat)
- [x] Multiple valid IDs: confirm prompt shows summary, \`--yes\` skips it
- [x] Invalid ID rejected before InfluxDB connection, quoted in error message
- [x] Mixed valid + invalid IDs: only invalid ones named in error
- [x] Race ID not found in InfluxDB: aborts and names the missing ID(s)
- [x] Duplicate IDs passed on command line: deduped before confirmation and deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)