### PR TITLE
docs: update README and docstrings for 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ docker pull ghcr.io/wot-lemons/lemongrass:latest
 
 **Docker** — pass your credentials via an env file (see `.env.sample`). To pin to a specific version instead of `latest`, replace the tag (e.g. `1.2.3`). Available tags are listed at `ghcr.io/wot-lemons/lemongrass`.
 
+> **Note:** `CAR_NUMBER` is required for live/monitor mode. Omit it for completed races to write laps for all competitors (fieldwide backfill).
+
 ```shell
 docker run --rm -it --env-file .env ghcr.io/wot-lemons/lemongrass:latest lemongrass laps RACE_ID CAR_NUMBER -m -n
 ```
@@ -151,27 +153,29 @@ Lap Position      LapTime FlagStatus    TotalTime
 
 ### Completed Race
 
-You can retrieve info for a completed race too.
+You can retrieve info for a completed race too. Omit `CAR_NUMBER` to write laps for all competitors in the field (fieldwide backfill mode).
 
 **Docker:**
 
 ```shell
+# Single car
 docker run --rm -it \
   --env-file .env \
   ghcr.io/wot-lemons/lemongrass:latest \
   lemongrass laps RACE_ID CAR_NUMBER
+
+# Full field
+docker run --rm -it \
+  --env-file .env \
+  ghcr.io/wot-lemons/lemongrass:latest \
+  lemongrass laps RACE_ID
 ```
 
-**pip:**
+**pip / uv:**
 
 ```shell
-lemongrass laps RACE_ID CAR_NUMBER
-```
-
-**uv:**
-
-```shell
-lemongrass laps RACE_ID CAR_NUMBER
+lemongrass laps RACE_ID CAR_NUMBER   # single car
+lemongrass laps RACE_ID              # full field
 ```
 
 Real example:
@@ -260,6 +264,37 @@ Lap      LapTime Position FlagStatus    TotalTime
 --------------------------------------------------------------------------------
 ```
 
+## Race Management
+
+The `races` subcommand provides tools for inspecting and managing race data stored in InfluxDB.
+
+```shell
+lemongrass races <subcommand> [args]
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| `list` | Show all stored races with lap counts and schema status |
+| `prune RACE_ID...` | Delete all data for one or more races from InfluxDB |
+| `backfill` | Run historical backfill (alias for `lemongrass race-backfill`) |
+| `diagnose RACE_ID CAR_NUMBER` | Compare RaceMonitor vs InfluxDB lap counts for a specific car |
+
+### Examples
+
+```shell
+# List all stored races and their schema version status
+lemongrass races list
+
+# Delete a race (prompts for confirmation)
+lemongrass races prune 144185
+
+# Delete multiple races at once, skipping confirmation
+lemongrass races prune 144185 120037 --yes
+
+# Diagnose a lap count mismatch for car 252 in race 144185
+lemongrass races diagnose 144185 252
+```
+
 ## Upgrading from v1.x
 
 As of v2.0.0, the individual entry points (`laps`, `telem`, `race-backfill`, `pisugar-monitor`, `race-diagnose`) were replaced by a single `lemongrass` command. If you have the old package installed, update and prefix commands with `lemongrass`:
