### PR TITLE
chore(lint): expand ruff rules and fix violations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ exclude = [".git", "__pycache__", "build", "dist", ".venv"]
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "D1", "I", "B", "UP", "RUF", "N", "C4", "SIM"]
-ignore = ["D107"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["D1", "SIM117"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,5 +43,11 @@ lemongrass = "lemongrass.cli:main"
 line-length = 100
 exclude = [".git", "__pycache__", "build", "dist", ".venv"]
 
+[tool.ruff.lint]
+select = ["E", "F", "W", "D1", "I", "B", "UP", "RUF", "N"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["D1"]
+
 [dependency-groups]
 dev = ["pytest>=8"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,10 +44,11 @@ line-length = 100
 exclude = [".git", "__pycache__", "build", "dist", ".venv"]
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "D1", "I", "B", "UP", "RUF", "N"]
+select = ["E", "F", "W", "D1", "I", "B", "UP", "RUF", "N", "C4", "SIM"]
+ignore = ["D107"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = ["D1"]
+"tests/**" = ["D1", "SIM117"]
 
 [dependency-groups]
 dev = ["pytest>=8"]

--- a/src/lemongrass/cli.py
+++ b/src/lemongrass/cli.py
@@ -1,3 +1,4 @@
+"""Entry point for the lemongrass CLI dispatcher."""
 import importlib
 import sys
 
@@ -12,6 +13,7 @@ _COMMANDS = {
 
 
 def main():
+    """Dispatch to the subcommand named by the first CLI argument."""
     if len(sys.argv) >= 2 and sys.argv[1] in ("-h", "--help"):
         print("Usage: lemongrass <command> [args]")
         print(f"Commands: {', '.join(_COMMANDS)}")

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -12,6 +12,7 @@
 #   writes are the during-race approximation; the backfill makes the final record authoritative.
 
 import argparse
+import contextlib
 import csv
 import enum
 import logging
@@ -481,9 +482,7 @@ def print_rankings(sorted_competitors, _race_live, selected_class, categories):
 
     for competitor in sorted_competitors:
         for item in competitor:
-            if item == "FirstName" and item != '':
-                list_of_names.append(competitor[item])
-            elif item == "LastName" and item != '':
+            if (item == "FirstName" and item != '') or (item == "LastName" and item != ''):
                 list_of_names.append(competitor[item])
 
     for competitor in sorted_competitors:
@@ -880,10 +879,8 @@ def _resolve_class_historical(car_number, session_details):
         if competitor['Number'] == car_number:
             tracked_category = competitor['Category']
             for lap in competitor['LapTimes']:
-                try:
+                with contextlib.suppress(ValueError, TypeError):
                     tracked_laps[int(lap['Lap'])] = int(lap['Position'])
-                except (ValueError, TypeError):
-                    pass
             break
 
     if tracked_category is None:
@@ -899,10 +896,8 @@ def _resolve_class_historical(car_number, session_details):
         if competitor['Number'] == car_number or competitor['Category'] != tracked_category:
             continue
         for lap in competitor['LapTimes']:
-            try:
+            with contextlib.suppress(ValueError, TypeError):
                 class_lap_positions[int(lap['Lap'])].append(int(lap['Position']))
-            except (ValueError, TypeError):
-                pass
 
     class_positions = {
         lap_num: 1 + sum(1 for pos in class_lap_positions.get(lap_num, []) if pos < tracked_pos)

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """Interact with the RaceMonitor lap timing system."""
 #
 # Timestamp anchoring (design decision):
@@ -17,10 +16,10 @@ import csv
 import enum
 import logging
 import os
-from collections import defaultdict
 import sys
 import threading
 import time
+from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
@@ -54,6 +53,8 @@ _LIVE_CHECK_INTERVAL = 5
 
 
 class MonitorStatus(enum.Enum):
+    """Return values from monitor_routine indicating how polling ended."""
+
     RACE_ENDED = "race_ended"
     INTERRUPTED = "interrupted"
 
@@ -210,11 +211,13 @@ def main():
 
             if not opts.network_mode:
                 return _run_race(
-                    RaceContext(race_id, car_number, client, None, start_epoc, metadata=metadata), opts, response)
+                    RaceContext(race_id, car_number, client, None, start_epoc, metadata=metadata),
+                    opts, response)
 
             if opts.dry_run:
                 return _run_race(
-                    RaceContext(race_id, car_number, client, None, start_epoc, metadata=metadata), opts, response)
+                    RaceContext(race_id, car_number, client, None, start_epoc, metadata=metadata),
+                    opts, response)
 
             with InfluxDBClient(
                 url='https://influxdb.focism.com', token=influx_token, org='focism'
@@ -278,7 +281,9 @@ def live_race(ctx, opts):
     competitor_details['Name'] = (
         competitor_details['FirstName'] + ' ' + competitor_details['LastName'])
 
-    competitor_name = f"{competitor_details.get('FirstName', '')} {competitor_details.get('LastName', '')}".strip() or None
+    first = competitor_details.get('FirstName', '')
+    last = competitor_details.get('LastName', '')
+    competitor_name = f"{first} {last}".strip() or None
     car_info = competitor_details.get('AdditionalData') or None
     class_name, class_position = _resolve_class_live(session_response, ctx.car_number)
 
@@ -385,7 +390,8 @@ def old_race(ctx, opts):
                     {**lap, 'FlagStatus': flag_map.get(lap['FlagStatus'], str(lap['FlagStatus']))}
                     for lap in comp_laps
                 ]
-                class_name, class_positions = _resolve_class_historical(comp_number, session_details)
+                class_name, class_positions = _resolve_class_historical(
+                    comp_number, session_details)
                 session_entry['competitors'].append({
                     'influx_laps': influx_laps,
                     'competitor_name': comp_name,
@@ -396,7 +402,8 @@ def old_race(ctx, opts):
                 })
             pending_writes.append(session_entry)
 
-    if opts.network_mode and (not pending_writes or not any(s['competitors'] for s in pending_writes)):
+    no_data = not pending_writes or not any(s['competitors'] for s in pending_writes)
+    if opts.network_mode and no_data:
         logging.warning(
             "No competitors with laps found for race %s — skipping write", ctx.race_id)
         return
@@ -418,7 +425,8 @@ def old_race(ctx, opts):
             total_competitors = sum(len(s['competitors']) for s in pending_writes)
             for session in pending_writes:
                 for comp in session['competitors']:
-                    print(f"  would write {len(comp['influx_laps'])} laps for car {comp['car_number']}")
+                    nlaps = len(comp['influx_laps'])
+                    print(f"  would write {nlaps} laps for car {comp['car_number']}")
             print(f"  {total_competitors} competitor(s), {total_laps} laps total")
             print(UNDERLINE)
             return
@@ -426,7 +434,9 @@ def old_race(ctx, opts):
         if opts.skip_if_complete and expected > 0:
             total, current = existing_lap_counts_fieldwide(ctx)
             if total == expected and current == expected:
-                race_ts_ms = ctx.start_epoc * 1000 if ctx.start_epoc != 0 else int(time.time() * 1000)
+                race_ts_ms = (
+                    ctx.start_epoc * 1000 if ctx.start_epoc != 0 else int(time.time() * 1000)
+                )
                 push_influx_race(ctx, race_ts_ms)
                 logging.info(
                     "SKIP: race %s already complete and current (%d laps, schema v%d)",

--- a/src/lemongrass/pisugar_monitor.py
+++ b/src/lemongrass/pisugar_monitor.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """Sends PiSugar measurements to InfluxDB."""
 
 import base64
@@ -9,9 +8,9 @@ import os
 import urllib.error
 import urllib.parse
 import urllib.request
-
 from datetime import datetime, timezone
 from time import sleep, time
+
 from influxdb_client import InfluxDBClient, Point
 from influxdb_client.client.write_api import SYNCHRONOUS
 

--- a/src/lemongrass/race_backfill.py
+++ b/src/lemongrass/race_backfill.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """Discover and backfill historical 24 Hours of Lemons lap data.
 
 Searches the RaceMonitor API for past Real Hoopties, GP du Lac, and Halloween
@@ -145,8 +144,10 @@ def validate_backfill(pairs, query_api):
         if not end_epoc:
             logging.warning("race %s: end_time_epoc=0 in races bucket, using now() as range stop",
                             race_id)
-        range_stop = (datetime.fromtimestamp(end_epoc, tz=timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
-                      if end_epoc else datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'))
+        range_stop = (
+            datetime.fromtimestamp(end_epoc, tz=timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+            if end_epoc else datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+        )
 
         lap_tables = query_api.query(
             f'from(bucket: "laps")\n'

--- a/src/lemongrass/race_diagnose.py
+++ b/src/lemongrass/race_diagnose.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """Diagnose lap data discrepancies for a specific race and car number.
 
 Queries both the RaceMonitor API and InfluxDB and prints side-by-side lap
@@ -85,8 +84,10 @@ def diagnose_influx(query_api, race_id, car_number, start_epoc=0, end_epoc=0):
     """Print stored lap count, time range, and all lap numbers from InfluxDB."""
     print(f'\n=== InfluxDB: race {race_id}, car {car_number} ===')
 
-    range_start = (datetime.fromtimestamp(start_epoc, tz=timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
-                   if start_epoc else EPOCH_START)
+    range_start = (
+        datetime.fromtimestamp(start_epoc, tz=timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+        if start_epoc else EPOCH_START
+    )
     if not end_epoc:
         print(f"  Warning: end_time_epoc not set for race {race_id}, using now() as range stop")
     range_stop = (datetime.fromtimestamp(end_epoc, tz=timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')

--- a/src/lemongrass/races.py
+++ b/src/lemongrass/races.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """lemongrass races subcommand: inspect and manage race data stored in InfluxDB.
 
 Subcommands: list, prune, backfill, diagnose.
@@ -114,8 +113,9 @@ def _handle_list():
 def _handle_prune():
     """Parse args and delete all data for the specified race(s) from InfluxDB,
     prompting for confirmation unless --yes is passed."""
-    parser = argparse.ArgumentParser(prog='lemongrass-races-prune',
-                                     description='Delete all data for one or more races from InfluxDB')
+    parser = argparse.ArgumentParser(
+        prog='lemongrass-races-prune',
+        description='Delete all data for one or more races from InfluxDB')
     parser.add_argument('race_id', nargs='+')
     parser.add_argument('--yes', action='store_true', default=False,
                         help='Skip confirmation prompt')

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """Sends OBD-II measurements to InfluxDB."""
 
-from datetime import datetime, timezone
 import logging
 import os
 import threading
+from datetime import datetime, timezone
 from time import sleep
 
 import obd

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,8 +8,9 @@ import lemongrass.cli as cli
 
 class TestDispatcher:
     def test_no_args_exits_nonzero(self):
-        with patch.object(sys, 'argv', ['lemongrass']), pytest.raises(SystemExit) as exc:
-            cli.main()
+        with patch.object(sys, 'argv', ['lemongrass']):
+            with pytest.raises(SystemExit) as exc:
+                cli.main()
         assert exc.value.code != 0
 
     def test_unknown_command_exits_nonzero(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,9 +8,8 @@ import lemongrass.cli as cli
 
 class TestDispatcher:
     def test_no_args_exits_nonzero(self):
-        with patch.object(sys, 'argv', ['lemongrass']):
-            with pytest.raises(SystemExit) as exc:
-                cli.main()
+        with patch.object(sys, 'argv', ['lemongrass']), pytest.raises(SystemExit) as exc:
+            cli.main()
         assert exc.value.code != 0
 
     def test_unknown_command_exits_nonzero(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 import sys
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 import lemongrass.cli as cli

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -907,10 +907,9 @@ class TestLiveRace:
     def test_network_mode_calls_get_session_once(self):
         ctx = self._ctx()
         opts = _mod.RaceOptions(network_mode=True)
-        with patch.object(_mod, 'print_rankings'):
-            with patch.object(_mod, 'push_influx'):
-                with patch.object(_mod, 'push_influx_race'):
-                    _mod.live_race(ctx, opts)
+        with patch.object(_mod, 'print_rankings'), patch.object(_mod, 'push_influx'):
+            with patch.object(_mod, 'push_influx_race'):
+                _mod.live_race(ctx, opts)
         assert ctx.client.live.get_session.call_count == 1
 
 
@@ -946,11 +945,10 @@ class TestOldRaceClassWiring:
         ctx.client.results.session_details.return_value = self._session_details()
         with patch.object(
             _mod, '_resolve_class_historical', return_value=('A', {1: 1})
-        ) as mock_resolve:
-            with patch.object(_mod, 'push_influx'):
-                with patch.object(_mod, 'push_influx_race'):
-                    with patch.object(_mod, 'print_rankings'):
-                        _mod.old_race(ctx, opts)
+        ) as mock_resolve, patch.object(_mod, 'push_influx'):
+            with patch.object(_mod, 'push_influx_race'):
+                with patch.object(_mod, 'print_rankings'):
+                    _mod.old_race(ctx, opts)
         mock_resolve.assert_any_call('42', self._session_details())
 
     def test_passes_class_name_to_build_lap_points(self):
@@ -1927,11 +1925,10 @@ class TestOldRaceFullField:
         opts = _mod.RaceOptions(network_mode=True)
         with patch.object(
             _mod, '_resolve_class_historical', return_value=('A', {1: 1})
-        ) as mock_resolve:
-            with patch.object(_mod, 'push_influx_race'):
-                with patch.object(_mod, 'delete_existing_laps'):
-                    with patch.object(_mod, 'print_rankings'):
-                        _mod.old_race(ctx, opts)
+        ) as mock_resolve, patch.object(_mod, 'push_influx_race'):
+            with patch.object(_mod, 'delete_existing_laps'):
+                with patch.object(_mod, 'print_rankings'):
+                    _mod.old_race(ctx, opts)
         assert mock_resolve.call_count == 2
         assert {c.args[0] for c in mock_resolve.call_args_list} == {'42', '99'}
 

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -907,9 +907,10 @@ class TestLiveRace:
     def test_network_mode_calls_get_session_once(self):
         ctx = self._ctx()
         opts = _mod.RaceOptions(network_mode=True)
-        with patch.object(_mod, 'print_rankings'), patch.object(_mod, 'push_influx'):
-            with patch.object(_mod, 'push_influx_race'):
-                _mod.live_race(ctx, opts)
+        with patch.object(_mod, 'print_rankings'):
+            with patch.object(_mod, 'push_influx'):
+                with patch.object(_mod, 'push_influx_race'):
+                    _mod.live_race(ctx, opts)
         assert ctx.client.live.get_session.call_count == 1
 
 
@@ -945,10 +946,11 @@ class TestOldRaceClassWiring:
         ctx.client.results.session_details.return_value = self._session_details()
         with patch.object(
             _mod, '_resolve_class_historical', return_value=('A', {1: 1})
-        ) as mock_resolve, patch.object(_mod, 'push_influx'):
-            with patch.object(_mod, 'push_influx_race'):
-                with patch.object(_mod, 'print_rankings'):
-                    _mod.old_race(ctx, opts)
+        ) as mock_resolve:
+            with patch.object(_mod, 'push_influx'):
+                with patch.object(_mod, 'push_influx_race'):
+                    with patch.object(_mod, 'print_rankings'):
+                        _mod.old_race(ctx, opts)
         mock_resolve.assert_any_call('42', self._session_details())
 
     def test_passes_class_name_to_build_lap_points(self):
@@ -1925,10 +1927,11 @@ class TestOldRaceFullField:
         opts = _mod.RaceOptions(network_mode=True)
         with patch.object(
             _mod, '_resolve_class_historical', return_value=('A', {1: 1})
-        ) as mock_resolve, patch.object(_mod, 'push_influx_race'):
-            with patch.object(_mod, 'delete_existing_laps'):
-                with patch.object(_mod, 'print_rankings'):
-                    _mod.old_race(ctx, opts)
+        ) as mock_resolve:
+            with patch.object(_mod, 'push_influx_race'):
+                with patch.object(_mod, 'delete_existing_laps'):
+                    with patch.object(_mod, 'print_rankings'):
+                        _mod.old_race(ctx, opts)
         assert mock_resolve.call_count == 2
         assert {c.args[0] for c in mock_resolve.call_args_list} == {'42', '99'}
 

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -1,5 +1,6 @@
 import logging
 import threading
+from typing import ClassVar
 from unittest.mock import MagicMock, call, mock_open, patch
 
 import lemongrass.laps as _mod
@@ -495,7 +496,7 @@ class TestPushInfluxClassInfo:
         assert record.endswith('1090000')
 
     def test_warns_when_effective_epoc_is_zero(self, caplog):
-        ctx, write_api = self._ctx()  # ctx.start_epoc = 0
+        ctx, _write_api = self._ctx()  # ctx.start_epoc = 0
         with caplog.at_level(logging.WARNING):
             _mod.push_influx(ctx, self._laps(), False)
         assert any('epoch' in r.message.lower() and r.levelno == logging.WARNING
@@ -577,7 +578,7 @@ class TestPushInfluxClassInfo:
         assert 'car_number=42' not in record
 
     def test_passes_session_id_to_build_lap_points(self):
-        ctx, write_api = self._ctx()
+        ctx, _write_api = self._ctx()
         with patch.object(_mod, '_build_lap_points', return_value=[]) as mock_build:
             _mod.push_influx(ctx, self._laps(), False, session_id=77)
         assert mock_build.call_args.args[8] == 77
@@ -1308,7 +1309,8 @@ class TestLiveClassWiring:
             {'Lap': '1', 'LapTime': '0:01:30.000', 'Position': '3',
              'FlagStatus': '0', 'TotalTime': '0:01:30.000'},
         ]
-        new_laps = existing_laps + [
+        new_laps = [
+            *existing_laps,
             {'Lap': '2', 'LapTime': '0:01:31.000', 'Position': '3',
              'FlagStatus': '0', 'TotalTime': '0:03:01.000'},
         ]
@@ -1329,7 +1331,8 @@ class TestLiveClassWiring:
             {'Lap': '1', 'LapTime': '0:01:30.000', 'Position': '3',
              'FlagStatus': '0', 'TotalTime': '0:01:30.000'},
         ]
-        new_laps = existing_laps + [
+        new_laps = [
+            *existing_laps,
             {'Lap': '2', 'LapTime': '0:01:31.000', 'Position': '3',
              'FlagStatus': '0', 'TotalTime': '0:03:01.000'},
         ]
@@ -1358,7 +1361,8 @@ class TestLiveClassWiring:
     def test_live_race_passes_car_info_to_push_influx(self):
         ctx = self._make_ctx()
         opts = _mod.RaceOptions(network_mode=True)
-        ctx.client.live.get_racer.return_value['Details']['Competitor']['AdditionalData'] = '2005/Toy/Celica'
+        competitor = ctx.client.live.get_racer.return_value['Details']['Competitor']
+        competitor['AdditionalData'] = '2005/Toy/Celica'
         with patch.object(_mod, '_resolve_class_live', return_value=('A', 1)):
             with patch.object(_mod, 'push_influx') as mock_push:
                 with patch.object(_mod, 'push_influx_race'):
@@ -1434,7 +1438,8 @@ class TestLiveClassWiring:
             {'Lap': '1', 'LapTime': '0:01:30.000', 'Position': '3',
              'FlagStatus': '0', 'TotalTime': '0:01:30.000'},
         ]
-        new_laps = existing_laps + [
+        new_laps = [
+            *existing_laps,
             {'Lap': '2', 'LapTime': '0:01:31.000', 'Position': '3',
              'FlagStatus': '0', 'TotalTime': '0:03:01.000'},
         ]
@@ -1460,7 +1465,8 @@ class TestLiveClassWiring:
             {'Lap': '1', 'LapTime': '0:01:30.000', 'Position': '3',
              'FlagStatus': '0', 'TotalTime': '0:01:30.000'},
         ]
-        new_laps = existing_laps + [
+        new_laps = [
+            *existing_laps,
             {'Lap': '2', 'LapTime': '0:01:31.000', 'Position': '3',
              'FlagStatus': '0', 'TotalTime': '0:03:01.000'},
         ]
@@ -1481,7 +1487,7 @@ class TestLiveClassWiring:
 class TestMonitorRoutineEpocRecheck:
     # A lap that is already in the laps list — refresh_competitor returns it so the
     # "new lap" branch never executes, keeping tests focused on the recheck logic.
-    _existing_lap = {
+    _existing_lap: ClassVar[dict] = {
         'Lap': '1', 'LapTime': '0:01:30.000', 'Position': '1',
         'FlagStatus': '0', 'TotalTime': '0:01:30.000',
     }
@@ -1686,59 +1692,59 @@ class TestPushInfluxRace:
         assert call_order == ['delete', 'write']
 
     def test_delete_targets_correct_race_id(self):
-        ctx, write_api, delete_api = self._ctx()
+        ctx, _write_api, delete_api = self._ctx()
         _mod.push_influx_race(ctx, 5000000)
         predicate = delete_api.delete.call_args.kwargs['predicate']
         assert 'race_id="999"' in predicate
         assert '_measurement="race"' in predicate
 
     def test_delete_targets_races_bucket(self):
-        ctx, write_api, delete_api = self._ctx()
+        ctx, _write_api, delete_api = self._ctx()
         _mod.push_influx_race(ctx, 5000000)
         assert delete_api.delete.call_args.kwargs['bucket'] == 'races'
 
     def test_writes_to_races_bucket(self):
-        ctx, write_api, delete_api = self._ctx()
+        ctx, write_api, _delete_api = self._ctx()
         _mod.push_influx_race(ctx, 5000000)
         assert write_api.write.call_args.kwargs['bucket'] == 'races'
 
     def test_measurement_is_race(self):
-        ctx, write_api, delete_api = self._ctx()
+        ctx, write_api, _delete_api = self._ctx()
         _mod.push_influx_race(ctx, 5000000)
         assert self._record(write_api).startswith('race,')
 
     def test_race_id_tag(self):
-        ctx, write_api, delete_api = self._ctx()
+        ctx, write_api, _delete_api = self._ctx()
         _mod.push_influx_race(ctx, 5000000)
         assert 'race_id=999' in self._record(write_api)
 
     def test_track_name_tag(self):
-        ctx, write_api, delete_api = self._ctx()
+        ctx, write_api, _delete_api = self._ctx()
         _mod.push_influx_race(ctx, 5000000)
         assert 'track_name=Road\\ America' in self._record(write_api)
 
     def test_end_time_epoc_field(self):
-        ctx, write_api, delete_api = self._ctx()
+        ctx, write_api, _delete_api = self._ctx()
         _mod.push_influx_race(ctx, 5000000)
         assert 'end_time_epoc=1749132000i' in self._record(write_api)
 
     def test_uses_provided_timestamp(self):
-        ctx, write_api, delete_api = self._ctx()
+        ctx, write_api, _delete_api = self._ctx()
         _mod.push_influx_race(ctx, 5000)
         assert self._record(write_api).endswith('5000')
 
     def test_exception_during_delete_is_logged_not_raised(self):
-        ctx, write_api, delete_api = self._ctx()
+        ctx, _write_api, delete_api = self._ctx()
         delete_api.delete.side_effect = Exception("network error")
         _mod.push_influx_race(ctx, 5000000)  # must not raise
 
     def test_exception_during_write_is_logged_not_raised(self):
-        ctx, write_api, delete_api = self._ctx()
+        ctx, write_api, _delete_api = self._ctx()
         write_api.write.side_effect = Exception("network error")
         _mod.push_influx_race(ctx, 5000000)  # must not raise
 
     def test_omits_series_name_tag_when_none(self):
-        ctx, write_api, delete_api = self._ctx()
+        ctx, write_api, _delete_api = self._ctx()
         ctx.metadata = _mod.RaceMetadata(
             race_name='Race', track_name='Track', series_name=None, end_time_epoc=0)
         _mod.push_influx_race(ctx, 1000)
@@ -1772,68 +1778,68 @@ class TestPushInfluxSession:
         assert call_order == ['delete', 'write']
 
     def test_delete_targets_correct_session_id(self):
-        ctx, write_api, delete_api = self._ctx()
+        ctx, _write_api, delete_api = self._ctx()
         _mod.push_influx_session(ctx, 42, 'Day 1', 1700000000)
         predicate = delete_api.delete.call_args.kwargs['predicate']
         assert 'session_id="42"' in predicate
         assert '_measurement="session"' in predicate
 
     def test_delete_targets_race_sessions_bucket(self):
-        ctx, write_api, delete_api = self._ctx()
+        ctx, _write_api, delete_api = self._ctx()
         _mod.push_influx_session(ctx, 42, 'Day 1', 1700000000)
         assert delete_api.delete.call_args.kwargs['bucket'] == 'race_sessions'
 
     def test_writes_to_race_sessions_bucket(self):
-        ctx, write_api, delete_api = self._ctx()
+        ctx, write_api, _delete_api = self._ctx()
         _mod.push_influx_session(ctx, 42, 'Day 1', 1700000000)
         assert write_api.write.call_args.kwargs['bucket'] == 'race_sessions'
 
     def test_measurement_is_session(self):
-        ctx, write_api, delete_api = self._ctx()
+        ctx, write_api, _delete_api = self._ctx()
         _mod.push_influx_session(ctx, 42, 'Day 1', 1700000000)
         assert self._record(write_api).startswith('session,')
 
     def test_race_id_tag(self):
-        ctx, write_api, delete_api = self._ctx()
+        ctx, write_api, _delete_api = self._ctx()
         _mod.push_influx_session(ctx, 42, 'Day 1', 1700000000)
         assert 'race_id=999' in self._record(write_api)
 
     def test_session_id_tag(self):
-        ctx, write_api, delete_api = self._ctx()
+        ctx, write_api, _delete_api = self._ctx()
         _mod.push_influx_session(ctx, 42, 'Day 1', 1700000000)
         assert 'session_id=42' in self._record(write_api)
 
     def test_session_name_field(self):
-        ctx, write_api, delete_api = self._ctx()
+        ctx, write_api, _delete_api = self._ctx()
         _mod.push_influx_session(ctx, 42, 'Day 1', 1700000000)
         assert 'session_name="Day 1"' in self._record(write_api)
 
     def test_start_epoc_field(self):
-        ctx, write_api, delete_api = self._ctx()
+        ctx, write_api, _delete_api = self._ctx()
         _mod.push_influx_session(ctx, 42, 'Day 1', 1700000000)
         assert 'start_epoc=1700000000i' in self._record(write_api)
 
     def test_timestamp_uses_start_epoc_ms(self):
-        ctx, write_api, delete_api = self._ctx()
+        ctx, write_api, _delete_api = self._ctx()
         _mod.push_influx_session(ctx, 42, 'Day 1', 1700000000)
         assert self._record(write_api).endswith('1700000000000')
 
     def test_exception_during_delete_is_logged_not_raised(self, caplog):
-        ctx, write_api, delete_api = self._ctx()
+        ctx, _write_api, delete_api = self._ctx()
         delete_api.delete.side_effect = Exception('network error')
         with caplog.at_level(logging.ERROR):
             _mod.push_influx_session(ctx, 42, 'Day 1', 1700000000)  # must not raise
         assert "Writing session failed" in caplog.text
 
     def test_exception_during_write_is_logged_not_raised(self, caplog):
-        ctx, write_api, delete_api = self._ctx()
+        ctx, write_api, _delete_api = self._ctx()
         write_api.write.side_effect = Exception('network error')
         with caplog.at_level(logging.ERROR):
             _mod.push_influx_session(ctx, 42, 'Day 1', 1700000000)  # must not raise
         assert "Writing session failed" in caplog.text
 
     def test_start_epoc_none_writes_zero(self):
-        ctx, write_api, delete_api = self._ctx()
+        ctx, write_api, _delete_api = self._ctx()
         _mod.push_influx_session(ctx, 42, 'Day 1', None)
         assert 'start_epoc=0i' in self._record(write_api)
         assert self._record(write_api).endswith('0')

--- a/tests/test_races.py
+++ b/tests/test_races.py
@@ -359,9 +359,8 @@ class TestHandleList:
         assert out.index('New Race') < out.index('Old Race')
 
     def test_exits_when_no_influx_token(self):
-        with patch.dict('os.environ', {}, clear=True):
-            with pytest.raises(SystemExit) as exc:
-                _mod._handle_list()
+        with patch.dict('os.environ', {}, clear=True), pytest.raises(SystemExit) as exc:
+            _mod._handle_list()
         assert exc.value.code != 0
 
 

--- a/tests/test_races.py
+++ b/tests/test_races.py
@@ -359,8 +359,9 @@ class TestHandleList:
         assert out.index('New Race') < out.index('Old Race')
 
     def test_exits_when_no_influx_token(self):
-        with patch.dict('os.environ', {}, clear=True), pytest.raises(SystemExit) as exc:
-            _mod._handle_list()
+        with patch.dict('os.environ', {}, clear=True):
+            with pytest.raises(SystemExit) as exc:
+                _mod._handle_list()
         assert exc.value.code != 0
 
 

--- a/tests/test_races.py
+++ b/tests/test_races.py
@@ -1,5 +1,6 @@
 import sys
 from unittest.mock import MagicMock, patch
+
 import pytest
 
 import lemongrass.races as _mod
@@ -209,7 +210,7 @@ class TestHandlePrune:
                 with patch.dict('os.environ', {'INFLUX_TELEMETRY_TOKEN': 'tok'}):
                     _mod._handle_prune()
         delete_api = fake_client.delete_api.return_value
-        assert delete_api.delete.call_count == 6  # 3 buckets × 2 races
+        assert delete_api.delete.call_count == 6  # 3 buckets x 2 races
         buckets = [c.kwargs.get('bucket') for c in delete_api.delete.call_args_list]
         assert buckets.count('laps') == 2
         assert buckets.count('races') == 2


### PR DESCRIPTION
## Summary

Expands the ruff rule set in two passes and fixes all violations.

**Pass 1 — core rules:** Adds `D1`, `I`, `B`, `UP`, `RUF`, and `N`; suppresses `D1` in `tests/**`. Fixes line-length violations, unsorted imports, missing docstrings, unused unpacked variables, list-concatenation style, mutable `ClassVar`, and an ambiguous unicode character.

**Pass 2 — C4 and SIM:** Adds `C4` (flake8-comprehensions) and `SIM` (flake8-simplify). Key decisions:
- `SIM105`: two `try/except/pass` blocks in `laps.py` replaced with `contextlib.suppress`
- `SIM117`: suppressed in `tests/**` — nested `patch.object` calls are clearer nested and ruff couldn't auto-fix the 100 test violations anyway
- `D107` (`__init__` docstrings): not ignored — no bare `__init__` methods exist in `src/`; suppress only when there's a live violation

All test `with` blocks use consistent nested style throughout.

## Test plan

- [x] `uv run ruff check .` passes clean with all new rule sets
- [x] `uv run pytest` — all 290 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)