### PR TITLE
feat(backfill): allow --upgrade-stored and --force together

### DIFF
--- a/src/lemongrass/race_backfill.py
+++ b/src/lemongrass/race_backfill.py
@@ -90,7 +90,9 @@ def _build_parser():
                        default=False,
                        help='Re-backfill stored races with schema versions older than current; '
                             'mutually exclusive with --override, --start-year, '
-                            '--car, and --validate')
+                            '--car, and --validate. Combine with --force to also re-fetch '
+                            'races already at the current schema (re-queries every race from '
+                            'RaceMonitor, subject to its rate limit)')
     return parser
 
 
@@ -259,7 +261,7 @@ def run_upgrade_stored(query_api, dry_run=False, force=False):
                         race_id, race_name, SCHEMA_VERSION)
             continue
 
-        if force and current == total:
+        if current == total:  # force is implied here (the non-force case returned above)
             logging.info("race %s (%s): already current, %s",
                         race_id, race_name,
                         "would force re-backfill" if dry_run else "force re-backfilling")

--- a/src/lemongrass/race_backfill.py
+++ b/src/lemongrass/race_backfill.py
@@ -89,7 +89,7 @@ def _build_parser():
     parser.add_argument('--upgrade-stored', dest='upgrade_stored', action='store_true',
                        default=False,
                        help='Re-backfill stored races with schema versions older than current; '
-                            'mutually exclusive with --force, --override, --start-year, '
+                            'mutually exclusive with --override, --start-year, '
                             '--car, and --validate')
     return parser
 
@@ -210,11 +210,11 @@ def run_backfill(races, default_car, overrides, dry_run=False, force=False):
     return failures
 
 
-def run_upgrade_stored(query_api, dry_run=False):
+def run_upgrade_stored(query_api, dry_run=False, force=False):
     """Query InfluxDB for stored races with stale schema versions and re-backfill them.
 
-    Races already at the current SCHEMA_VERSION are skipped. Re-backfill calls
-    `lemongrass laps -n <race_id>` with no car_number (fieldwide mode).
+    Races already at the current SCHEMA_VERSION are skipped unless force is True.
+    Re-backfill calls `lemongrass laps -n <race_id>` with no car_number (fieldwide mode).
     """
     from lemongrass.laps import SCHEMA_VERSION
 
@@ -254,14 +254,19 @@ def run_upgrade_stored(query_api, dry_run=False):
             logging.info("race %s (%s): no laps stored, skipping", race_id, race_name)
             continue
 
-        if current == total:
+        if current == total and not force:
             logging.info("race %s (%s): already at schema v%d, skipping",
                         race_id, race_name, SCHEMA_VERSION)
             continue
 
-        logging.info("race %s (%s): stale (%d/%d at current schema), %s",
-                    race_id, race_name, current, total,
-                    "would re-backfill" if dry_run else "re-backfilling")
+        if force and current == total:
+            logging.info("race %s (%s): already current, %s",
+                        race_id, race_name,
+                        "would force re-backfill" if dry_run else "force re-backfilling")
+        else:
+            logging.info("race %s (%s): stale (%d/%d at current schema), %s",
+                        race_id, race_name, current, total,
+                        "would re-backfill" if dry_run else "re-backfilling")
         if dry_run:
             continue
 
@@ -284,7 +289,6 @@ def main():
 
     if args.upgrade_stored:
         exclusive = [
-            args.force,
             bool(args.overrides),
             args.start_year != DEFAULT_START_YEAR,
             args.car_number != DEFAULT_CAR_NUMBER,
@@ -292,7 +296,7 @@ def main():
         ]
         if any(exclusive):
             logging.error(
-                "--upgrade-stored is mutually exclusive with --force, --override, "
+                "--upgrade-stored is mutually exclusive with --override, "
                 "--start-year, --car, and --validate")
             sys.exit(1)
         influx_token = os.environ.get('INFLUX_TELEMETRY_TOKEN')
@@ -303,7 +307,8 @@ def main():
         try:
             with InfluxDBClient(url='https://influxdb.focism.com',
                                token=influx_token, org='focism') as influx_client:
-                failures = run_upgrade_stored(influx_client.query_api(), dry_run=args.dry_run)
+                failures = run_upgrade_stored(influx_client.query_api(),
+                                              dry_run=args.dry_run, force=args.force)
         except KeyboardInterrupt:
             logging.info("Interrupted, exiting.")
             sys.exit(130)

