### PR TITLE
fix(laps): skip laps with corrupted lap numbers instead of crashing

### DIFF
--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -636,7 +636,12 @@ def monitor_routine(ctx, laps, opts, competitor_name=None, car_info=None, _stop_
                     if opts.network_mode:
                         class_name, class_position = _resolve_class_live(
                             session_response, ctx.car_number)
-                        new_lap_num = int(lap['Lap'])
+                        try:
+                            new_lap_num = int(lap['Lap'])
+                        except (ValueError, TypeError):
+                            logging.warning(
+                                "unparseable lap number %r in monitor; skipping", lap['Lap'])
+                            continue
                         class_positions = (
                             {new_lap_num: class_position} if class_position is not None else None)
                         push_influx(
@@ -709,7 +714,12 @@ def _build_lap_points(ctx, laps, competitor_name, car_info, class_name, class_po
     for lap in laps:
         time_lap_completed_ms = start_epoc_ms + (_time_to_ms(lap['TotalTime']) or 0)
         lap_time_ms = _time_to_ms(lap['LapTime'])
-        lap_num = int(lap['Lap'])
+        try:
+            lap_num = int(lap['Lap'])
+        except (ValueError, TypeError):
+            logging.warning("unparseable lap number %r for %s; skipping lap", lap['Lap'],
+                            competitor_name)
+            continue
         try:
             position = int(lap['Position'])
         except (ValueError, TypeError):

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -2720,3 +2720,25 @@ class TestMonitorRoutineCorruptedLapNumber:
                 with patch.object(_mod, 'push_influx') as mock_push:
                     _mod.monitor_routine(ctx, [], opts, _stop_event=stop)
         mock_push.assert_not_called()
+
+    def test_bad_lap_number_logs_warning_in_monitor(self, caplog):
+        stop = threading.Event()
+        ctx = self._ctx()
+        opts = _mod.RaceOptions(network_mode=True, interval=0)
+
+        corrupted_lap = {'Lap': '$J', 'LapTime': '0:01:30.000', 'Position': '3',
+                         'FlagStatus': 'Green', 'TotalTime': '0:01:30.000'}
+
+        call_count = 0
+        def fake_refresh(c):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                stop.set()
+            return [corrupted_lap]
+
+        with patch.object(_mod, 'refresh_competitor', side_effect=fake_refresh):
+            with patch.object(_mod, '_resolve_class_live', return_value=('A', 1)):
+                with caplog.at_level(logging.WARNING):
+                    _mod.monitor_routine(ctx, [], opts, _stop_event=stop)
+        assert any('$J' in r.message for r in caplog.records)

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -2654,3 +2654,69 @@ class TestPushInfluxStandingsHistorical:
             _mod.push_influx_standings_historical(ctx, entry)
         lp = mock_write.call_args[0][1][0].to_line_protocol()
         assert 'class_position' not in lp
+
+
+class TestBuildLapPointsCorruptedLapNumber:
+    """Corrupted Lap field (e.g. '$J') must not crash the write — the lap is skipped."""
+
+    def _ctx(self):
+        write_api = MagicMock()
+        ctx = _mod.RaceContext('999', '42', MagicMock(), write_api, 0)
+        return ctx, write_api
+
+    def _lap(self, lap_num='1'):
+        return {'Lap': lap_num, 'LapTime': '0:01:30.000', 'Position': '3',
+                'FlagStatus': 'Green', 'TotalTime': '0:01:30.000'}
+
+    def test_skips_lap_when_lap_number_unparseable(self):
+        ctx, write_api = self._ctx()
+        laps = [self._lap('$J')]
+        _mod.push_influx(ctx, laps, False)
+        write_api.write.assert_not_called()
+
+    def test_logs_warning_when_lap_number_unparseable(self, caplog):
+        ctx, _ = self._ctx()
+        with caplog.at_level(logging.WARNING):
+            _mod.push_influx(ctx, [self._lap('$J')], False)
+        assert any('$J' in r.message for r in caplog.records)
+
+    def test_other_laps_still_written_when_one_has_bad_lap_number(self):
+        ctx, write_api = self._ctx()
+        laps = [self._lap('$J'), self._lap('2')]
+        _mod.push_influx(ctx, laps, False)
+        write_api.write.assert_called_once()
+        record = write_api.write.call_args[1]['record']
+        assert len(record) == 1
+        assert 'lap_no=2i' in record[0].to_line_protocol()
+
+
+class TestMonitorRoutineCorruptedLapNumber:
+    """A new lap with a corrupted Lap field must not crash the monitor loop."""
+
+    def _ctx(self):
+        write_api = MagicMock()
+        ctx = _mod.RaceContext('999', '42', MagicMock(), write_api, 0)
+        ctx.client.live.get_session.return_value = {'Successful': False}
+        return ctx
+
+    def test_bad_lap_number_does_not_crash_monitor_in_network_mode(self):
+        stop = threading.Event()
+        ctx = self._ctx()
+        opts = _mod.RaceOptions(network_mode=True, interval=0)
+
+        corrupted_lap = {'Lap': '$J', 'LapTime': '0:01:30.000', 'Position': '3',
+                         'FlagStatus': 'Green', 'TotalTime': '0:01:30.000'}
+
+        call_count = 0
+        def fake_refresh(c):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                stop.set()
+            return [corrupted_lap]
+
+        with patch.object(_mod, 'refresh_competitor', side_effect=fake_refresh):
+            with patch.object(_mod, '_resolve_class_live', return_value=('A', 1)):
+                with patch.object(_mod, 'push_influx') as mock_push:
+                    _mod.monitor_routine(ctx, [], opts, _stop_event=stop)
+        mock_push.assert_not_called()


### PR DESCRIPTION
## Summary

- \`int(lap['Lap'])\` was unguarded in both \`_build_lap_points\` and \`monitor_routine\`
- When the RaceMonitor API returns a corrupted value like \`'$J'\` or \`'$G'\` for the lap number, this raised \`ValueError\`, aborting the entire historical race write or crashing the monitor loop
- Both sites now catch \`ValueError\`/\`TypeError\`, log a warning, and skip the affected lap — consistent with existing handling for \`Position\` and \`LapTime\`

## Root cause

The error observed in production:
\`\`\`
ERROR - Writing laps failed for race 83203: invalid literal for int() with base 10: '$J'
WARNING - Skipping race stamp so next run will re-backfill
\`\`\`

\`_build_lap_points\` raised from \`int(lap['Lap'])\`, propagated uncaught to \`old_race\`'s broad \`except Exception\`, which logged the error and returned without stamping the race (correct recovery behavior, wrong root cause).

The \`monitor_routine\` site had the same bug but would have crashed the process entirely (no \`except Exception\` there).

## Test plan

- [x] \`TestBuildLapPointsCorruptedLapNumber::test_skips_lap_when_lap_number_unparseable\`
- [x] \`TestBuildLapPointsCorruptedLapNumber::test_logs_warning_when_lap_number_unparseable\`
- [x] \`TestBuildLapPointsCorruptedLapNumber::test_other_laps_still_written_when_one_has_bad_lap_number\`
- [x] \`TestMonitorRoutineCorruptedLapNumber::test_bad_lap_number_does_not_crash_monitor_in_network_mode\`
- [x] \`TestMonitorRoutineCorruptedLapNumber::test_bad_lap_number_logs_warning_in_monitor\`
- [x] Full suite: 343 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)