### PR TITLE
chore(local-testing): render purple best lap on standings dashboard

### DIFF
--- a/local-testing/grafana/provisioning/dashboards/json/standings.json
+++ b/local-testing/grafana/provisioning/dashboards/json/standings.json
@@ -152,6 +152,10 @@
                 }
               },
               {
+                "id": "fieldMinMax",
+                "value": true
+              },
+              {
                 "id": "thresholds",
                 "value": {
                   "mode": "percentage",
@@ -174,7 +178,8 @@
               {
                 "id": "custom.cellOptions",
                 "value": {
-                  "type": "color-background-solid"
+                  "type": "color-background",
+                  "mode": "basic"
                 }
               }
             ]


### PR DESCRIPTION
## Summary

Ports the best-lap highlighting fixes from `../iac` to the local-testing Grafana standings dashboard, so the overall best lap renders with a purple background locally just like in the deployed (iac) dashboard.

Two substantive changes:
- Add `"fieldMinMax": true` so the per-field min/max is computed and the purple threshold actually renders (iac #139).
- Change `custom.cellOptions` type from `color-background-solid` → `color-background` with `"mode": "basic"`, the valid Grafana 10+ cell type (iac #138).

Formatting and an unrelated template-variable ordering difference between the two repos' copies were left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)