### PR TITLE
fix(telem): write fuel status under -Fuel-System-Status not b'0103'

### DIFF
--- a/local-testing/grafana/provisioning/dashboards/json/race-control.json
+++ b/local-testing/grafana/provisioning/dashboards/json/race-control.json
@@ -2430,7 +2430,7 @@
               "type": "fill"
             }
           ],
-          "measurement": "b'0103'",
+          "measurement": "-Fuel-System-Status",
           "orderByTime": "ASC",
           "policy": "autogen",
           "refId": "A",
@@ -3380,7 +3380,7 @@
               "type": "fill"
             }
           ],
-          "measurement": "0103",
+          "measurement": "-Fuel-System-Status",
           "orderByTime": "ASC",
           "policy": "default",
           "refId": "A",

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -62,8 +62,12 @@ def new_fuel_status(r):
         return
 
     ts = datetime.now(timezone.utc)
-    measurement = str(r.command).split(":", maxsplit=1)[0]
-    measurement = measurement.replace(" ", "-")
+    try:
+        measurement = str(r.command).split(":")[1]
+        measurement = measurement.replace(" ", "-")
+    except IndexError:
+        logger.debug("Caught IndexError in new_fuel_status")
+        return
 
     fuel_status = next((v for k, v in FUEL_STATUS_MAP.items() if k in r.value), 255)
     if fuel_status == 3:

--- a/tests/test_telem.py
+++ b/tests/test_telem.py
@@ -103,6 +103,13 @@ class TestNewFuelStatus:
         _mod.new_fuel_status(r)
         assert len(_mod.pending_points) == 1
 
+    def test_returns_early_on_malformed_command(self):
+        r = MagicMock()
+        r.command = _Cmd("no colon here")
+        r.value = ["Closed loop, using oxygen sensor feedback to determine fuel mix"]
+        _mod.new_fuel_status(r)
+        assert len(_mod.pending_points) == 0
+
     def test_measurement_name_uses_description(self):
         r = MagicMock()
         r.command = _Cmd("b'0103': Fuel System Status")

--- a/tests/test_telem.py
+++ b/tests/test_telem.py
@@ -84,24 +84,39 @@ class TestNewFuelStatus:
 
     def test_appends_known_status(self):
         r = MagicMock()
-        r.command = _Cmd("FUEL_STATUS")
+        r.command = _Cmd("b'0103': Fuel System Status")
         r.value = ["Closed loop, using oxygen sensor feedback to determine fuel mix"]
         _mod.new_fuel_status(r)
         assert len(_mod.pending_points) == 1
 
     def test_skips_falsy_first_element(self):
         r = MagicMock()
-        r.command = _Cmd("FUEL_STATUS")
+        r.command = _Cmd("b'0103': Fuel System Status")
         r.value = [None]
         _mod.new_fuel_status(r)
         assert len(_mod.pending_points) == 0
 
     def test_appends_for_unknown_status(self):
         r = MagicMock()
-        r.command = _Cmd("FUEL_STATUS")
+        r.command = _Cmd("b'0103': Fuel System Status")
         r.value = ["Unknown mode that maps to nothing"]
         _mod.new_fuel_status(r)
         assert len(_mod.pending_points) == 1
+
+    def test_measurement_name_uses_description(self):
+        r = MagicMock()
+        r.command = _Cmd("b'0103': Fuel System Status")
+        r.value = ["Closed loop, using oxygen sensor feedback to determine fuel mix"]
+        captured_name = []
+        original_point = _mod.Point
+
+        def capture_point(name):
+            captured_name.append(name)
+            return original_point(name)
+
+        with patch.object(_mod, "Point", side_effect=capture_point):
+            _mod.new_fuel_status(r)
+        assert captured_name[0] == "-Fuel-System-Status"
 
 
 class TestFlushPoints:


### PR DESCRIPTION
## Problem

The OBD telemetry collector wrote the fuel-status measurement under the garbage name `b'0103'` — a Python `bytes` repr. `new_fuel_status` read the wrong half of `str(command)` (`split(":", maxsplit=1)[0]` → the raw-bytes command code) while every other PID (`new_value`) reads the human-description half (`split(":")[1]`). The bug shipped because no test asserted the fuel-status measurement name and the test mock used an unrealistic colon-less string.

## Changes

- **`telem.py`** — `new_fuel_status` now reads the description half like `new_value`, plus the same `IndexError` guard, writing `-Fuel-System-Status` (consistent with all other PIDs).
- **`tests/test_telem.py`** — regression test asserting the measurement name (`b'0103': Fuel System Status` mock); a test covering the `IndexError` early-return guard; 3 existing fuel-status mocks updated to realistic colon-bearing strings so they still exercise their intended guards under the fixed code.
- **`local-testing/.../race-control.json`** — the two fuel-status panels repointed from `b'0103'`/`0103` to `-Fuel-System-Status`.

## Related work (already done)

- **Prod dashboards** — WOT-Lemons/iac#140 (**merged**): the same two panel repoints in the prod race-control dashboard.
- **Historical data** — 81,095 existing `b'0103'` points copied to `-Fuel-System-Status` in prod `stats_252/autogen` and the old rows deleted.

## Deploy note

Merging this deploys the collector that writes `-Fuel-System-Status`. Prod panels (iac#140) and migrated history already point at the new name, so there is no data gap.

## Testing

telem suite green (16 tests), full suite passing, ruff clean. TDD: regression test confirmed RED (`assert "b'0103'" == "-Fuel-System-Status"`) before the fix, GREEN after.
