### PR TITLE
feat: integrate race-monitor 0.6.0 (multi-token load balancing + streaming command logging)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "influxdb-client~=1.47",
     "obd~=0.7",
     "pandas~=2.3",
-    "race-monitor>=0.5.1,<1",
+    "race-monitor>=0.6.0,<1",
 ]
 
 [project.urls]

--- a/src/lemongrass/_env.py
+++ b/src/lemongrass/_env.py
@@ -7,5 +7,8 @@ def resolve_tokens() -> str | list[str]:
     multi = os.environ.get('RACEMONITOR_TOKENS')
     if multi:
         tokens = [t.strip() for t in multi.split(',') if t.strip()]
-        return tokens if len(tokens) > 1 else (tokens[0] if tokens else '')
+        if len(tokens) > 1:
+            return tokens
+        if tokens:
+            return tokens[0]
     return os.environ.get('RACEMONITOR_TOKEN', '')

--- a/src/lemongrass/_env.py
+++ b/src/lemongrass/_env.py
@@ -1,0 +1,11 @@
+"""Environment variable helpers shared across lemongrass commands."""
+import os
+
+
+def resolve_tokens() -> str | list[str]:
+    """Return tokens from RACEMONITOR_TOKENS (comma-separated) or fall back to RACEMONITOR_TOKEN."""
+    multi = os.environ.get('RACEMONITOR_TOKENS')
+    if multi:
+        tokens = [t.strip() for t in multi.split(',') if t.strip()]
+        return tokens if len(tokens) > 1 else (tokens[0] if tokens else '')
+    return os.environ.get('RACEMONITOR_TOKEN', '')

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -53,6 +53,15 @@ _WRITE_BATCH_SIZE = 5000
 _LIVE_CHECK_INTERVAL = 5
 
 
+def _resolve_tokens() -> str | list[str]:
+    """Return tokens from RACEMONITOR_TOKENS (comma-separated) or fall back to RACEMONITOR_TOKEN."""
+    multi = os.environ.get('RACEMONITOR_TOKENS')
+    if multi:
+        tokens = [t.strip() for t in multi.split(',') if t.strip()]
+        return tokens if len(tokens) > 1 else (tokens[0] if tokens else '')
+    return os.environ.get('RACEMONITOR_TOKEN', '')
+
+
 class MonitorStatus(enum.Enum):
     """Return values from monitor_routine indicating how polling ended."""
 
@@ -147,9 +156,9 @@ def main():
     # Pandas default max rows truncating lap times. I don't expect a team to do more than 1024 laps.
     pandas.set_option("display.max_rows", 1024)
 
-    token = os.environ.get('RACEMONITOR_TOKEN')
-    if not token:
-        logging.error("RACEMONITOR_TOKEN environment variable not set")
+    tokens = _resolve_tokens()
+    if not tokens:
+        logging.error("RACEMONITOR_TOKENS or RACEMONITOR_TOKEN environment variable not set")
         sys.exit(1)
 
     influx_token = None
@@ -173,7 +182,7 @@ def main():
     )
 
     try:
-        with RaceMonitorClient(api_token=token) as client:
+        with RaceMonitorClient(api_token=tokens) as client:
             race_details = client.race.details(race_id)
 
             start_epoc = 0

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -12,7 +12,6 @@
 #   writes are the during-race approximation; the backfill makes the final record authoritative.
 
 import argparse
-import contextlib
 import csv
 import enum
 import logging
@@ -27,7 +26,7 @@ from datetime import datetime, timezone
 import pandas
 from influxdb_client import InfluxDBClient, Point, WritePrecision
 from influxdb_client.client.write_api import SYNCHRONOUS
-from race_monitor import RaceMonitorClient
+from race_monitor import RaceMonitorClient, get_streaming_command
 
 UNDERLINE = "-" * 80
 
@@ -60,6 +59,17 @@ def _resolve_tokens() -> str | list[str]:
         tokens = [t.strip() for t in multi.split(',') if t.strip()]
         return tokens if len(tokens) > 1 else (tokens[0] if tokens else '')
     return os.environ.get('RACEMONITOR_TOKEN', '')
+
+
+def _describe_bad_value(value: object, field: str) -> str:
+    """Return a log string distinguishing known streaming tokens from random garbage."""
+    cmd = get_streaming_command(value)
+    if cmd is not None:
+        return (
+            f"streaming command token {value!r} ({cmd.name}) in {field} field"
+            " — known API quirk, not data corruption"
+        )
+    return f"unparseable {field} value {value!r}"
 
 
 class MonitorStatus(enum.Enum):
@@ -649,7 +659,8 @@ def monitor_routine(ctx, laps, opts, competitor_name=None, car_info=None, _stop_
                             new_lap_num = int(lap['Lap'])
                         except (ValueError, TypeError):
                             logging.warning(
-                                "unparseable lap number %r in monitor; skipping", lap['Lap'])
+                                "%s in monitor; skipping",
+                                _describe_bad_value(lap['Lap'], 'Lap'))
                             continue
                         class_positions = (
                             {new_lap_num: class_position} if class_position is not None else None)
