### PR TITLE
fix(laps): handle non-numeric Position values in print_rankings sort

### DIFF
--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -507,7 +507,9 @@ def print_rankings(sorted_competitors, _race_live, selected_class, categories):
         sorted_competitors_df = sorted_competitors_df.rename(
             columns={'Category': 'Class', 'Number': '#', 'Position': 'Overall Pos.'})
         sorted_competitors_df = sorted_competitors_df.sort_values(
-            'Overall Pos.', key=pandas.to_numeric, ignore_index=True)
+            'Overall Pos.',
+            key=lambda s: pandas.to_numeric(s, errors='coerce'),
+            ignore_index=True)
         sorted_competitors_df['Class Pos.'] = (
             sorted_competitors_df.groupby('Class').cumcount() + 1)
         sorted_competitors_df = sorted_competitors_df[
@@ -523,7 +525,9 @@ def print_rankings(sorted_competitors, _race_live, selected_class, categories):
         sorted_competitors_df = sorted_competitors_df.rename(
             columns={'Category': 'Class', 'Number': '#', 'Position': 'Pos.'})
         sorted_competitors_df = sorted_competitors_df.sort_values(
-            'Pos.', key=pandas.to_numeric, ignore_index=True)
+            'Pos.',
+            key=lambda s: pandas.to_numeric(s, errors='coerce'),
+            ignore_index=True)
         sorted_competitors_df['Class Pos.'] = (
             sorted_competitors_df.groupby('Class').cumcount() + 1)
         sorted_competitors_df = sorted_competitors_df[

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -2120,14 +2120,45 @@ class TestPrintRankingsNonNumericPosition:
         return {'1': {'ID': '1', 'Name': 'Gold'}}
 
     @pytest.mark.parametrize("bad_pos", ['6$G', '$G', 'P1', '--'])
-    def test_non_numeric_position_does_not_crash(self, bad_pos, capsys):
+    def test_non_numeric_position_does_not_crash(self, bad_pos):
         competitors = [self._competitor(position=bad_pos)]
         _mod.print_rankings(competitors, False, None, self._categories())
 
     @pytest.mark.parametrize("bad_pos", ['6$G', '$G', 'P1', '--'])
-    def test_non_numeric_position_with_selected_class_does_not_crash(self, bad_pos, capsys):
+    def test_non_numeric_position_with_selected_class_does_not_crash(self, bad_pos):
         competitors = [self._competitor(position=bad_pos)]
         _mod.print_rankings(competitors, False, (None, 'gold'), self._categories())
+
+
+class TestPrintRankingsSortOrder:
+    """Behavioral tests using real pandas (conftest mocks pandas; patch it back)."""
+
+    def _competitor(self, position='1', number='42', name='Jane', category='1', laps='5'):
+        return {
+            'Position': position, 'Number': number, 'FirstName': name, 'LastName': '',
+            'Laps': laps, 'Category': category, 'Transponder': 'T1',
+        }
+
+    def _categories(self):
+        return {'1': {'ID': '1', 'Name': 'Gold'}}
+
+    def test_numeric_position_sorts_before_non_numeric(self, capsys):
+        import sys
+        # conftest mocks pandas in sys.modules; pop it to import the real one
+        pandas_mock = sys.modules.pop('pandas', None)
+        try:
+            import pandas as real_pandas
+        finally:
+            if pandas_mock is not None:
+                sys.modules['pandas'] = pandas_mock
+        competitors = [
+            self._competitor(position='6$G', number='99'),
+            self._competitor(position='1', number='42'),
+        ]
+        with patch.object(_mod, 'pandas', real_pandas):
+            _mod.print_rankings(competitors, False, None, self._categories())
+        out = capsys.readouterr().out
+        assert out.index('42') < out.index('99')
 
 
 class TestWritePointsChunked:

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -2109,6 +2109,27 @@ class TestBuildLapPointsNonNumericPosition:
         assert 'position=3i' in points[0].to_line_protocol()
 
 
+class TestPrintRankingsNonNumericPosition:
+    def _competitor(self, position='1', number='42', name='Jane', category='1', laps='5'):
+        return {
+            'Position': position, 'Number': number, 'FirstName': name, 'LastName': '',
+            'Laps': laps, 'Category': category, 'Transponder': 'T1',
+        }
+
+    def _categories(self):
+        return {'1': {'ID': '1', 'Name': 'Gold'}}
+
+    @pytest.mark.parametrize("bad_pos", ['6$G', '$G', 'P1', '--'])
+    def test_non_numeric_position_does_not_crash(self, bad_pos, capsys):
+        competitors = [self._competitor(position=bad_pos)]
+        _mod.print_rankings(competitors, False, None, self._categories())
+
+    @pytest.mark.parametrize("bad_pos", ['6$G', '$G', 'P1', '--'])
+    def test_non_numeric_position_with_selected_class_does_not_crash(self, bad_pos, capsys):
+        competitors = [self._competitor(position=bad_pos)]
+        _mod.print_rankings(competitors, False, (None, 'gold'), self._categories())
+
+
 class TestWritePointsChunked:
     def test_single_chunk_when_below_batch_size(self):
         write_api = MagicMock()


### PR DESCRIPTION
## Summary

- `print_rankings` crashed during backfill when a competitor's `Position` field contained a timing-system code like `"6$G"` — `pandas.to_numeric` used as a `sort_values` key raises on unparseable strings by default
- Fixed both sort paths (overall rankings and filtered-by-class) by wrapping in a lambda that passes `errors='coerce'`, so bad values become NaN and sort to the end instead of crashing
- Same root cause as 2a39c0c (lap Position in `_build_lap_points`), but a separate code path

## Test plan

- `TestPrintRankingsNonNumericPosition` — 8 parametrized crash-safety cases covering `6$G`, `$G`, `P1`, `--` in both the overall and class-filtered paths (conftest mocks pandas, so output assertions aren't feasible here)
- `TestPrintRankingsSortOrder` — behavioral test using real pandas (temporarily pops the sys.modules mock) to verify position `'1'` sorts before `'6$G'`
- Full suite: `uv run pytest` — 305 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)