### PR TITLE
fix(standings): rank historical class positions by final position

### DIFF
--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -1110,6 +1110,30 @@ def _compute_class_positions_live(session_response):
     return result
 
 
+def _compute_class_positions_final(competitors):
+    """Return {car_number: class_position} for a completed session, ranking
+    same-class competitors by their final overall position.
+
+    Mirrors _compute_class_positions_live. Used for the standings snapshot instead
+    of the per-lap class_positions dict: that dict holds each car's class position
+    at its own last lap, computed only against same-class cars that reached that
+    lap, so cars finishing at different lap counts collide on the same value.
+    """
+    by_class = defaultdict(list)
+    for comp in competitors:
+        try:
+            pos = int(comp['final_position'])
+        except (ValueError, TypeError):
+            continue
+        by_class[comp['class_name']].append((pos, comp['car_number']))
+    result = {}
+    for entries in by_class.values():
+        entries.sort()
+        for rank, (_, car_number) in enumerate(entries, 1):
+            result[car_number] = rank
+    return result
+
+
 def push_influx_standings_live(ctx, session_response, session_id, prev_standings=None):
     """Write one standings point per competitor when standings have changed.
 
@@ -1187,6 +1211,7 @@ def push_influx_standings_historical(ctx, session_entry):
     start_epoc = session_entry.get('start_epoc') or 0
     timestamp_ms = start_epoc * 1000
     session_id = session_entry['session_id']
+    class_positions_final = _compute_class_positions_final(session_entry['competitors'])
     points = []
     for comp in session_entry['competitors']:
         try:
@@ -1197,10 +1222,7 @@ def push_influx_standings_historical(ctx, session_entry):
             lap_count = int(comp['final_laps'])
         except (ValueError, TypeError):
             continue
-        class_positions = comp.get('class_positions') or {}
-        class_position = (
-            class_positions[max(class_positions)] if class_positions else None
-        )
+        class_position = class_positions_final.get(comp['car_number'])
         best_lap_ms = _time_to_ms(comp.get('best_lap_time') or '')
         last_lap_ms = _time_to_ms(comp.get('last_lap_time') or '')
         point = (

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -2943,14 +2943,49 @@ class TestPushInfluxStandingsHistorical:
         lp = mock_write.call_args[0][1][0].to_line_protocol()
         assert lp.startswith('standings,')
 
-    def test_uses_final_class_position(self):
+    def test_class_position_ranks_by_final_position_within_class(self):
+        # Regression: final class position must rank same-class cars by their final
+        # overall position. Previously it read each car's last-lap value from the
+        # per-lap class_positions dict — computed at each car's own (differing) last
+        # lap — so cars finishing at different lap counts collided on the same class
+        # position. Here all three cars carry a colliding per-lap dict ({1: 9}) but
+        # distinct final positions, so they must come out 1/2/3.
         ctx = _mod.RaceContext('123', None, MagicMock(), MagicMock(), 0)
-        comp = self._comp(class_positions={1: 3, 2: 2, 3: 1})
-        entry = self._entry([comp])
+        entry = self._entry([
+            self._comp(car_number='974', position='33', class_name='B',
+                       class_positions={1: 9}),
+            self._comp(car_number='60', position='46', class_name='B',
+                       class_positions={1: 9}),
+            self._comp(car_number='151', position='81', class_name='B',
+                       class_positions={1: 9}),
+        ])
         with patch.object(_mod, '_write_points_chunked') as mock_write:
             _mod.push_influx_standings_historical(ctx, entry)
-        lp = mock_write.call_args[0][1][0].to_line_protocol()
-        assert 'class_position=1i' in lp
+        by_car = {
+            p.to_line_protocol().split('car_number=', 1)[1].split(',', 1)[0]:
+                p.to_line_protocol()
+            for p in mock_write.call_args[0][1]
+        }
+        assert 'class_position=1i' in by_car['974']
+        assert 'class_position=2i' in by_car['60']
+        assert 'class_position=3i' in by_car['151']
+
+    def test_class_positions_independent_across_classes(self):
+        # Each class is ranked independently, both starting at 1.
+        ctx = _mod.RaceContext('123', None, MagicMock(), MagicMock(), 0)
+        entry = self._entry([
+            self._comp(car_number='1', position='2', class_name='A'),
+            self._comp(car_number='2', position='5', class_name='B'),
+        ])
+        with patch.object(_mod, '_write_points_chunked') as mock_write:
+            _mod.push_influx_standings_historical(ctx, entry)
+        by_car = {
+            p.to_line_protocol().split('car_number=', 1)[1].split(',', 1)[0]:
+                p.to_line_protocol()
+            for p in mock_write.call_args[0][1]
+        }
+        assert 'class_position=1i' in by_car['1']
+        assert 'class_position=1i' in by_car['2']
 
     def test_session_id_tagged(self):
         ctx = _mod.RaceContext('123', None, MagicMock(), MagicMock(), 0)
@@ -2976,13 +3011,15 @@ class TestPushInfluxStandingsHistorical:
         assert 'best_lap_time' not in lp
         assert 'last_lap_time' not in lp
 
-    def test_empty_class_positions_omits_class_position_field(self):
+    def test_empty_per_lap_class_positions_still_ranks_by_final_position(self):
+        # The standings class position is derived from final overall position, so an
+        # empty per-lap class_positions dict no longer suppresses it.
         ctx = _mod.RaceContext('123', None, MagicMock(), MagicMock(), 0)
         entry = self._entry([self._comp(class_positions={})])
         with patch.object(_mod, '_write_points_chunked') as mock_write:
             _mod.push_influx_standings_historical(ctx, entry)
         lp = mock_write.call_args[0][1][0].to_line_protocol()
-        assert 'class_position' not in lp
+        assert 'class_position=1i' in lp
 
     def test_car_info_is_field_not_tag(self):
         ctx = _mod.RaceContext('123', None, MagicMock(), MagicMock(), 0)


### PR DESCRIPTION
## Summary

Fixes duplicate class positions in historical/backfilled standings. In the standings table, multiple cars in the same class showed the **same class position** (e.g. three class-B cars all displayed as class position 9).

## Root cause

`push_influx_standings_historical` derived each car's final class position from the per-lap `class_positions` dict at the car's **own last lap**:

```python
class_position = class_positions[max(class_positions)] if class_positions else None
```

`_resolve_class_historical` computes a car's class position on lap *N* against only the same-class cars that *also reached lap N*. Taking each car's last lap means every car is measured at a different lap number against a different competitor subset, so cars finishing at different lap counts collide on the same class position.

## Fix

Rank same-class competitors by their **final overall position**, mirroring the live path (`_compute_class_positions_live`). Adds `_compute_class_positions_final` and uses it in `push_influx_standings_historical`. The per-lap dict is still used for the lap series (`_build_lap_points`) and is unchanged.

## Verification

- `uv run pytest` → 417 passed; `uv run ruff check` clean.
- New regression test reproduces the exact failing scenario (three same-class cars with colliding per-lap values but distinct final positions → 1/2/3).
- Re-backfilled a real race against a local InfluxDB stack and ran the actual Standings dashboard query: 29 class-B cars now have 29 distinct class positions (previously duplicated).

## Note

This is a code bugfix, not a schema change, so `SCHEMA_VERSION` is unchanged. Standings already stored in InfluxDB keep the old (buggy) values until re-backfilled. A plain targeted re-backfill rewrites them (`lemongrass laps <race_id> -n`); the bulk `race-backfill --upgrade-stored` path needs `--force` to revisit races already at the current schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)