### PR TITLE
fix(laps): handle non-numeric Position values from RaceMonitor API

### DIFF
--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -691,6 +691,11 @@ def _build_lap_points(ctx, laps, competitor_name, car_info, class_name, class_po
         time_lap_completed_ms = start_epoc_ms + _time_to_ms(lap['TotalTime'])
         lap_time_ms = _time_to_ms(lap['LapTime'])
         lap_num = int(lap['Lap'])
+        try:
+            position = int(lap['Position'])
+        except (ValueError, TypeError):
+            logging.warning("unparseable position %r on lap %s for %s; writing 999", lap['Position'], lap_num, competitor_name)
+            position = 999
         point = (
             Point("lap")
             .tag("race_id", ctx.race_id)
@@ -700,7 +705,7 @@ def _build_lap_points(ctx, laps, competitor_name, car_info, class_name, class_po
             .tag("car_number", car_number)
             .field("lap_no", lap_num)
             .field("lap_time", lap_time_ms)
-            .field("position", int(lap['Position']))
+            .field("position", position)
             .field("flag_status", lap['FlagStatus'])
             .field("schema_version", SCHEMA_VERSION)
             .time(time_lap_completed_ms, WritePrecision.MS)

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -694,8 +694,11 @@ def _build_lap_points(ctx, laps, competitor_name, car_info, class_name, class_po
         try:
             position = int(lap['Position'])
         except (ValueError, TypeError):
-            logging.warning("unparseable position %r on lap %s for %s; writing 999", lap['Position'], lap_num, competitor_name)
-            position = 999
+            logging.warning(
+                "unparseable position %r on lap %s for %s; omitting field",
+                lap['Position'], lap_num, competitor_name,
+            )
+            position = None
         point = (
             Point("lap")
             .tag("race_id", ctx.race_id)
@@ -705,11 +708,12 @@ def _build_lap_points(ctx, laps, competitor_name, car_info, class_name, class_po
             .tag("car_number", car_number)
             .field("lap_no", lap_num)
             .field("lap_time", lap_time_ms)
-            .field("position", position)
             .field("flag_status", lap['FlagStatus'])
             .field("schema_version", SCHEMA_VERSION)
             .time(time_lap_completed_ms, WritePrecision.MS)
         )
+        if position is not None:
+            point = point.field("position", position)
         if session_id is not None:
             point = point.tag("session_id", str(session_id))
         if class_positions is not None:

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -2075,6 +2075,31 @@ class TestBuildLapPointsSessionId:
         assert 'session_id' not in self._build(None)
 
 
+class TestBuildLapPointsNonNumericPosition:
+    def _ctx(self):
+        return _mod.RaceContext('138911', '77', MagicMock(), MagicMock(), 0)
+
+    def _make_lap(self, lap='227', position='1'):
+        return {'Lap': lap, 'LapTime': '104', 'Position': position,
+                'FlagStatus': 'Green', 'TotalTime': '121'}
+
+    def test_non_numeric_position_writes_999(self):
+        laps = [self._make_lap(position='$G')]
+        points = _mod._build_lap_points(self._ctx(), laps, 'Car 77', None, 'Gold', None, 0, '77')
+        assert len(points) == 1
+        assert 'position=999i' in points[0].to_line_protocol()
+
+    def test_lap_number_preserved_when_position_bad(self):
+        laps = [self._make_lap(lap='227', position='$G')]
+        points = _mod._build_lap_points(self._ctx(), laps, 'Car 77', None, 'Gold', None, 0, '77')
+        assert 'lap_no=227i' in points[0].to_line_protocol()
+
+    def test_numeric_position_written_normally(self):
+        laps = [self._make_lap(lap='227', position='3')]
+        points = _mod._build_lap_points(self._ctx(), laps, 'Car 77', None, 'Gold', None, 0, '77')
+        assert 'position=3i' in points[0].to_line_protocol()
+
+
 class TestWritePointsChunked:
     def test_single_chunk_when_below_batch_size(self):
         write_api = MagicMock()

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -3,6 +3,8 @@ import threading
 from typing import ClassVar
 from unittest.mock import MagicMock, call, mock_open, patch
 
+import pytest
+
 import lemongrass.laps as _mod
 
 
@@ -2083,11 +2085,18 @@ class TestBuildLapPointsNonNumericPosition:
         return {'Lap': lap, 'LapTime': '104', 'Position': position,
                 'FlagStatus': 'Green', 'TotalTime': '121'}
 
-    def test_non_numeric_position_writes_999(self):
-        laps = [self._make_lap(position='$G')]
+    @pytest.mark.parametrize("bad_pos", ['$G', 'P1', '--'])
+    def test_non_numeric_position_omits_field(self, bad_pos):
+        laps = [self._make_lap(position=bad_pos)]
         points = _mod._build_lap_points(self._ctx(), laps, 'Car 77', None, 'Gold', None, 0, '77')
         assert len(points) == 1
-        assert 'position=999i' in points[0].to_line_protocol()
+        assert 'position=' not in points[0].to_line_protocol()
+
+    def test_none_position_omits_field(self):
+        laps = [self._make_lap(position=None)]
+        points = _mod._build_lap_points(self._ctx(), laps, 'Car 77', None, 'Gold', None, 0, '77')
+        assert len(points) == 1
+        assert 'position=' not in points[0].to_line_protocol()
 
     def test_lap_number_preserved_when_position_bad(self):
         laps = [self._make_lap(lap='227', position='$G')]


### PR DESCRIPTION
## Summary

- Race 138911 car 77 has a \`'$G'\` status code in the \`Position\` field on lap 227 — a timing-system end-of-race status code, not a real position
- \`_build_lap_points\` was calling \`int(lap['Position'])\` with no guard, crashing the entire backfill for that race
- Now omits the \`position\` field entirely for non-numeric values (including \`None\`); InfluxDB leaves the field absent for that point, which is unambiguous and avoids polluting aggregations like \`min\`/\`max\` position

## Test plan

- [x] \`uv run pytest tests/test_laps.py\` — 187 tests pass
- [ ] Re-run backfill for race 138911 and confirm it completes without error
- [ ] Verify car 77 lap 227 appears in InfluxDB without a \`position\` field