@@ -268,6 +303,8 @@ As of v2.0.0, the individual entry points (`laps`, `telem`, `race-backfill`, `pi
 |--------|-------|
 | `laps RACE_ID CAR_NUMBER` | `lemongrass laps RACE_ID CAR_NUMBER` |
 | `telem` | `lemongrass telem` |
-| `race-backfill` | `lemongrass race-backfill` |
+| `race-backfill` | `lemongrass race-backfill` or `lemongrass races backfill` |
 | `pisugar-monitor` | `lemongrass pisugar-monitor` |
-| `race-diagnose` | `lemongrass race-diagnose` |
+| `race-diagnose` | `lemongrass race-diagnose` or `lemongrass races diagnose` |
+| *(new in 2.1.0)* | `lemongrass races list` — schema status overview |
+| *(new in 2.1.0)* | `lemongrass races prune RACE_ID` — delete race data |

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Or run ephemerally without installing:
 uvx lemongrass laps RACE_ID CAR_NUMBER -m -n
 ```
 
+> **Graceful exit:** Press Ctrl-C at any time to stop monitoring cleanly (exits 130). The monitor also exits automatically when the race ends.
+
 Real example:
 
 ```shell
@@ -276,7 +278,7 @@ lemongrass races <subcommand> [args]
 |------------|-------------|
 | `list` | Show all stored races with lap counts and schema status |
 | `prune RACE_ID...` | Delete all data for one or more races from InfluxDB |
-| `backfill` | Run historical backfill (alias for `lemongrass race-backfill`) |
+| `backfill` | Run historical backfill for all tracked races (delegates to `lemongrass race-backfill`; use `--help` for all options) |
 | `diagnose RACE_ID CAR_NUMBER` | Compare RaceMonitor vs InfluxDB lap counts for a specific car |
 
 ### Examples
@@ -295,6 +297,26 @@ lemongrass races prune 144185 120037 --yes
 lemongrass races diagnose 144185 252
 ```
 
+### Backfill Options
+
+The `backfill` subcommand delegates to `lemongrass race-backfill` and supports these flags:
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Print what would be backfilled without writing anything |
+| `--force` | Re-backfill every race, even those already complete and current |
+| `--upgrade-stored` | Re-process laps already in InfluxDB whose `schema_version` is older than current — faster than `--force` because it skips re-fetching from RaceMonitor |
+| `--override RACE_ID:CAR_NUMBER` | Override the default car number for a specific race (repeatable) |
+| `--validate` | Check that every expected race and car has data in InfluxDB |
+| `--start-year YEAR` | Only include races starting in this year or later (default: 2017) |
+| `--car NUMBER` | Default car number for all races (default: 252) |
+
+> **Note:** `--upgrade-stored` is mutually exclusive with `--force`, `--override`, `--start-year`, `--car`, and `--validate`.
+
+### Session Tracking
+
+All lap points written to InfluxDB include a `session_id` tag corresponding to the RaceMonitor session ID. In Flux queries you can filter by `session_id` to isolate specific race segments (e.g. Day 1 vs. Day 2). Session metadata is stored in the `race_sessions` bucket.
+
 ## Upgrading from v1.x
 
 As of v2.0.0, the individual entry points (`laps`, `telem`, `race-backfill`, `pisugar-monitor`, `race-diagnose`) were replaced by a single `lemongrass` command. If you have the old package installed, update and prefix commands with `lemongrass`:
@@ -306,5 +328,3 @@ As of v2.0.0, the individual entry points (`laps`, `telem`, `race-backfill`, `pi
 | `race-backfill` | `lemongrass race-backfill` or `lemongrass races backfill` |
 | `pisugar-monitor` | `lemongrass pisugar-monitor` |
 | `race-diagnose` | `lemongrass race-diagnose` or `lemongrass races diagnose` |
-| *(new in 2.1.0)* | `lemongrass races list` — schema status overview |
-| *(new in 2.1.0)* | `lemongrass races prune RACE_ID` — delete race data |

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -250,7 +250,9 @@ def _run_race(ctx, opts, response):
 
 
 def live_race(ctx, opts):
-    """Called if a race ID is live."""
+    """Handle a live race: fetch the current session, print rankings and racer detail,
+    optionally write lap points to InfluxDB, and optionally launch monitor_routine
+    to poll for new laps until the race ends or the user interrupts."""
     session_response = ctx.client.live.get_session(ctx.race_id)
 
     live_session_id = None
@@ -328,7 +330,10 @@ def live_race(ctx, opts):
 
 
 def old_race(ctx, opts):
-    """Called if a race ID is not live."""
+    """Handle a completed race: fetch all sessions and accumulate lap points for every
+    competitor across the full field (fieldwide backfill). After gathering the complete
+    expected lap count, decides whether to skip (already complete and current schema),
+    or delete existing laps and rewrite them all in one pass."""
     logging.debug("Getting sessions for race for %s", ctx.race_id)
     race_details = ctx.client.results.sessions_for_race(ctx.race_id)
 
@@ -647,6 +652,8 @@ def _time_to_ms(value):
 
 
 def _write_points_chunked(write_api, points, batch_size=_WRITE_BATCH_SIZE):
+    """Write points to the laps bucket in chunks of batch_size, logging progress
+    when more than one batch is needed."""
     chunks = range(0, len(points), batch_size)
     total = len(chunks)
     for batch_num, i in enumerate(chunks, 1):
@@ -774,9 +781,10 @@ def push_influx_session(ctx, session_id, session_name, start_epoc):
 def existing_lap_counts(ctx):
     """Return (total_laps, current_laps) for the tracked car's laps in this race.
 
-    Returns the count of existing laps for the tracked car. Used as a completeness
-    proxy — if the tracked car's laps are present and current, the race is considered
-    complete (the full field is not verified).
+    Counts laps filtered by ctx.car_number. Note: the historical backfill path
+    uses existing_lap_counts_fieldwide instead (which counts across all cars
+    without a car_number filter). This function is for single-car callers such
+    as tests or diagnostic tooling.
 
     total_laps  — number of lap points written for the tracked car.
     current_laps — number of those laps stamped with the current SCHEMA_VERSION.

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -331,9 +331,10 @@ def live_race(ctx, opts):
 
 def old_race(ctx, opts):
     """Handle a completed race: fetch all sessions and accumulate lap points for every
-    competitor across the full field (fieldwide backfill). After gathering the complete
-    expected lap count, decides whether to skip (already complete and current schema),
-    or delete existing laps and rewrite them all in one pass."""
+    competitor across the full field (fieldwide backfill). Each lap point is tagged with
+    session_id. After gathering the complete expected lap count, decides whether to skip
+    (already complete and current schema), or delete existing laps and rewrite them all
+    in one pass. Also the write path for lemongrass race-backfill --upgrade-stored."""
     logging.debug("Getting sessions for race for %s", ctx.race_id)
     race_details = ctx.client.results.sessions_for_race(ctx.race_id)
 
@@ -539,7 +540,14 @@ def write_csv(filename, competitor_lap_times):
 
 def monitor_routine(ctx, laps, opts, competitor_name=None, car_info=None, _stop_event=None,
                     session_id=None) -> MonitorStatus | None:
-    """Monitor mode: poll for new laps and display/push as they arrive."""
+    """Poll for new laps during a live race, printing and optionally pushing each to InfluxDB.
+
+    Returns MonitorStatus.RACE_ENDED when the race ends naturally, or
+    MonitorStatus.INTERRUPTED on KeyboardInterrupt (caller should exit 130).
+    _stop_event may be injected for testing; defaults to a new threading.Event.
+    session_id is tracked across polls and tags each written lap point; a new
+    session push fires whenever the live session ID changes.
+    """
     logging.info("Monitoring car %s...", ctx.car_number)
     print(UNDERLINE)
 
@@ -652,8 +660,8 @@ def _time_to_ms(value):
 
 
 def _write_points_chunked(write_api, points, batch_size=_WRITE_BATCH_SIZE):
-    """Write points to the laps bucket in chunks of batch_size, logging progress
-    when more than one batch is needed."""
+    """Write points to the laps bucket in chunks of batch_size, logging each
+    batch individually when more than one batch is needed."""
     chunks = range(0, len(points), batch_size)
     total = len(chunks)
     for batch_num, i in enumerate(chunks, 1):
@@ -702,7 +710,12 @@ def _build_lap_points(ctx, laps, competitor_name, car_info, class_name, class_po
 def push_influx(ctx, laps, monitor_mode, competitor_name=None, car_info=None,
                 class_name=None, class_positions=None, start_epoc=None,
                 car_number=None, session_id=None):
-    """Push lap data to InfluxDB."""
+    """Build and write lap points to InfluxDB for one competitor.
+
+    monitor_mode suppresses the "Writing laps..." log line (used for per-lap live writes).
+    car_number defaults to ctx.car_number when None. session_id is passed through as a
+    tag on each point.
+    """
     logging.debug("Entering network mode.")
     effective_car_number = car_number if car_number is not None else ctx.car_number
 

--- a/src/lemongrass/race_backfill.py
+++ b/src/lemongrass/race_backfill.py
@@ -6,26 +6,33 @@ Searches the RaceMonitor API for past Real Hoopties, GP du Lac, and Halloween
 Hoop races and writes lap data for a given car number to the laps/races InfluxDB
 buckets by invoking `laps -n` for each race found.
 
+Assumes `lemongrass` is installed as a CLI tool. If running from the repo, prefix
+commands with `uv run` (e.g. `uv run lemongrass race-backfill`).
+
 Usage:
     # Preview what would be backfilled (no writes)
-    uv run race-backfill --dry-run
+    lemongrass race-backfill --dry-run
 
     # Run the backfill (default car 252, from 2017 onwards). Races whose laps are
     # already complete and written under the current schema version are skipped.
-    uv run race-backfill
+    lemongrass race-backfill
 
     # Force a re-backfill of every race, even ones already complete and current
     # (e.g. after bumping SCHEMA_VERSION in laps to migrate historical data)
-    uv run race-backfill --force
+    lemongrass race-backfill --force
 
     # Override car number for a specific race (e.g. 2022 Hoopties used car 253)
-    uv run race-backfill --override 120037:253
+    lemongrass race-backfill --override 120037:253
 
     # Validate that backfilled races have data in InfluxDB
-    uv run race-backfill --validate --override 120037:253
+    lemongrass race-backfill --validate --override 120037:253
 
     # Backfill from a different year or for a different default car
-    uv run race-backfill --start-year 2023 --car 82
+    lemongrass race-backfill --start-year 2023 --car 82
+
+    # Re-write laps stored under an older schema version without re-fetching from
+    # RaceMonitor (faster than --force when only the schema tag changed)
+    lemongrass race-backfill --upgrade-stored
 
 Required environment variables:
     RACEMONITOR_TOKEN      — RaceMonitor API token (always required)
@@ -59,6 +66,7 @@ class _OverrideAction(argparse.Action):
 
 
 def _build_parser():
+    """Build and return the argument parser for lemongrass race-backfill."""
     parser = argparse.ArgumentParser(
         description='Discover and backfill historical Lemons lap data.')
     parser.add_argument('--dry-run', dest='dry_run', action='store_true', default=False,

--- a/src/lemongrass/race_diagnose.py
+++ b/src/lemongrass/race_diagnose.py
@@ -6,11 +6,14 @@ Queries both the RaceMonitor API and InfluxDB and prints side-by-side lap
 counts, session breakdown, and all stored lap numbers so you can pinpoint
 whether a count mismatch is an API issue or a write issue.
 
+Assumes `lemongrass` is installed as a CLI tool. If running from the repo, prefix
+with `uv run` (e.g. `uv run lemongrass race-diagnose 144185 252`).
+
 Usage:
-    uv run race-diagnose <race_id> <car_number>
+    lemongrass race-diagnose <race_id> <car_number>
 
 Example:
-    uv run race-diagnose 144185 252
+    lemongrass race-diagnose 144185 252
 
 Required environment variables:
     RACEMONITOR_TOKEN      — RaceMonitor API token

--- a/src/lemongrass/races.py
+++ b/src/lemongrass/races.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""lemongrass races subcommand dispatcher."""
+"""lemongrass races subcommand: inspect and manage race data stored in InfluxDB.
+
+Subcommands: list, prune, backfill, diagnose.
+Run `lemongrass races <subcommand> --help` for per-subcommand options.
+"""
 
 import argparse
 import logging
@@ -108,6 +112,8 @@ def _handle_list():
 
 
 def _handle_prune():
+    """Parse args and delete all data for the specified race(s) from InfluxDB,
+    prompting for confirmation unless --yes is passed."""
     parser = argparse.ArgumentParser(prog='lemongrass-races-prune',
                                      description='Delete all data for one or more races from InfluxDB')
     parser.add_argument('race_id', nargs='+')
@@ -185,10 +191,12 @@ def _handle_prune():
 
 
 def _handle_backfill():
+    """Delegate to lemongrass race-backfill (race_backfill.main)."""
     from lemongrass import race_backfill
     race_backfill.main()
 
 
 def _handle_diagnose():
+    """Delegate to lemongrass race-diagnose (race_diagnose.main)."""
     from lemongrass import race_diagnose
     race_diagnose.main()

--- a/src/lemongrass/races.py
+++ b/src/lemongrass/races.py
@@ -20,6 +20,8 @@ _RACE_ID_RE = re.compile(r'^[A-Za-z0-9_-]+$')
 
 
 def main():
+    """Entry point for `lemongrass races`. Dispatches to the appropriate subcommand
+    handler (list, prune, backfill, diagnose) based on the first argument."""
     if len(sys.argv) < 2 or sys.argv[1] not in _SUBCOMMANDS:
         print("Usage: lemongrass races <subcommand> [args]")
         print(f"Subcommands: {', '.join(_SUBCOMMANDS)}")
@@ -31,6 +33,7 @@ def main():
 
 
 def _require_influx_token():
+    """Read INFLUX_TELEMETRY_TOKEN from the environment, exiting with an error if unset."""
     token = os.environ.get('INFLUX_TELEMETRY_TOKEN')
     if not token:
         logging.error("INFLUX_TELEMETRY_TOKEN environment variable not set")
@@ -39,6 +42,8 @@ def _require_influx_token():
 
 
 def _handle_list():
+    """Print a table of all races in the races bucket with their total lap count and
+    schema version status (current, stale, or no laps)."""
     from lemongrass.laps import SCHEMA_VERSION
 
     token = _require_influx_token()


### PR DESCRIPTION
## Summary

- Add `CAR_NUMBER` optionality note to README: required for monitor mode, omit for fieldwide backfill
- Add graceful exit note (Ctrl-C exits 130, auto-exits when race ends) to monitor usage section
- Add Race Management section to README covering `list`, `prune`, `backfill`, and `diagnose` subcommands with examples
- Add Backfill Options table to README documenting all `race-backfill` flags (`--dry-run`, `--force`, `--upgrade-stored`, `--override`, `--validate`, `--start-year`, `--car`) and the `--upgrade-stored` mutual exclusion constraint
- Add Session Tracking section to README explaining `session_id` tag on lap points and the `race_sessions` bucket
- Update `race-backfill` and `race-diagnose` module docstrings from dev-style (`uv run`) invocations to installed-CLI style (`lemongrass`); add `--upgrade-stored` example to `race_backfill` docstring
- Expand `live_race`, `old_race`, `monitor_routine`, `push_influx`, and `existing_lap_counts` docstrings to reflect 2.1.0 fieldwide backfill and session tracking behavior
- Add missing docstrings to `_write_points_chunked`, `races.main`, `_require_influx_token`, `_handle_list`, `_build_parser`, `_handle_prune`, `_handle_backfill`, `_handle_diagnose`
- Expand `races.py` module docstring to list subcommands and link to `--help`

## Test plan

- [x] All 290 existing tests pass (no code changes)
- [x] README renders correctly on GitHub
- [x] `lemongrass races` help text matches README examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)