--- a/tests/test_race_backfill.py
+++ b/tests/test_race_backfill.py
@@ -422,6 +422,33 @@ class TestRunUpgradeStored:
         cmd = mock_run.call_args.args[0]
         assert cmd == ['lemongrass', 'laps', '-n', '101']
 
+    def test_force_logs_already_current_message(self, caplog):
+        import logging
+        query_api = self._query_api(
+            stored_races={'101': 'Lemons 2024'},
+            total_by_race={'101': 10},
+            current_by_race={'101': 10},  # already fully current
+        )
+        with patch.object(_mod.subprocess, 'run') as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            with caplog.at_level(logging.INFO):
+                _mod.run_upgrade_stored(query_api, force=True)
+        assert any('already current' in r.message and 'force re-backfilling' in r.message
+                   for r in caplog.records)
+
+    def test_dry_run_force_does_not_call_subprocess(self, caplog):
+        import logging
+        query_api = self._query_api(
+            stored_races={'101': 'Lemons 2024'},
+            total_by_race={'101': 10},
+            current_by_race={'101': 10},  # already current; only --force would touch it
+        )
+        with patch.object(_mod.subprocess, 'run') as mock_run:
+            with caplog.at_level(logging.INFO):
+                _mod.run_upgrade_stored(query_api, dry_run=True, force=True)
+        mock_run.assert_not_called()
+        assert any('would force re-backfill' in r.message for r in caplog.records)
+
     def test_force_still_skips_race_with_no_stored_laps(self):
         query_api = self._query_api(
             stored_races={'101': 'Lemons 2024'},

--- a/tests/test_race_backfill.py
+++ b/tests/test_race_backfill.py
@@ -409,6 +409,29 @@ class TestRunUpgradeStored:
             _mod.run_upgrade_stored(query_api)
         assert mock_run.call_count == 1
 
+    def test_force_rebackfills_race_already_at_current_schema(self):
+        query_api = self._query_api(
+            stored_races={'101': 'Lemons 2024'},
+            total_by_race={'101': 10},
+            current_by_race={'101': 10},  # already fully current
+        )
+        with patch.object(_mod.subprocess, 'run') as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            _mod.run_upgrade_stored(query_api, force=True)
+        assert mock_run.call_count == 1
+        cmd = mock_run.call_args.args[0]
+        assert cmd == ['lemongrass', 'laps', '-n', '101']
+
+    def test_force_still_skips_race_with_no_stored_laps(self):
+        query_api = self._query_api(
+            stored_races={'101': 'Lemons 2024'},
+            total_by_race={'101': 0},
+            current_by_race={},
+        )
+        with patch.object(_mod.subprocess, 'run') as mock_run:
+            _mod.run_upgrade_stored(query_api, force=True)
+        mock_run.assert_not_called()
+
 
 class TestUpgradeStoredArgParsing:
     def test_upgrade_stored_flag_accepted(self):
@@ -418,6 +441,12 @@ class TestUpgradeStoredArgParsing:
     def test_upgrade_stored_default_false(self):
         args = _mod._build_parser().parse_args([])
         assert args.upgrade_stored is False
+
+    def test_upgrade_stored_and_force_accepted_together(self):
+        # Previously mutually exclusive — must now parse without error
+        args = _mod._build_parser().parse_args(['--upgrade-stored', '--force'])
+        assert args.upgrade_stored is True
+        assert args.force is True
 
 
 class TestArgParsing:


### PR DESCRIPTION
## Summary

- `--upgrade-stored` and `--force` can now be used together
- With both flags, `run_upgrade_stored` re-backfills all stored races unconditionally, including those already at the current schema version
- Without `--force`, behavior is unchanged (only stale races are re-backfilled)
- Races with zero stored laps are still skipped in both cases
- `--upgrade-stored` help text documents that `--force` re-fetches every race from RaceMonitor (subject to its rate limit)

## Test plan

- [x] 60 tests pass (`uv run pytest tests/test_race_backfill.py`)
- [x] 5 new tests cover the new behavior: force re-backfills current-schema races, force still skips zero-lap races, `--upgrade-stored --force` parses together, the force "already current" log path, and `--dry-run --force` skips the subprocess
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)