### PR TITLE
ci: use release-please app token for uv.lock sync commit

### DIFF
--- a/.github/workflows/uv-lock-check.yml
+++ b/.github/workflows/uv-lock-check.yml
@@ -14,11 +14,18 @@ jobs:
     if: startsWith(github.head_ref, 'release-please--')
     runs-on: ubuntu-24.04
     permissions:
-      contents: write
+      contents: read
     steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ secrets.RELEASE_PLEASE_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
+
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.head_ref }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
@@ -27,8 +34,8 @@ jobs:
       - name: Sync lock file (release-please PRs)
         run: |
           uv lock
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "wot-lemons-release-please[bot]"
+          git config user.email "279497434+wot-lemons-release-please[bot]@users.noreply.github.com"
           git add uv.lock
           git diff --staged --quiet && exit 0
           git commit -m "chore: sync uv.lock"


### PR DESCRIPTION
## Summary

- Replaces `github-actions[bot]` with the `wot-lemons-release-please` GitHub App token for the `uv lock` commit in `uv-lock-check.yml`
- Pushes attributed to the app are treated as trusted app events by GitHub, so CI on the release-please PR branch runs without requiring manual workflow approval
- Drops `contents: write` on `GITHUB_TOKEN` (no longer needed; push authenticates via app token)
- Sets git identity to `wot-lemons-release-please[bot]` (ID `279497434`) to match the actual app

## Test plan

- [ ] Merge this, let release-please open its next PR, and confirm the `sync-lock` job runs and pushes without a manual approval gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)