@@ -697,7 +708,7 @@ def _time_to_ms(value):
         minutes = int(parts[-2]) if len(parts) >= 2 else 0
         return hours * 3600000 + minutes * 60000 + int(sec) * 1000 + int(ms or 0)
     except (ValueError, AttributeError):
-        logging.warning("unparseable lap time %r; omitting field", value)
+        logging.warning("%s; omitting field", _describe_bad_value(value, 'time'))
         return None
 
 
@@ -726,15 +737,15 @@ def _build_lap_points(ctx, laps, competitor_name, car_info, class_name, class_po
         try:
             lap_num = int(lap['Lap'])
         except (ValueError, TypeError):
-            logging.warning("unparseable lap number %r for %s; skipping lap", lap['Lap'],
-                            competitor_name)
+            logging.warning("%s for %s; skipping lap",
+                            _describe_bad_value(lap['Lap'], 'Lap'), competitor_name)
             continue
         try:
             position = int(lap['Position'])
         except (ValueError, TypeError):
             logging.warning(
-                "unparseable position %r on lap %s for %s; omitting field",
-                lap['Position'], lap_num, competitor_name,
+                "%s on lap %s for %s; omitting field",
+                _describe_bad_value(lap['Position'], 'Position'), lap_num, competitor_name,
             )
             position = None
         point = (
@@ -927,8 +938,11 @@ def _resolve_class_historical(car_number, session_details):
         if competitor['Number'] == car_number:
             tracked_category = competitor['Category']
             for lap in competitor['LapTimes']:
-                with contextlib.suppress(ValueError, TypeError):
+                try:
                     tracked_laps[int(lap['Lap'])] = int(lap['Position'])
+                except (ValueError, TypeError):
+                    logging.debug("%s in class resolution; skipping",
+                                  _describe_bad_value(lap['Lap'], 'Lap'))
             break
 
     if tracked_category is None:
@@ -944,8 +958,11 @@ def _resolve_class_historical(car_number, session_details):
         if competitor['Number'] == car_number or competitor['Category'] != tracked_category:
             continue
         for lap in competitor['LapTimes']:
-            with contextlib.suppress(ValueError, TypeError):
+            try:
                 class_lap_positions[int(lap['Lap'])].append(int(lap['Position']))
+            except (ValueError, TypeError):
+                logging.debug("%s in class position resolution; skipping",
+                              _describe_bad_value(lap['Lap'], 'Lap'))
 
     class_positions = {
         lap_num: 1 + sum(1 for pos in class_lap_positions.get(lap_num, []) if pos < tracked_pos)

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -28,6 +28,8 @@ from influxdb_client import InfluxDBClient, Point, WritePrecision
 from influxdb_client.client.write_api import SYNCHRONOUS
 from race_monitor import RaceMonitorClient, get_streaming_command
 
+from lemongrass._env import resolve_tokens
+
 UNDERLINE = "-" * 80
 
 EPOCH_START = '1970-01-01T00:00:00Z'
@@ -50,15 +52,6 @@ SCHEMA_VERSION = 3
 
 _WRITE_BATCH_SIZE = 5000
 _LIVE_CHECK_INTERVAL = 5
-
-
-def _resolve_tokens() -> str | list[str]:
-    """Return tokens from RACEMONITOR_TOKENS (comma-separated) or fall back to RACEMONITOR_TOKEN."""
-    multi = os.environ.get('RACEMONITOR_TOKENS')
-    if multi:
-        tokens = [t.strip() for t in multi.split(',') if t.strip()]
-        return tokens if len(tokens) > 1 else (tokens[0] if tokens else '')
-    return os.environ.get('RACEMONITOR_TOKEN', '')
 
 
 def _describe_bad_value(value: object, field: str) -> str:
@@ -166,7 +159,7 @@ def main():
     # Pandas default max rows truncating lap times. I don't expect a team to do more than 1024 laps.
     pandas.set_option("display.max_rows", 1024)
 
-    tokens = _resolve_tokens()
+    tokens = resolve_tokens()
     if not tokens:
         logging.error("RACEMONITOR_TOKENS or RACEMONITOR_TOKEN environment variable not set")
         sys.exit(1)

--- a/src/lemongrass/race_backfill.py
+++ b/src/lemongrass/race_backfill.py
@@ -34,7 +34,8 @@ Usage:
     lemongrass race-backfill --upgrade-stored
 
 Required environment variables:
-    RACEMONITOR_TOKEN      — RaceMonitor API token (always required)
+    RACEMONITOR_TOKENS     — comma-separated RaceMonitor API tokens (preferred)
+    RACEMONITOR_TOKEN      — single RaceMonitor API token (fallback)
     INFLUX_TELEMETRY_TOKEN — InfluxDB token (read-only sufficient for --validate;
                              full backfill requires write access via the laps command)
 """
@@ -47,6 +48,8 @@ import sys
 from datetime import datetime, timezone
 
 from race_monitor import RaceMonitorClient
+
+from lemongrass._env import resolve_tokens
 
 LEMONS_SEARCH_TERMS = ['Real Hoopties', 'GP du Lac', 'Halloween Hoop']
 DEFAULT_CAR_NUMBER = '252'
@@ -306,8 +309,7 @@ def main():
             sys.exit(130)
         sys.exit(1 if failures else 0)
 
-    from lemongrass.laps import _resolve_tokens
-    tokens = _resolve_tokens()
+    tokens = resolve_tokens()
     if not tokens:
         logging.error("RACEMONITOR_TOKENS or RACEMONITOR_TOKEN environment variable not set")
         sys.exit(1)

--- a/src/lemongrass/race_backfill.py
+++ b/src/lemongrass/race_backfill.py
@@ -306,15 +306,16 @@ def main():
             sys.exit(130)
         sys.exit(1 if failures else 0)
 
-    token = os.environ.get('RACEMONITOR_TOKEN')
-    if not token:
-        logging.error("RACEMONITOR_TOKEN environment variable not set")
+    from lemongrass.laps import _resolve_tokens
+    tokens = _resolve_tokens()
+    if not tokens:
+        logging.error("RACEMONITOR_TOKENS or RACEMONITOR_TOKEN environment variable not set")
         sys.exit(1)
 
     start_year_epoc = int(datetime(args.start_year, 1, 1, tzinfo=timezone.utc).timestamp())
 
     try:
-        with RaceMonitorClient(api_token=token) as client:
+        with RaceMonitorClient(api_token=tokens) as client:
             races = find_matching_races(client, start_year_epoc)
             logging.info("Found %d matching races", len(races))
 

--- a/src/lemongrass/race_diagnose.py
+++ b/src/lemongrass/race_diagnose.py
@@ -15,7 +15,8 @@ Example:
     lemongrass race-diagnose 144185 252
 
 Required environment variables:
-    RACEMONITOR_TOKEN      — RaceMonitor API token
+    RACEMONITOR_TOKENS     — comma-separated RaceMonitor API tokens (preferred)
+    RACEMONITOR_TOKEN      — single RaceMonitor API token (fallback)
     INFLUX_TELEMETRY_TOKEN — InfluxDB read token
 """
 
@@ -25,6 +26,8 @@ from datetime import datetime, timezone
 
 from influxdb_client import InfluxDBClient
 from race_monitor import RaceMonitorClient
+
+from lemongrass._env import resolve_tokens
 
 INFLUX_URL = 'https://influxdb.focism.com'
 INFLUX_ORG = 'focism'
@@ -121,11 +124,11 @@ def main():
 
     race_id, car_number = sys.argv[1], sys.argv[2]
 
-    rm_token = os.environ.get('RACEMONITOR_TOKEN')
+    rm_token = resolve_tokens()
     influx_token = os.environ.get('INFLUX_TELEMETRY_TOKEN')
 
     if not rm_token:
-        print("RACEMONITOR_TOKEN not set")
+        print("RACEMONITOR_TOKENS or RACEMONITOR_TOKEN not set")
         sys.exit(1)
     if not influx_token:
         print("INFLUX_TELEMETRY_TOKEN not set")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,8 @@ for _mod in [
 # The real get_streaming_command is needed for _describe_bad_value tests.
 # Temporarily remove the mock, import the real module, copy the function, restore.
 _race_monitor_mock = sys.modules.pop('race_monitor')
+# NOTE: if `import race_monitor` raises here, sys.modules['race_monitor'] is not restored;
+# safe because race-monitor is a hard pyproject.toml dependency.
 import race_monitor as _real_race_monitor  # noqa: E402
 _race_monitor_mock.get_streaming_command = _real_race_monitor.get_streaming_command
 sys.modules['race_monitor'] = _race_monitor_mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,3 +7,11 @@ for _mod in [
     'race_monitor',
 ]:
     sys.modules.setdefault(_mod, MagicMock())
+
+# The real get_streaming_command is needed for _describe_bad_value tests.
+# Temporarily remove the mock, import the real module, copy the function, restore.
+_race_monitor_mock = sys.modules.pop('race_monitor')
+import race_monitor as _real_race_monitor  # noqa: E402
+_race_monitor_mock.get_streaming_command = _real_race_monitor.get_streaming_command
+sys.modules['race_monitor'] = _race_monitor_mock
+del _real_race_monitor

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,9 +11,10 @@ for _mod in [
 # The real get_streaming_command is needed for _describe_bad_value tests.
 # Temporarily remove the mock, import the real module, copy the function, restore.
 _race_monitor_mock = sys.modules.pop('race_monitor')
-# NOTE: if `import race_monitor` raises here, sys.modules['race_monitor'] is not restored;
-# safe because race-monitor is a hard pyproject.toml dependency.
-import race_monitor as _real_race_monitor  # noqa: E402
-_race_monitor_mock.get_streaming_command = _real_race_monitor.get_streaming_command
-sys.modules['race_monitor'] = _race_monitor_mock
-del _real_race_monitor
+try:
+    import race_monitor as _real_race_monitor
+
+    _race_monitor_mock.get_streaming_command = _real_race_monitor.get_streaming_command
+    del _real_race_monitor
+finally:
+    sys.modules['race_monitor'] = _race_monitor_mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,5 +16,8 @@ try:
 
     _race_monitor_mock.get_streaming_command = _real_race_monitor.get_streaming_command
     del _real_race_monitor
+except ImportError:
+    sys.modules['race_monitor'] = _race_monitor_mock
+    raise
 finally:
     sys.modules['race_monitor'] = _race_monitor_mock

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import threading
 from typing import ClassVar
 from unittest.mock import MagicMock, call, mock_open, patch
@@ -6,6 +7,45 @@ from unittest.mock import MagicMock, call, mock_open, patch
 import pytest
 
 import lemongrass.laps as _mod
+
+
+class TestResolveTokens:
+    def test_multi_tokens_returns_list(self):
+        with patch.dict(os.environ, {'RACEMONITOR_TOKENS': 'TOKEN1,TOKEN2'}, clear=True):
+            result = _mod._resolve_tokens()
+        assert result == ['TOKEN1', 'TOKEN2']
+
+    def test_single_racemonitor_tokens_returns_string(self):
+        with patch.dict(os.environ, {'RACEMONITOR_TOKENS': 'TOKEN1'}, clear=True):
+            result = _mod._resolve_tokens()
+        assert result == 'TOKEN1'
+
+    def test_falls_back_to_racemonitor_token(self):
+        with patch.dict(os.environ, {'RACEMONITOR_TOKEN': 'FALLBACK'}, clear=True):
+            result = _mod._resolve_tokens()
+        assert result == 'FALLBACK'
+
+    def test_returns_empty_string_when_neither_set(self):
+        with patch.dict(os.environ, {}, clear=True):
+            result = _mod._resolve_tokens()
+        assert result == ''
+
+    def test_racemonitor_tokens_takes_priority(self):
+        with patch.dict(os.environ,
+                        {'RACEMONITOR_TOKENS': 'MULTI1,MULTI2', 'RACEMONITOR_TOKEN': 'SINGLE'},
+                        clear=True):
+            result = _mod._resolve_tokens()
+        assert result == ['MULTI1', 'MULTI2']
+
+    def test_strips_whitespace_from_tokens(self):
+        with patch.dict(os.environ, {'RACEMONITOR_TOKENS': ' TOKEN1 , TOKEN2 '}, clear=True):
+            result = _mod._resolve_tokens()
+        assert result == ['TOKEN1', 'TOKEN2']
+
+    def test_whitespace_only_racemonitor_tokens_returns_empty_string(self):
+        with patch.dict(os.environ, {'RACEMONITOR_TOKENS': '  ,  , '}, clear=True):
+            result = _mod._resolve_tokens()
+        assert result == ''
 
 
 class TestIntervalArg:

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -321,6 +321,28 @@ class TestMonitorRoutine:
         _, _, _, second_prev = mock_standings.call_args_list[1][0]
         assert second_prev == sentinel
 
+    def test_skips_lap_with_streaming_command_number_and_logs_command_name(self, caplog):
+        import logging
+        stop = threading.Event()
+        ctx = _mod.RaceContext('123', '42', MagicMock(), MagicMock(), 0)
+        opts = _mod.RaceOptions(network_mode=True, interval=0)
+
+        bad_lap = {'Lap': '$J', 'LapTime': '1:00.000'}
+        call_count = 0
+
+        def fake_refresh(c):
+            nonlocal call_count
+            call_count += 1
+            stop.set()
+            return [bad_lap]
+
+        ctx.client.live.get_session.return_value = {'Successful': False}
+        with patch.object(_mod, 'refresh_competitor', side_effect=fake_refresh):
+            with caplog.at_level(logging.WARNING):
+                _mod.monitor_routine(ctx, [], opts, _stop_event=stop)
+
+        assert 'Passing Information' in caplog.text
+
 
 class TestWriteCSV:
     def test_opens_file_with_correct_name(self):
@@ -540,6 +562,20 @@ class TestTimeToMs:
         with caplog.at_level(logging.WARNING):
             _mod._time_to_ms('3$H')
         assert '3$H' in caplog.text
+
+    def test_returns_none_for_streaming_command_and_logs_command_name(self, caplog):
+        import logging
+        with caplog.at_level(logging.WARNING):
+            result = _mod._time_to_ms('$F')
+        assert result is None
+        assert 'Heartbeat' in caplog.text
+
+    def test_returns_none_for_garbage_and_logs_unparseable(self, caplog):
+        import logging
+        with caplog.at_level(logging.WARNING):
+            result = _mod._time_to_ms('not-a-time')
+        assert result is None
+        assert 'unparseable' in caplog.text
 
 
 class TestPushInfluxClassInfo:
@@ -2782,3 +2818,45 @@ class TestMonitorRoutineCorruptedLapNumber:
                 with caplog.at_level(logging.WARNING):
                     _mod.monitor_routine(ctx, [], opts, _stop_event=stop)
         assert any('$J' in r.message for r in caplog.records)
+
+
+class TestDescribeBadValue:
+    def test_known_streaming_command_includes_token_and_name(self):
+        result = _mod._describe_bad_value('$J', 'Lap')
+        assert '$J' in result
+        assert 'Passing Information' in result
+        assert 'known API quirk' in result
+
+    def test_unknown_garbage_says_unparseable(self):
+        result = _mod._describe_bad_value('????', 'Lap')
+        assert 'unparseable' in result
+
+    def test_includes_field_name_in_garbage_message(self):
+        result = _mod._describe_bad_value('????', 'LapTime')
+        assert 'LapTime' in result
+
+    def test_non_string_says_unparseable(self):
+        result = _mod._describe_bad_value(None, 'Lap')
+        assert 'unparseable' in result
+
+
+class TestBuildLapPoints:
+    def test_skips_streaming_command_in_lap_field_and_logs_command_name(self, caplog):
+        import logging
+        ctx = _mod.RaceContext('123', '42', MagicMock(), MagicMock(), 1000000)
+        laps = [{'Lap': '$J', 'LapTime': '1:00.000', 'TotalTime': '1:00.000',
+                 'FlagStatus': 'Green', 'Position': '1'}]
+        with caplog.at_level(logging.WARNING):
+            points = _mod._build_lap_points(ctx, laps, 'Driver', None, None, None, 1000000, '42')
+        assert points == []
+        assert 'Passing Information' in caplog.text
+
+    def test_omits_position_for_streaming_command_and_logs_command_name(self, caplog):
+        import logging
+        ctx = _mod.RaceContext('123', '42', MagicMock(), MagicMock(), 1000000)
+        laps = [{'Lap': '1', 'LapTime': '1:00.000', 'TotalTime': '1:00.000',
+                 'FlagStatus': 'Green', 'Position': '$G'}]
+        with caplog.at_level(logging.WARNING):
+            points = _mod._build_lap_points(ctx, laps, 'Driver', None, None, None, 1000000, '42')
+        assert len(points) == 1  # lap still written, position omitted
+        assert 'Race Information' in caplog.text

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -48,6 +48,13 @@ class TestResolveTokens:
             result = _env_mod.resolve_tokens()
         assert result == ''
 
+    def test_whitespace_only_racemonitor_tokens_falls_back_to_single_token(self):
+        with patch.dict(os.environ,
+                        {'RACEMONITOR_TOKENS': '  ,  , ', 'RACEMONITOR_TOKEN': 'FALLBACK'},
+                        clear=True):
+            result = _env_mod.resolve_tokens()
+        assert result == 'FALLBACK'
+
 
 class TestIntervalArg:
     def test_default_interval_is_30(self):

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -55,6 +55,13 @@ class TestResolveTokens:
             result = _env_mod.resolve_tokens()
         assert result == 'FALLBACK'
 
+    def test_whitespace_only_no_commas_falls_back_to_single_token(self):
+        with patch.dict(os.environ,
+                        {'RACEMONITOR_TOKENS': '  ', 'RACEMONITOR_TOKEN': 'FALLBACK'},
+                        clear=True):
+            result = _env_mod.resolve_tokens()
+        assert result == 'FALLBACK'
+
 
 class TestIntervalArg:
     def test_default_interval_is_30(self):

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -62,6 +62,25 @@ class TestResolveTokens:
             result = _env_mod.resolve_tokens()
         assert result == 'FALLBACK'
 
+    def test_empty_string_racemonitor_tokens_falls_back_to_single_token(self):
+        with patch.dict(os.environ,
+                        {'RACEMONITOR_TOKENS': '', 'RACEMONITOR_TOKEN': 'FALLBACK'},
+                        clear=True):
+            result = _env_mod.resolve_tokens()
+        assert result == 'FALLBACK'
+
+    def test_bare_comma_falls_back_to_single_token(self):
+        with patch.dict(os.environ,
+                        {'RACEMONITOR_TOKENS': ',', 'RACEMONITOR_TOKEN': 'FALLBACK'},
+                        clear=True):
+            result = _env_mod.resolve_tokens()
+        assert result == 'FALLBACK'
+
+    def test_middle_empty_slot_is_silently_dropped(self):
+        with patch.dict(os.environ, {'RACEMONITOR_TOKENS': 'TOKEN1,,TOKEN2'}, clear=True):
+            result = _env_mod.resolve_tokens()
+        assert result == ['TOKEN1', 'TOKEN2']
+
 
 class TestIntervalArg:
     def test_default_interval_is_30(self):
@@ -337,9 +356,6 @@ class TestMonitorRoutine:
         assert second_prev == sentinel
 
     def test_skips_lap_with_streaming_command_number_and_logs_command_name(self, caplog):
-        # This test asserts the human-readable command name appears; see
-        # TestMonitorRoutineCorruptedLapNumber.test_bad_lap_number_logs_warning_in_monitor
-        # for the test that asserts the token value itself appears.
         import logging
         stop = threading.Event()
         ctx = _mod.RaceContext('123', '42', MagicMock(), MagicMock(), 0)
@@ -2841,6 +2857,7 @@ class TestDescribeBadValue:
         assert '$J' in result
         assert 'Passing Information' in result
         assert 'known API quirk' in result
+        assert 'Lap' in result
 
     def test_unknown_garbage_says_unparseable(self):
         result = _mod._describe_bad_value('????', 'Lap')
@@ -2875,3 +2892,15 @@ class TestBuildLapPointsStreamingToken:
             points = _mod._build_lap_points(ctx, laps, 'Driver', None, None, None, 1000000, '42')
         assert len(points) == 1  # lap still written, position omitted
         assert 'Race Information' in caplog.text
+
+
+class TestMainMissingToken:
+    def test_logs_error_and_exits_when_no_token_set(self, caplog):
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(_mod.sys, 'argv', ['laps', '12345', '42']):
+                with caplog.at_level(logging.ERROR):
+                    with pytest.raises(SystemExit) as exc_info:
+                        _mod.main()
+        assert exc_info.value.code == 1
+        assert any('RACEMONITOR_TOKENS' in r.message and 'RACEMONITOR_TOKEN' in r.message
+                   for r in caplog.records)

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -322,17 +322,17 @@ class TestMonitorRoutine:
         assert second_prev == sentinel
 
     def test_skips_lap_with_streaming_command_number_and_logs_command_name(self, caplog):
+        # This test asserts the human-readable command name appears; see
+        # TestMonitorRoutineCorruptedLapNumber.test_bad_lap_number_logs_warning_in_monitor
+        # for the test that asserts the token value itself appears.
         import logging
         stop = threading.Event()
         ctx = _mod.RaceContext('123', '42', MagicMock(), MagicMock(), 0)
         opts = _mod.RaceOptions(network_mode=True, interval=0)
 
         bad_lap = {'Lap': '$J', 'LapTime': '1:00.000'}
-        call_count = 0
 
         def fake_refresh(c):
-            nonlocal call_count
-            call_count += 1
             stop.set()
             return [bad_lap]
 
@@ -2840,7 +2840,7 @@ class TestDescribeBadValue:
         assert 'unparseable' in result
 
 
-class TestBuildLapPoints:
+class TestBuildLapPointsStreamingToken:
     def test_skips_streaming_command_in_lap_field_and_logs_command_name(self, caplog):
         import logging
         ctx = _mod.RaceContext('123', '42', MagicMock(), MagicMock(), 1000000)

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -6,45 +6,46 @@ from unittest.mock import MagicMock, call, mock_open, patch
 
 import pytest
 
+import lemongrass._env as _env_mod
 import lemongrass.laps as _mod
 
 
 class TestResolveTokens:
     def test_multi_tokens_returns_list(self):
         with patch.dict(os.environ, {'RACEMONITOR_TOKENS': 'TOKEN1,TOKEN2'}, clear=True):
-            result = _mod._resolve_tokens()
+            result = _env_mod.resolve_tokens()
         assert result == ['TOKEN1', 'TOKEN2']
 
     def test_single_racemonitor_tokens_returns_string(self):
         with patch.dict(os.environ, {'RACEMONITOR_TOKENS': 'TOKEN1'}, clear=True):
-            result = _mod._resolve_tokens()
+            result = _env_mod.resolve_tokens()
         assert result == 'TOKEN1'
 
     def test_falls_back_to_racemonitor_token(self):
         with patch.dict(os.environ, {'RACEMONITOR_TOKEN': 'FALLBACK'}, clear=True):
-            result = _mod._resolve_tokens()
+            result = _env_mod.resolve_tokens()
         assert result == 'FALLBACK'
 
     def test_returns_empty_string_when_neither_set(self):
         with patch.dict(os.environ, {}, clear=True):
-            result = _mod._resolve_tokens()
+            result = _env_mod.resolve_tokens()
         assert result == ''
 
     def test_racemonitor_tokens_takes_priority(self):
         with patch.dict(os.environ,
                         {'RACEMONITOR_TOKENS': 'MULTI1,MULTI2', 'RACEMONITOR_TOKEN': 'SINGLE'},
                         clear=True):
-            result = _mod._resolve_tokens()
+            result = _env_mod.resolve_tokens()
         assert result == ['MULTI1', 'MULTI2']
 
     def test_strips_whitespace_from_tokens(self):
         with patch.dict(os.environ, {'RACEMONITOR_TOKENS': ' TOKEN1 , TOKEN2 '}, clear=True):
-            result = _mod._resolve_tokens()
+            result = _env_mod.resolve_tokens()
         assert result == ['TOKEN1', 'TOKEN2']
 
     def test_whitespace_only_racemonitor_tokens_returns_empty_string(self):
         with patch.dict(os.environ, {'RACEMONITOR_TOKENS': '  ,  , '}, clear=True):
-            result = _mod._resolve_tokens()
+            result = _env_mod.resolve_tokens()
         assert result == ''
 
 

--- a/tests/test_race_backfill.py
+++ b/tests/test_race_backfill.py
@@ -1,5 +1,9 @@
+import os
+import sys
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 import lemongrass.race_backfill as _mod
 
@@ -453,4 +457,36 @@ class TestArgParsing:
     def test_force_defaults_to_false(self):
         args = _mod._build_parser().parse_args([])
         assert args.force is False
+
+
+class TestMainTokenResolution:
+    def _run_main(self, env):
+        mock_client = MagicMock()
+        with patch.dict(os.environ, env, clear=True):
+            with patch.object(sys, 'argv', ['race-backfill']):
+                with patch('lemongrass.race_backfill.RaceMonitorClient') as mock_rm_cls:
+                    mock_rm_cls.return_value.__enter__.return_value = mock_client
+                    with patch.object(_mod, 'find_matching_races', return_value=[]):
+                        with patch.object(_mod, 'run_backfill', return_value=[]):
+                            _mod.main()
+        return mock_rm_cls
+
+    def test_uses_racemonitor_tokens_when_set(self):
+        mock_rm_cls = self._run_main({'RACEMONITOR_TOKENS': 'TOKEN1'})
+        mock_rm_cls.assert_called_once_with(api_token='TOKEN1')
+
+    def test_uses_multi_token_list_when_multiple_tokens_set(self):
+        mock_rm_cls = self._run_main({'RACEMONITOR_TOKENS': 'TOKEN1,TOKEN2'})
+        mock_rm_cls.assert_called_once_with(api_token=['TOKEN1', 'TOKEN2'])
+
+    def test_falls_back_to_racemonitor_token(self):
+        mock_rm_cls = self._run_main({'RACEMONITOR_TOKEN': 'FALLBACK'})
+        mock_rm_cls.assert_called_once_with(api_token='FALLBACK')
+
+    def test_exits_when_no_token_set(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(sys, 'argv', ['race-backfill']):
+                with pytest.raises(SystemExit) as exc_info:
+                    _mod.main()
+        assert exc_info.value.code == 1
 

--- a/tests/test_race_diagnose.py
+++ b/tests/test_race_diagnose.py
@@ -59,3 +59,4 @@ class TestMainTokenResolution:
                     _mod.main()
         out = capsys.readouterr().out
         assert 'RACEMONITOR_TOKENS' in out
+        assert 'RACEMONITOR_TOKEN' in out

--- a/tests/test_race_diagnose.py
+++ b/tests/test_race_diagnose.py
@@ -1,0 +1,61 @@
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import lemongrass.race_diagnose as _mod
+
+
+class TestMainTokenResolution:
+    def _run_main(self, env):
+        mock_client = MagicMock()
+        mock_client.race.details.return_value = {'Successful': False}
+        mock_client.results.sessions_for_race.return_value = {'Sessions': []}
+        mock_influx = MagicMock()
+        mock_influx.query_api.return_value = MagicMock()
+
+        with patch.dict(os.environ, env, clear=True):
+            with patch.object(sys, 'argv', ['race-diagnose', '12345', '42']):
+                with patch('lemongrass.race_diagnose.RaceMonitorClient') as mock_rm_cls:
+                    mock_rm_cls.return_value.__enter__.return_value = mock_client
+                    with patch('lemongrass.race_diagnose.InfluxDBClient') as mock_influx_cls:
+                        mock_influx_cls.return_value.__enter__.return_value = mock_influx
+                        _mod.main()
+        return mock_rm_cls
+
+    def test_uses_racemonitor_tokens_when_set(self):
+        mock_rm_cls = self._run_main({
+            'RACEMONITOR_TOKENS': 'TOKEN1',
+            'INFLUX_TELEMETRY_TOKEN': 'ITOKEN',
+        })
+        mock_rm_cls.assert_called_once_with(api_token='TOKEN1')
+
+    def test_uses_multi_token_list_when_multiple_tokens_set(self):
+        mock_rm_cls = self._run_main({
+            'RACEMONITOR_TOKENS': 'TOKEN1,TOKEN2',
+            'INFLUX_TELEMETRY_TOKEN': 'ITOKEN',
+        })
+        mock_rm_cls.assert_called_once_with(api_token=['TOKEN1', 'TOKEN2'])
+
+    def test_falls_back_to_racemonitor_token(self):
+        mock_rm_cls = self._run_main({
+            'RACEMONITOR_TOKEN': 'FALLBACK',
+            'INFLUX_TELEMETRY_TOKEN': 'ITOKEN',
+        })
+        mock_rm_cls.assert_called_once_with(api_token='FALLBACK')
+
+    def test_exits_when_no_token_set(self):
+        with patch.dict(os.environ, {'INFLUX_TELEMETRY_TOKEN': 'ITOKEN'}, clear=True):
+            with patch.object(sys, 'argv', ['race-diagnose', '12345', '42']):
+                with pytest.raises(SystemExit) as exc_info:
+                    _mod.main()
+        assert exc_info.value.code == 1
+
+    def test_error_message_mentions_both_token_vars(self, capsys):
+        with patch.dict(os.environ, {'INFLUX_TELEMETRY_TOKEN': 'ITOKEN'}, clear=True):
+            with patch.object(sys, 'argv', ['race-diagnose', '12345', '42']):
+                with pytest.raises(SystemExit):
+                    _mod.main()
+        out = capsys.readouterr().out
+        assert 'RACEMONITOR_TOKENS' in out

--- a/uv.lock
+++ b/uv.lock
@@ -166,7 +166,7 @@ requires-dist = [
     { name = "influxdb-client", specifier = "~=1.47" },
     { name = "obd", specifier = "~=0.7" },
     { name = "pandas", specifier = "~=2.3" },
-    { name = "race-monitor", specifier = ">=0.5.1,<1" },
+    { name = "race-monitor", specifier = ">=0.6.0,<1" },
 ]
 
 [package.metadata.requires-dev]
@@ -496,15 +496,15 @@ wheels = [
 
 [[package]]
 name = "race-monitor"
-version = "0.5.1"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "idna" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/f4/9a8c144fa040a1f499597fccde38082c6d140df63f3e0fe69bbe5fed0002/race_monitor-0.5.1.tar.gz", hash = "sha256:89faa62e2eb7ae66dc635156f64ed13dbc007a8ab22350374602aab00964e74a", size = 10815, upload-time = "2026-06-06T17:57:23.776Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/e7/585e297db952a8a1bc2ea1dde1e07705a4436e510c8adcefb7c6de9517c3/race_monitor-0.6.0.tar.gz", hash = "sha256:c60d485121c0bbb4d48311ddccc78979aca587473e45048211d8f4b9b479c4da", size = 13839, upload-time = "2026-06-25T21:58:52.183Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/f8/5e4807b75a9f67d2b13b79bec1e4e559a514c123121ad1389279093372c8/race_monitor-0.5.1-py3-none-any.whl", hash = "sha256:c5dbf91cd0d3f3c1e0eadb571a388e3f765a5cadb2904db39ce14072f9f58863", size = 15973, upload-time = "2026-06-06T17:57:22.486Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c2/19165ef47b3c342931a43b3209946b2a731a1e67c07f2b6ebf238c7be4eb/race_monitor-0.6.0-py3-none-any.whl", hash = "sha256:c4f460320399b4aa93c5a5452c5c5962d9494b75fc677836daab8495a1ac9c62", size = 19545, upload-time = "2026-06-25T21:58:51.059Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Multi-token load balancing:** New `resolve_tokens()` helper in `lemongrass/_env.py` reads `RACEMONITOR_TOKENS` (comma-separated list) or falls back to `RACEMONITOR_TOKEN`. All three command entrypoints (`laps`, `race_backfill`, `race_diagnose`) use the shared helper, enabling higher throughput via race-monitor 0.6's built-in token rotation.
- **Streaming command logging:** New `_describe_bad_value()` helper wraps `get_streaming_command()` to distinguish known streaming protocol tokens (e.g. `$J → "Passing Information"`) from random garbage in parse-error log messages. All four parse-error sites in `laps.py` updated. `contextlib.suppress` blocks in `_resolve_class_historical` replaced with logged `try/except` so streaming tokens in historical data are now visible at DEBUG level.

## Test plan

- [ ] `uv run pytest` — 374 tests pass
- [ ] Set `RACEMONITOR_TOKENS=TOKEN1,TOKEN2` and verify both tokens are used in rotation
- [ ] Set only `RACEMONITOR_TOKEN=TOKEN` and verify fallback works
- [ ] Trigger a parse error with a streaming command value and verify log message names the command (e.g. "Passing Information") instead of saying "unparseable"

🤖 Generated with [Claude Code](https://claude.com/claude-code)