### PR TITLE
fix(laps): omit lap_time field instead of storing 0 on parse failure

### DIFF
--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -668,8 +668,8 @@ def _time_to_ms(value):
         minutes = int(parts[-2]) if len(parts) >= 2 else 0
         return hours * 3600000 + minutes * 60000 + int(sec) * 1000 + int(ms or 0)
     except (ValueError, AttributeError):
-        logging.warning("unparseable lap time %r; writing 0 ms", value)
-        return 0
+        logging.warning("unparseable lap time %r; omitting field", value)
+        return None
 
 
 def _write_points_chunked(write_api, points, batch_size=_WRITE_BATCH_SIZE):
@@ -692,7 +692,7 @@ def _build_lap_points(ctx, laps, competitor_name, car_info, class_name, class_po
     start_epoc_ms = effective_epoc * 1000
     points = []
     for lap in laps:
-        time_lap_completed_ms = start_epoc_ms + _time_to_ms(lap['TotalTime'])
+        time_lap_completed_ms = start_epoc_ms + (_time_to_ms(lap['TotalTime']) or 0)
         lap_time_ms = _time_to_ms(lap['LapTime'])
         lap_num = int(lap['Lap'])
         try:
@@ -711,11 +711,12 @@ def _build_lap_points(ctx, laps, competitor_name, car_info, class_name, class_po
             .tag("class", class_name)
             .tag("car_number", car_number)
             .field("lap_no", lap_num)
-            .field("lap_time", lap_time_ms)
             .field("flag_status", lap['FlagStatus'])
             .field("schema_version", SCHEMA_VERSION)
             .time(time_lap_completed_ms, WritePrecision.MS)
         )
+        if lap_time_ms is not None:
+            point = point.field("lap_time", lap_time_ms)
         if position is not None:
             point = point.field("position", position)
         if session_id is not None:

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -658,8 +658,9 @@ def _time_to_ms(value):
     fractional '.mmm' part optional. RaceMonitor omits the hours component when a
     value is under an hour, so we right-align the colon-separated parts.
 
-    Returns 0 for unparseable values; the API occasionally returns garbage for
-    invalid or pit laps.
+    Returns None for unparseable values, which causes the field to be omitted
+    from the InfluxDB point. The API occasionally returns garbage for invalid
+    or pit laps.
     """
     try:
         parts = value.split(':')

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -417,8 +417,8 @@ class TestTimeToMs:
     def test_missing_milliseconds(self):
         assert _mod._time_to_ms('45:30') == 45 * 60000 + 30 * 1000
 
-    def test_unparseable_value_returns_zero(self):
-        assert _mod._time_to_ms('3$H') == 0
+    def test_unparseable_value_returns_none(self):
+        assert _mod._time_to_ms('3$H') is None
 
     def test_unparseable_value_logs_warning(self, caplog):
         import logging
@@ -571,6 +571,13 @@ class TestPushInfluxClassInfo:
         assert 'lap_time=90000i' in record
         # TotalTime 45:30.000 = 2730000 ms; start_epoc=0 → timestamp 2730000
         assert record.endswith('2730000')
+
+    def test_omits_lap_time_field_when_unparseable(self):
+        ctx, write_api = self._ctx()
+        laps = [{'Lap': '1', 'LapTime': '3$H', 'Position': '1',
+                 'FlagStatus': 'Green', 'TotalTime': '0:01:30.000'}]
+        _mod.push_influx(ctx, laps, False)
+        assert 'lap_time' not in self._record(write_api)
 
     def test_explicit_car_number_overrides_ctx(self):
         ctx, write_api = self._ctx()  # ctx.car_number = '42'

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -579,6 +579,14 @@ class TestPushInfluxClassInfo:
         _mod.push_influx(ctx, laps, False)
         assert 'lap_time' not in self._record(write_api)
 
+    def test_unparseable_total_time_anchors_to_start_epoc(self):
+        ctx, write_api = self._ctx()  # start_epoc=0
+        laps = [{'Lap': '1', 'LapTime': '1:30.000', 'Position': '1',
+                 'FlagStatus': 'Green', 'TotalTime': '3$H'}]
+        _mod.push_influx(ctx, laps, False)
+        # TotalTime unparseable → falls back to 0; timestamp = start_epoc_ms + 0 = 0
+        assert self._record(write_api).endswith(' 0')
+
     def test_explicit_car_number_overrides_ctx(self):
         ctx, write_api = self._ctx()  # ctx.car_number = '42'
         _mod.push_influx(ctx, self._laps(), False, car_number='99')


### PR DESCRIPTION
## Summary

- \`_time_to_ms\` now returns \`None\` instead of \`0\` when a lap time string is unparseable
- \`lap_time\` is conditionally added to the InfluxDB point (same pattern as \`position\`), so malformed values produce a missing field rather than a misleading \`0ms\`
- \`TotalTime\` (used as the point timestamp anchor) falls back to \`or 0\` to preserve existing timestamp behavior
- Updated \`_time_to_ms\` docstring to reflect the new return value

## Test plan

- [ ] \`test_unparseable_value_returns_none\` — confirms \`_time_to_ms\` returns \`None\` for garbage input
- [ ] \`test_omits_lap_time_field_when_unparseable\` — confirms the field is absent from the InfluxDB line protocol when \`LapTime\` is malformed
- [ ] \`test_unparseable_total_time_anchors_to_start_epoc\` — confirms unparseable \`TotalTime\` falls back to \`start_epoc_ms + 0\`
- [ ] Full suite: \`uv run pytest\` (307 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)