### PR TITLE
feat(laps): live and historical standings writes to InfluxDB

### DIFF
--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -999,6 +999,65 @@ def _compute_class_positions_live(session_response):
     return result
 
 
+def push_influx_standings_live(ctx, session_response, session_id):
+    """Write one standings point per competitor from a live session snapshot."""
+    if not session_response.get('Successful'):
+        logging.debug("push_influx_standings_live: unsuccessful session response, skipping")
+        return
+    competitors = session_response['Session']['Competitors']
+    classes = session_response['Session']['Classes']
+    class_positions = _compute_class_positions_live(session_response)
+    timestamp_ms = int(time.time() * 1000)
+    points = []
+    for comp in competitors.values():
+        try:
+            position = int(comp['Position'])
+        except (ValueError, TypeError):
+            continue
+        try:
+            lap_count = int(comp['Laps'])
+        except (ValueError, TypeError):
+            continue
+        class_id = comp['ClassID']
+        class_name = classes.get(class_id, {}).get('Description', class_id)
+        competitor_name = (
+            f"{comp.get('FirstName', '')} {comp.get('LastName', '')}".strip() or None
+        )
+        car_info = comp.get('AdditionalData') or None
+        car_number = comp['Number']
+        best_lap_ms = _time_to_ms(comp.get('BestLapTime', ''))
+        last_lap_ms = _time_to_ms(comp.get('LastLapTime', ''))
+        class_position = class_positions.get(car_number)
+        point = (
+            Point("standings")
+            .tag("race_id", ctx.race_id)
+            .tag("car_number", car_number)
+            .tag("competitor_name", competitor_name)
+            .tag("car_info", car_info)
+            .tag("class", class_name)
+            .field("position", position)
+            .field("lap_count", lap_count)
+            .time(timestamp_ms, WritePrecision.MS)
+        )
+        if session_id is not None:
+            point = point.tag("session_id", str(session_id))
+        if class_position is not None:
+            point = point.field("class_position", class_position)
+        if best_lap_ms is not None:
+            point = point.field("best_lap_time", best_lap_ms)
+        if last_lap_ms is not None:
+            point = point.field("last_lap_time", last_lap_ms)
+        points.append(point)
+    if points:
+        try:
+            _write_points_chunked(ctx.write_api, points)
+            logging.debug(
+                "Wrote %d standings points for live race %s", len(points), ctx.race_id)
+        except Exception as e:
+            logging.error(
+                "Writing standings failed for race %s: %s", ctx.race_id, e)
+
+
 def _resolve_race_metadata(race_details, client):
     """Resolve race-level metadata from race details and a single series lookup."""
     if not race_details.get('Successful'):

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -578,6 +578,7 @@ def monitor_routine(ctx, laps, opts, competitor_name=None, car_info=None, _stop_
 
     stop = _stop_event if _stop_event is not None else threading.Event()
     poll_count = 0
+    prev_standings = {}
     try:
         while not stop.wait(timeout=opts.interval):
             poll_count += 1
@@ -603,6 +604,7 @@ def monitor_routine(ctx, laps, opts, competitor_name=None, car_info=None, _stop_
                 if new_session_id and new_session_id != session_id:
                     print(f"\nNew session: {session_response['Session'].get('Name', '')}")
                     session_id = new_session_id
+                    prev_standings = {}
                     if opts.network_mode:
                         push_influx_session(
                             ctx, session_id, session_response['Session'].get('Name'), None)
@@ -610,7 +612,8 @@ def monitor_routine(ctx, laps, opts, competitor_name=None, car_info=None, _stop_
                 logging.debug("get_session returned unsuccessful; may be between sessions")
 
             if opts.network_mode:
-                push_influx_standings_live(ctx, session_response, session_id)
+                prev_standings = push_influx_standings_live(
+                    ctx, session_response, session_id, prev_standings)
 
             if poll_count % _LIVE_CHECK_INTERVAL == 0:
                 try:
@@ -1010,15 +1013,23 @@ def _compute_class_positions_live(session_response):
     return result
 
 
-def push_influx_standings_live(ctx, session_response, session_id):
-    """Write one standings point per competitor from a live session snapshot."""
+def push_influx_standings_live(ctx, session_response, session_id, prev_standings=None):
+    """Write one standings point per competitor when standings have changed.
+
+    prev_standings maps car_number to a (position, lap_count, class_position,
+    best_lap_ms, last_lap_ms) snapshot from the previous poll.  The entire
+    field is compared atomically — if any competitor changed, all are written.
+    Pass None to write all competitors unconditionally (e.g. at race startup).
+    Returns the current standings snapshot dict for the caller to pass next poll.
+    """
     if not session_response.get('Successful'):
         logging.debug("push_influx_standings_live: unsuccessful session response, skipping")
-        return
+        return prev_standings if prev_standings is not None else {}
     competitors = session_response['Session']['Competitors']
     classes = session_response['Session']['Classes']
     class_positions = _compute_class_positions_live(session_response)
     timestamp_ms = int(time.time() * 1000)
+    curr_standings = {}
     points = []
     for comp in competitors.values():
         try:
@@ -1039,6 +1050,8 @@ def push_influx_standings_live(ctx, session_response, session_id):
         best_lap_ms = _time_to_ms(comp.get('BestLapTime', ''))
         last_lap_ms = _time_to_ms(comp.get('LastLapTime', ''))
         class_position = class_positions.get(car_number)
+        curr_standings[car_number] = (
+            position, lap_count, class_position, best_lap_ms, last_lap_ms)
         point = (
             Point("standings")
             .tag("race_id", ctx.race_id)
@@ -1059,7 +1072,7 @@ def push_influx_standings_live(ctx, session_response, session_id):
         if last_lap_ms is not None:
             point = point.field("last_lap_time", last_lap_ms)
         points.append(point)
-    if points:
+    if points and curr_standings != prev_standings:
         try:
             _write_points_chunked(ctx.write_api, points)
             logging.debug(
@@ -1067,6 +1080,8 @@ def push_influx_standings_live(ctx, session_response, session_id):
         except Exception as e:
             logging.error(
                 "Writing standings failed for race %s: %s", ctx.race_id, e)
+            return prev_standings if prev_standings is not None else {}
+    return curr_standings
 
 
 def push_influx_standings_historical(ctx, session_entry):

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -401,6 +401,10 @@ def old_race(ctx, opts):
                     'class_name': class_name,
                     'class_positions': class_positions,
                     'car_number': comp_number,
+                    'final_position': competitor.get('Position', ''),
+                    'final_laps': competitor.get('Laps', ''),
+                    'best_lap_time': competitor.get('BestLapTime', ''),
+                    'last_lap_time': competitor.get('LastLapTime', ''),
                 })
             pending_writes.append(session_entry)
 
@@ -471,6 +475,9 @@ def old_race(ctx, opts):
         for session in pending_writes:
             push_influx_session(
                 ctx, session['session_id'], session['session_name'], session['start_epoc'])
+
+        for session in pending_writes:
+            push_influx_standings_historical(ctx, session)
 
     print_rankings(sorted_competitors, False, opts.selected_class,
                    session_details['Session']['Categories'])
@@ -1060,6 +1067,58 @@ def push_influx_standings_live(ctx, session_response, session_id):
         except Exception as e:
             logging.error(
                 "Writing standings failed for race %s: %s", ctx.race_id, e)
+
+
+def push_influx_standings_historical(ctx, session_entry):
+    """Write one standings point per competitor from a completed session."""
+    start_epoc = session_entry.get('start_epoc') or 0
+    timestamp_ms = start_epoc * 1000
+    session_id = session_entry['session_id']
+    points = []
+    for comp in session_entry['competitors']:
+        try:
+            position = int(comp['final_position'])
+        except (ValueError, TypeError):
+            continue
+        try:
+            lap_count = int(comp['final_laps'])
+        except (ValueError, TypeError):
+            continue
+        class_positions = comp.get('class_positions') or {}
+        class_position = (
+            class_positions[max(class_positions)] if class_positions else None
+        )
+        best_lap_ms = _time_to_ms(comp.get('best_lap_time') or '')
+        last_lap_ms = _time_to_ms(comp.get('last_lap_time') or '')
+        point = (
+            Point("standings")
+            .tag("race_id", ctx.race_id)
+            .tag("car_number", comp['car_number'])
+            .tag("competitor_name", comp['competitor_name'])
+            .tag("car_info", comp['car_info'])
+            .tag("class", comp['class_name'])
+            .tag("session_id", str(session_id))
+            .field("position", position)
+            .field("lap_count", lap_count)
+            .time(timestamp_ms, WritePrecision.MS)
+        )
+        if class_position is not None:
+            point = point.field("class_position", class_position)
+        if best_lap_ms is not None:
+            point = point.field("best_lap_time", best_lap_ms)
+        if last_lap_ms is not None:
+            point = point.field("last_lap_time", last_lap_ms)
+        points.append(point)
+    if points:
+        try:
+            _write_points_chunked(ctx.write_api, points)
+            logging.debug(
+                "Wrote %d historical standings for race %s session %s",
+                len(points), ctx.race_id, session_id)
+        except Exception as e:
+            logging.error(
+                "Writing historical standings failed for race %s session %s: %s",
+                ctx.race_id, session_id, e)
 
 
 def _resolve_race_metadata(race_details, client):

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -324,6 +324,7 @@ def live_race(ctx, opts):
             logging.info("Car %s: class %r", ctx.car_number, class_name)
             push_influx(ctx, laps, False, competitor_name=competitor_name, car_info=car_info,
                         class_name=class_name, class_positions=None, session_id=live_session_id)
+        push_influx_standings_live(ctx, session_response, live_session_id)
 
     if opts.save_file:
         # Create filename and call function to write to CSV
@@ -600,6 +601,9 @@ def monitor_routine(ctx, laps, opts, competitor_name=None, car_info=None, _stop_
                             ctx, session_id, session_response['Session'].get('Name'), None)
             else:
                 logging.debug("get_session returned unsuccessful; may be between sessions")
+
+            if opts.network_mode:
+                push_influx_standings_live(ctx, session_response, session_id)
 
             if poll_count % _LIVE_CHECK_INTERVAL == 0:
                 try:

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -979,6 +979,26 @@ def _resolve_class_live(session_response, car_number):
     return class_name, class_position
 
 
+def _compute_class_positions_live(session_response):
+    """Return {car_number: class_position} for all live competitors in one pass."""
+    if not session_response.get('Successful'):
+        return {}
+    competitors = session_response['Session']['Competitors']
+    by_class = defaultdict(list)
+    for comp in competitors.values():
+        try:
+            pos = int(comp['Position'])
+        except (ValueError, TypeError):
+            continue
+        by_class[comp['ClassID']].append((pos, comp['Number']))
+    result = {}
+    for entries in by_class.values():
+        entries.sort()
+        for rank, (_, car_number) in enumerate(entries, 1):
+            result[car_number] = rank
+    return result
+
+
 def _resolve_race_metadata(race_details, client):
     """Resolve race-level metadata from race details and a single series lookup."""
     if not race_details.get('Successful'):

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -206,6 +206,51 @@ class TestMonitorRoutine:
         captured = capsys.readouterr()
         assert 'Monitoring stopped' in captured.out
 
+    def test_standings_written_each_poll_in_network_mode(self):
+        stop = threading.Event()
+        ctx = _mod.RaceContext('123', '42', MagicMock(), MagicMock(), 0)
+        opts = _mod.RaceOptions(network_mode=True, interval=0)
+
+        call_count = 0
+        def fake_get_session(race_id):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                stop.set()
+            return {'Successful': True, 'Session': {
+                'ID': 'sess-1', 'Name': 'S', 'Competitors': {}, 'Classes': {}}}
+
+        ctx.client.live.get_session.side_effect = fake_get_session
+
+        with patch.object(_mod, 'refresh_competitor', return_value=[]):
+            with patch.object(_mod, 'push_influx_standings_live') as mock_standings:
+                with patch.object(_mod, 'push_influx'):
+                    _mod.monitor_routine(ctx, [], opts, _stop_event=stop)
+
+        mock_standings.assert_called_once_with(ctx, mock_standings.call_args[0][1], 'sess-1')
+
+    def test_standings_not_written_when_not_network_mode(self):
+        stop = threading.Event()
+        ctx = _mod.RaceContext('123', '42', MagicMock(), None, 0)
+        opts = _mod.RaceOptions(network_mode=False, interval=0)
+
+        call_count = 0
+        def fake_get_session(race_id):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                stop.set()
+            return {'Successful': True, 'Session': {
+                'ID': 'sess-1', 'Name': 'S', 'Competitors': {}, 'Classes': {}}}
+
+        ctx.client.live.get_session.side_effect = fake_get_session
+
+        with patch.object(_mod, 'refresh_competitor', return_value=[]):
+            with patch.object(_mod, 'push_influx_standings_live') as mock_standings:
+                _mod.monitor_routine(ctx, [], opts, _stop_event=stop)
+
+        mock_standings.assert_not_called()
+
 
 class TestWriteCSV:
     def test_opens_file_with_correct_name(self):
@@ -929,6 +974,61 @@ class TestLiveRace:
                 with patch.object(_mod, 'push_influx_race'):
                     _mod.live_race(ctx, opts)
         assert ctx.client.live.get_session.call_count == 1
+
+
+class TestLiveRaceStandingsWrite:
+    def test_standings_written_at_startup_in_network_mode(self):
+        ctx = _mod.RaceContext('123', '42', MagicMock(), MagicMock(), 1000)
+        ctx.metadata = _mod.RaceMetadata('Race', 'Track', None, 9999)
+        opts = _mod.RaceOptions(network_mode=True, monitor_mode=False, interval=30)
+
+        session_resp = {'Successful': True, 'Session': {
+            'ID': 'sess-1', 'Name': 'S', 'Competitors': {}, 'Classes': {}}}
+        ctx.client.live.get_session.return_value = session_resp
+        ctx.client.live.get_racer.return_value = {
+            'Successful': True,
+            'Details': {
+                'Competitor': {
+                    'FirstName': 'Ben', 'LastName': 'K', 'Number': '42',
+                    'Transponder': 'T', 'BestPosition': '1', 'Position': '1',
+                    'Laps': '5', 'BestLap': '3', 'BestLapTime': '1:30.000',
+                    'TotalTime': '10:00.000', 'AdditionalData': None,
+                },
+                'Laps': [],
+            },
+        }
+
+        with patch.object(_mod, 'push_influx_race'):
+            with patch.object(_mod, 'push_influx_session'):
+                with patch.object(_mod, 'push_influx'):
+                    with patch.object(_mod, 'push_influx_standings_live') as mock_standings:
+                        _mod.live_race(ctx, opts)
+
+        mock_standings.assert_called_once_with(ctx, session_resp, 'sess-1')
+
+    def test_standings_not_written_at_startup_when_not_network_mode(self):
+        ctx = _mod.RaceContext('123', '42', MagicMock(), None, 1000)
+        opts = _mod.RaceOptions(network_mode=False, monitor_mode=False, interval=30)
+
+        ctx.client.live.get_session.return_value = {'Successful': True, 'Session': {
+            'ID': 'sess-1', 'Name': 'S', 'Competitors': {}, 'Classes': {}}}
+        ctx.client.live.get_racer.return_value = {
+            'Successful': True,
+            'Details': {
+                'Competitor': {
+                    'FirstName': 'Ben', 'LastName': 'K', 'Number': '42',
+                    'Transponder': 'T', 'BestPosition': '1', 'Position': '1',
+                    'Laps': '5', 'BestLap': '3', 'BestLapTime': '1:30.000',
+                    'TotalTime': '10:00.000', 'AdditionalData': None,
+                },
+                'Laps': [],
+            },
+        }
+
+        with patch.object(_mod, 'push_influx_standings_live') as mock_standings:
+            _mod.live_race(ctx, opts)
+
+        mock_standings.assert_not_called()
 
 
 class TestOldRaceClassWiring:

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -227,7 +227,7 @@ class TestMonitorRoutine:
                 with patch.object(_mod, 'push_influx'):
                     _mod.monitor_routine(ctx, [], opts, _stop_event=stop)
 
-        mock_standings.assert_called_once_with(ctx, mock_standings.call_args[0][1], 'sess-1')
+        mock_standings.assert_called_once_with(ctx, mock_standings.call_args[0][1], 'sess-1', {})
 
     def test_standings_not_written_when_not_network_mode(self):
         stop = threading.Event()
@@ -250,6 +250,36 @@ class TestMonitorRoutine:
                 _mod.monitor_routine(ctx, [], opts, _stop_event=stop)
 
         mock_standings.assert_not_called()
+
+    def test_prev_standings_threaded_back_each_poll(self):
+        """Verify monitor_routine passes the return value of each standings call
+        back as prev_standings on the subsequent poll."""
+        stop = threading.Event()
+        ctx = _mod.RaceContext('123', '42', MagicMock(), MagicMock(), 0)
+        opts = _mod.RaceOptions(network_mode=True, interval=0)
+        sentinel = {'42': (1, 5, None, None, None)}
+
+        call_count = 0
+        def fake_get_session(race_id):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                stop.set()
+            return {'Successful': True, 'Session': {
+                'ID': 'sess-1', 'Name': 'S', 'Competitors': {}, 'Classes': {}}}
+
+        ctx.client.live.get_session.side_effect = fake_get_session
+
+        # First call returns sentinel; second call should receive it as prev_standings.
+        mock_standings = MagicMock(return_value=sentinel)
+        with patch.object(_mod, 'refresh_competitor', return_value=[]):
+            with patch.object(_mod, 'push_influx_standings_live', mock_standings):
+                with patch.object(_mod, 'push_influx'):
+                    _mod.monitor_routine(ctx, [], opts, _stop_event=stop)
+
+        assert mock_standings.call_count == 2
+        _, _, _, second_prev = mock_standings.call_args_list[1][0]
+        assert second_prev == sentinel
 
 
 class TestWriteCSV:
@@ -2476,6 +2506,72 @@ class TestPushInfluxStandingsLive:
         with patch.object(_mod, '_write_points_chunked') as mock_write:
             _mod.push_influx_standings_live(ctx, {'Successful': False}, 'sess-1')
         mock_write.assert_not_called()
+
+    def test_returns_curr_standings_dict(self):
+        ctx = _mod.RaceContext('123', None, MagicMock(), MagicMock(), 0)
+        resp = self._resp([self._comp('42', position='1'), self._comp('7', position='2')])
+        with patch.object(_mod, '_write_points_chunked'):
+            result = _mod.push_influx_standings_live(ctx, resp, 'sess-1')
+        assert '42' in result
+        assert '7' in result
+
+    def test_unchanged_standings_skips_write(self):
+        ctx = _mod.RaceContext('123', None, MagicMock(), MagicMock(), 0)
+        resp = self._resp([self._comp('42', position='1', laps='5'),
+                           self._comp('7', position='2', laps='5')])
+        with patch.object(_mod, '_write_points_chunked') as mock_write:
+            prev = _mod.push_influx_standings_live(ctx, resp, 'sess-1')
+        mock_write.assert_called_once()
+        with patch.object(_mod, '_write_points_chunked') as mock_write2:
+            _mod.push_influx_standings_live(ctx, resp, 'sess-1', prev)
+        mock_write2.assert_not_called()
+
+    def test_any_position_change_writes_all_competitors(self):
+        ctx = _mod.RaceContext('123', None, MagicMock(), MagicMock(), 0)
+        resp1 = self._resp([self._comp('42', position='2', laps='5'),
+                            self._comp('7', position='1', laps='5')])
+        resp2 = self._resp([self._comp('42', position='1', laps='5'),
+                            self._comp('7', position='2', laps='5')])
+        with patch.object(_mod, '_write_points_chunked'):
+            prev = _mod.push_influx_standings_live(ctx, resp1, 'sess-1')
+        with patch.object(_mod, '_write_points_chunked') as mock_write:
+            _mod.push_influx_standings_live(ctx, resp2, 'sess-1', prev)
+        mock_write.assert_called_once()
+        assert len(mock_write.call_args[0][1]) == 2
+
+    def test_new_lap_triggers_write(self):
+        ctx = _mod.RaceContext('123', None, MagicMock(), MagicMock(), 0)
+        resp1 = self._resp([self._comp('42', position='1', laps='5')])
+        resp2 = self._resp([self._comp('42', position='1', laps='6')])
+        with patch.object(_mod, '_write_points_chunked'):
+            prev = _mod.push_influx_standings_live(ctx, resp1, 'sess-1')
+        with patch.object(_mod, '_write_points_chunked') as mock_write:
+            _mod.push_influx_standings_live(ctx, resp2, 'sess-1', prev)
+        mock_write.assert_called_once()
+
+    def test_none_prev_standings_writes_all(self):
+        ctx = _mod.RaceContext('123', None, MagicMock(), MagicMock(), 0)
+        resp = self._resp([self._comp('42'), self._comp('7', position='2')])
+        with patch.object(_mod, '_write_points_chunked') as mock_write:
+            _mod.push_influx_standings_live(ctx, resp, 'sess-1', None)
+        mock_write.assert_called_once()
+        assert len(mock_write.call_args[0][1]) == 2
+
+    def test_unsuccessful_response_returns_prev_standings(self):
+        ctx = _mod.RaceContext('123', None, MagicMock(), MagicMock(), 0)
+        prev = {'42': (1, 5, None, None, None)}
+        result = _mod.push_influx_standings_live(ctx, {'Successful': False}, 'sess-1', prev)
+        assert result == prev
+
+    def test_write_failure_returns_prev_standings_for_retry(self):
+        ctx = _mod.RaceContext('123', None, MagicMock(), MagicMock(), 0)
+        resp1 = self._resp([self._comp('42', position='1', laps='5')])
+        resp2 = self._resp([self._comp('42', position='1', laps='6')])
+        with patch.object(_mod, '_write_points_chunked'):
+            prev = _mod.push_influx_standings_live(ctx, resp1, 'sess-1')
+        with patch.object(_mod, '_write_points_chunked', side_effect=Exception("influx down")):
+            result = _mod.push_influx_standings_live(ctx, resp2, 'sess-1', prev)
+        assert result == prev
 
 
 class TestPushInfluxStandingsHistorical:

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -1226,7 +1226,8 @@ class TestOldRaceClassWiring:
                                           return_value=('A', {1: 1})):
                             _mod.old_race(ctx, opts)
         mock_del.assert_called_once_with(ctx)
-        assert order == ['delete', 'write']
+        assert order[0] == 'delete'
+        assert 'write' in order
 
     def test_delete_fires_once_across_multiple_sessions(self):
         ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
@@ -2475,3 +2476,85 @@ class TestPushInfluxStandingsLive:
         with patch.object(_mod, '_write_points_chunked') as mock_write:
             _mod.push_influx_standings_live(ctx, {'Successful': False}, 'sess-1')
         mock_write.assert_not_called()
+
+
+class TestPushInfluxStandingsHistorical:
+    def _entry(self, competitors):
+        return {
+            'session_id': 101,
+            'session_name': 'Race',
+            'start_epoc': 1700000000,
+            'competitors': competitors,
+        }
+
+    def _comp(self, car_number='42', position='3', laps='50', class_name='B',
+              class_positions=None, best='1:30.000', last='1:31.000'):
+        return {
+            'car_number': car_number,
+            'competitor_name': 'Ben K',
+            'car_info': None,
+            'class_name': class_name,
+            'class_positions': class_positions if class_positions is not None else {50: 2},
+            'influx_laps': [],
+            'final_position': position,
+            'final_laps': laps,
+            'best_lap_time': best,
+            'last_lap_time': last,
+        }
+
+    def test_writes_one_point_per_competitor(self):
+        ctx = _mod.RaceContext('123', None, MagicMock(), MagicMock(), 0)
+        entry = self._entry([self._comp('42'), self._comp('7', position='5')])
+        with patch.object(_mod, '_write_points_chunked') as mock_write:
+            _mod.push_influx_standings_historical(ctx, entry)
+        mock_write.assert_called_once()
+        assert len(mock_write.call_args[0][1]) == 2
+
+    def test_measurement_is_standings(self):
+        ctx = _mod.RaceContext('123', None, MagicMock(), MagicMock(), 0)
+        entry = self._entry([self._comp()])
+        with patch.object(_mod, '_write_points_chunked') as mock_write:
+            _mod.push_influx_standings_historical(ctx, entry)
+        lp = mock_write.call_args[0][1][0].to_line_protocol()
+        assert lp.startswith('standings,')
+
+    def test_uses_final_class_position(self):
+        ctx = _mod.RaceContext('123', None, MagicMock(), MagicMock(), 0)
+        comp = self._comp(class_positions={1: 3, 2: 2, 3: 1})
+        entry = self._entry([comp])
+        with patch.object(_mod, '_write_points_chunked') as mock_write:
+            _mod.push_influx_standings_historical(ctx, entry)
+        lp = mock_write.call_args[0][1][0].to_line_protocol()
+        assert 'class_position=1i' in lp
+
+    def test_session_id_tagged(self):
+        ctx = _mod.RaceContext('123', None, MagicMock(), MagicMock(), 0)
+        entry = self._entry([self._comp()])
+        with patch.object(_mod, '_write_points_chunked') as mock_write:
+            _mod.push_influx_standings_historical(ctx, entry)
+        lp = mock_write.call_args[0][1][0].to_line_protocol()
+        assert 'session_id=101' in lp
+
+    def test_non_numeric_position_skipped(self):
+        ctx = _mod.RaceContext('123', None, MagicMock(), MagicMock(), 0)
+        entry = self._entry([self._comp(position='DNF')])
+        with patch.object(_mod, '_write_points_chunked') as mock_write:
+            _mod.push_influx_standings_historical(ctx, entry)
+        mock_write.assert_not_called()
+
+    def test_unparseable_lap_times_omitted(self):
+        ctx = _mod.RaceContext('123', None, MagicMock(), MagicMock(), 0)
+        entry = self._entry([self._comp(best='', last='')])
+        with patch.object(_mod, '_write_points_chunked') as mock_write:
+            _mod.push_influx_standings_historical(ctx, entry)
+        lp = mock_write.call_args[0][1][0].to_line_protocol()
+        assert 'best_lap_time' not in lp
+        assert 'last_lap_time' not in lp
+
+    def test_empty_class_positions_omits_class_position_field(self):
+        ctx = _mod.RaceContext('123', None, MagicMock(), MagicMock(), 0)
+        entry = self._entry([self._comp(class_positions={})])
+        with patch.object(_mod, '_write_points_chunked') as mock_write:
+            _mod.push_influx_standings_historical(ctx, entry)
+        lp = mock_write.call_args[0][1][0].to_line_protocol()
+        assert 'class_position' not in lp

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -2249,3 +2249,56 @@ class TestDryRun:
         out = capsys.readouterr().out
         assert 'car 42' in out
         assert '2 laps' in out
+
+
+class TestComputeClassPositionsLive:
+    def _resp(self, competitors, classes=None):
+        return {
+            'Successful': True,
+            'Session': {
+                'Competitors': {str(i): c for i, c in enumerate(competitors)},
+                'Classes': classes or {},
+            },
+        }
+
+    def _comp(self, number, class_id, position):
+        return {'Number': number, 'ClassID': class_id, 'Position': position}
+
+    def test_single_class_ranked_by_position(self):
+        resp = self._resp([
+            self._comp('42', 'A', '1'),
+            self._comp('7',  'A', '2'),
+            self._comp('99', 'A', '3'),
+        ])
+        result = _mod._compute_class_positions_live(resp)
+        assert result == {'42': 1, '7': 2, '99': 3}
+
+    def test_multiple_classes_ranked_independently(self):
+        resp = self._resp([
+            self._comp('42', 'A', '1'),
+            self._comp('7',  'B', '2'),
+            self._comp('99', 'A', '3'),
+            self._comp('5',  'B', '4'),
+        ])
+        result = _mod._compute_class_positions_live(resp)
+        assert result['42'] == 1  # class A, overall 1st
+        assert result['99'] == 2  # class A, overall 3rd
+        assert result['7']  == 1  # class B, overall 2nd
+        assert result['5']  == 2  # class B, overall 4th
+
+    def test_non_numeric_position_excluded(self):
+        resp = self._resp([
+            self._comp('42', 'A', '1'),
+            self._comp('7',  'A', 'N/A'),
+        ])
+        result = _mod._compute_class_positions_live(resp)
+        assert '7' not in result
+        assert result['42'] == 1
+
+    def test_single_car_class_gets_position_1(self):
+        resp = self._resp([self._comp('42', 'A', '5')])
+        result = _mod._compute_class_positions_live(resp)
+        assert result == {'42': 1}
+
+    def test_unsuccessful_response_returns_empty(self):
+        assert _mod._compute_class_positions_live({'Successful': False}) == {}

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -2302,3 +2302,76 @@ class TestComputeClassPositionsLive:
 
     def test_unsuccessful_response_returns_empty(self):
         assert _mod._compute_class_positions_live({'Successful': False}) == {}
+
+
+class TestPushInfluxStandingsLive:
+    def _resp(self, competitors, classes=None):
+        return {
+            'Successful': True,
+            'Session': {
+                'Competitors': {str(i): c for i, c in enumerate(competitors)},
+                'Classes': classes or {},
+            },
+        }
+
+    def _comp(self, number='42', class_id='A', position='1', laps='5',
+              best='1:30.000', last='1:31.000'):
+        return {
+            'Number': number, 'ClassID': class_id, 'Position': position,
+            'Laps': laps, 'FirstName': 'Ben', 'LastName': 'K',
+            'AdditionalData': None, 'BestLapTime': best, 'LastLapTime': last,
+        }
+
+    def test_writes_one_point_per_competitor(self):
+        ctx = _mod.RaceContext('123', None, MagicMock(), MagicMock(), 0)
+        resp = self._resp([self._comp('42'), self._comp('7', position='2')])
+        with patch.object(_mod, '_write_points_chunked') as mock_write:
+            _mod.push_influx_standings_live(ctx, resp, 'sess-1')
+        mock_write.assert_called_once()
+        assert len(mock_write.call_args[0][1]) == 2
+
+    def test_measurement_is_standings(self):
+        ctx = _mod.RaceContext('123', None, MagicMock(), MagicMock(), 0)
+        resp = self._resp([self._comp()])
+        with patch.object(_mod, '_write_points_chunked') as mock_write:
+            _mod.push_influx_standings_live(ctx, resp, 'sess-1')
+        lp = mock_write.call_args[0][1][0].to_line_protocol()
+        assert lp.startswith('standings,')
+
+    def test_session_id_tagged(self):
+        ctx = _mod.RaceContext('123', None, MagicMock(), MagicMock(), 0)
+        resp = self._resp([self._comp()])
+        with patch.object(_mod, '_write_points_chunked') as mock_write:
+            _mod.push_influx_standings_live(ctx, resp, 'sess-99')
+        lp = mock_write.call_args[0][1][0].to_line_protocol()
+        assert 'session_id=sess-99' in lp
+
+    def test_session_id_none_omits_tag(self):
+        ctx = _mod.RaceContext('123', None, MagicMock(), MagicMock(), 0)
+        resp = self._resp([self._comp()])
+        with patch.object(_mod, '_write_points_chunked') as mock_write:
+            _mod.push_influx_standings_live(ctx, resp, None)
+        lp = mock_write.call_args[0][1][0].to_line_protocol()
+        assert 'session_id' not in lp
+
+    def test_non_numeric_position_skips_competitor(self):
+        ctx = _mod.RaceContext('123', None, MagicMock(), MagicMock(), 0)
+        resp = self._resp([self._comp(position='N/A')])
+        with patch.object(_mod, '_write_points_chunked') as mock_write:
+            _mod.push_influx_standings_live(ctx, resp, 'sess-1')
+        mock_write.assert_not_called()
+
+    def test_unparseable_lap_times_omitted(self):
+        ctx = _mod.RaceContext('123', None, MagicMock(), MagicMock(), 0)
+        resp = self._resp([self._comp(best='', last='')])
+        with patch.object(_mod, '_write_points_chunked') as mock_write:
+            _mod.push_influx_standings_live(ctx, resp, 'sess-1')
+        lp = mock_write.call_args[0][1][0].to_line_protocol()
+        assert 'best_lap_time' not in lp
+        assert 'last_lap_time' not in lp
+
+    def test_unsuccessful_response_writes_nothing(self):
+        ctx = _mod.RaceContext('123', None, MagicMock(), MagicMock(), 0)
+        with patch.object(_mod, '_write_points_chunked') as mock_write:
+            _mod.push_influx_standings_live(ctx, {'Successful': False}, 'sess-1')
+        mock_write.assert_not_called()


### PR DESCRIPTION
## Summary

- Adds `_compute_class_positions_live` — pure single-pass class ranking from `get_session()` response
- Adds `push_influx_standings_live` — writes one `standings` point per competitor each poll (in `monitor_routine`) and at live race startup (in `live_race`), guarded by `opts.network_mode`; skips the write when the whole-field snapshot is unchanged from the previous poll
- Adds `push_influx_standings_historical` — writes final standings per session during `old_race` backfill; four new fields added to competitor dicts (`final_position`, `final_laps`, `best_lap_time`, `last_lap_time`)
- Updates Grafana standings dashboard in the IAC repo to query from the `standings` measurement with `lap_count`, `best_lap_time`, `last_lap_time` columns (separate IAC commit)

## Test plan

- [ ] 229 tests pass (`uv run pytest -q`)
- [ ] Verify live standings appear in Grafana during a live race
- [ ] Verify historical standings appear after `old_race` backfill
- [ ] Confirm IAC dashboard deployed and standings panel shows correct class ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added standings tracking alongside lap updates for live sessions and historical backfills.
  * Live polling now records standings only when they change, reducing duplicate updates.
  * Historical race data now includes final position, lap counts, and lap-time details in standings records.

* **Bug Fixes**
  * Improved handling of session changes so live standings reset correctly between sessions.
  * Skips invalid or unparseable position and lap-time values instead of writing incomplete data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->