### PR TITLE
fix(race-backfill): invoke laps via lemongrass dispatcher

### DIFF
--- a/src/lemongrass/race_backfill.py
+++ b/src/lemongrass/race_backfill.py
@@ -185,7 +185,7 @@ def run_backfill(races, default_car, overrides, dry_run=False, force=False):
     for race in races:
         race_id = str(race['ID'])
         car_number = resolve_car_number(race_id, default_car, overrides)
-        cmd = ['laps', '-n']
+        cmd = ['lemongrass', 'laps', '-n']
         if not force:
             cmd.append('--skip-if-complete')
         cmd += [race_id, car_number]
@@ -262,7 +262,7 @@ def run_upgrade_stored(query_api, dry_run=False):
         if dry_run:
             continue
 
-        result = subprocess.run(['laps', '-n', str(race_id)], capture_output=False)
+        result = subprocess.run(['lemongrass', 'laps', '-n', str(race_id)], capture_output=False)
         if result.returncode == 130:
             logging.info("laps was interrupted; stopping upgrade.")
             break

--- a/src/lemongrass/race_backfill.py
+++ b/src/lemongrass/race_backfill.py
@@ -3,7 +3,7 @@
 
 Searches the RaceMonitor API for past Real Hoopties, GP du Lac, and Halloween
 Hoop races and writes lap data for a given car number to the laps/races InfluxDB
-buckets by invoking `laps -n` for each race found.
+buckets by invoking `lemongrass laps -n` for each race found.
 
 Assumes `lemongrass` is installed as a CLI tool. If running from the repo, prefix
 commands with `uv run` (e.g. `uv run lemongrass race-backfill`).
@@ -176,9 +176,9 @@ def validate_backfill(pairs, query_api):
 
 
 def run_backfill(races, default_car, overrides, dry_run=False, force=False):
-    """Run `laps -n` for each race, using per-race car number overrides where set.
+    """Run `lemongrass laps -n` for each race, using per-race car number overrides where set.
 
-    Unless force is set, passes --skip-if-complete so `laps` skips races whose
+    Unless force is set, passes --skip-if-complete so `lemongrass laps` skips races whose
     laps are already complete and written under the current schema version.
     """
     failures = []
@@ -211,7 +211,7 @@ def run_upgrade_stored(query_api, dry_run=False):
     """Query InfluxDB for stored races with stale schema versions and re-backfill them.
 
     Races already at the current SCHEMA_VERSION are skipped. Re-backfill calls
-    `laps -n <race_id>` with no car_number (fieldwide mode).
+    `lemongrass laps -n <race_id>` with no car_number (fieldwide mode).
     """
     from lemongrass.laps import SCHEMA_VERSION
 

--- a/tests/test_race_backfill.py
+++ b/tests/test_race_backfill.py
@@ -122,7 +122,7 @@ class TestRunBackfill:
             mock_run.return_value = MagicMock(returncode=0)
             _mod.run_backfill(self._races()[:1], default_car='252', overrides={})
         cmd = mock_run.call_args.args[0]
-        assert cmd[0] == 'laps'
+        assert cmd[:2] == ['lemongrass', 'laps']
 
     def test_failure_summary_logged_when_any_race_fails(self, caplog):
         import logging
@@ -348,7 +348,7 @@ class TestRunUpgradeStored:
             _mod.run_upgrade_stored(query_api)
         assert mock_run.call_count == 1
         cmd = mock_run.call_args.args[0]
-        assert cmd == ['laps', '-n', '101']
+        assert cmd == ['lemongrass', 'laps', '-n', '101']
 
     def test_dry_run_does_not_call_subprocess(self):
         query_api = self._query_api(

--- a/tests/test_race_backfill.py
+++ b/tests/test_race_backfill.py
@@ -117,7 +117,7 @@ class TestRunBackfill:
         assert any('Real Hoopties 2022' in r.message and '253' in r.message
                    for r in caplog.records)
 
-    def test_subprocess_invokes_laps_entry_point(self):
+    def test_subprocess_invokes_lemongrass_laps(self):
         with patch.object(_mod.subprocess, 'run') as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
             _mod.run_backfill(self._races()[:1], default_car='252', overrides={})


### PR DESCRIPTION
## Summary

- `race_backfill.py` called `subprocess.run(['laps', ...])` assuming a standalone `laps` binary
- That binary was removed in 9e5f85a when the CLI was consolidated under the `lemongrass` dispatcher, but `race_backfill.py` was never updated
- Both call sites (`run_backfill` and `run_upgrade_stored`) now use `['lemongrass', 'laps', ...]`
- Updated tests and docstrings to match

## Test plan

- [x] `uv run pytest` passes (290 tests)
- [x] Docstrings in module, `run_backfill`, and `run_upgrade_stored` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)