### PR TITLE
feat(telem): OBD watch-list optimization + trouble-code capture

### DIFF
--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -36,6 +36,9 @@ AIR_STATUS_MAP = {
 pending_points = []
 pending_lock = threading.Lock()
 
+_connection = None  # set by main(); lets new_status trigger on-demand DTC lookups
+_last_dtc_count = 0  # only ever written from the Async callback thread; no lock needed
+
 
 def new_value(r):
     """Queue new measurement for batch write to InfluxDB."""
@@ -134,8 +137,32 @@ def _query_fuel_type_once(connection):
         )
 
 
+def _fetch_and_store_dtcs():
+    """Force a live GET_DTC read and queue the active codes as one point."""
+    # Async.query() only returns cached watched-command values, and GET_DTC is
+    # deliberately never watched (see _route_command), so the blocking
+    # OBD.query() is called directly -- the same technique Async's own
+    # background thread uses internally (asynchronous.py's run() method).
+    # Safe here because this only ever runs from inside an Async callback,
+    # which already executes on that same background thread.
+    if _connection is None:
+        return
+
+    r = obd.OBD.query(_connection, obd.commands.GET_DTC, force=True)
+    if r.value is None:
+        logger.debug("Caught null value in _fetch_and_store_dtcs")
+        return
+
+    codes = ",".join(code for code, _ in r.value)
+    ts = datetime.now(timezone.utc)
+    with pending_lock:
+        pending_points.append(Point("-Get-DTCs").field("value", codes).time(ts))
+
+
 def new_status(r):
     """Queue MIL and DTC count for batch write to InfluxDB."""
+    global _last_dtc_count
+
     if r.value is None:
         logger.debug("Caught null value in new_status")
         return
@@ -153,10 +180,18 @@ def new_status(r):
             Point(f"{measurement}-MIL").field("value", int(r.value.MIL)).time(ts)
         )
         pending_points.append(
-            Point(f"{measurement}-DTC-Count").field(
-                "value", r.value.DTC_count
-            ).time(ts)
+            Point(f"{measurement}-DTC-Count").field("value", r.value.DTC_count).time(ts)
         )
+
+    # Only the primary STATUS command drives the on-demand DTC lookup;
+    # STATUS_DRIVE_CYCLE just records its own MIL/count.
+    if r.command.name != "STATUS":
+        return
+
+    dtc_count = r.value.DTC_count
+    if dtc_count > _last_dtc_count:
+        _fetch_and_store_dtcs()
+    _last_dtc_count = dtc_count
 
 
 def connect():

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -108,6 +108,32 @@ def new_air_status(r):
         )
 
 
+def _query_fuel_type_once(connection):
+    """Query FUEL_TYPE once and queue a single point (it never changes mid-session)."""
+    if not connection.supports(obd.commands.FUEL_TYPE):
+        return
+
+    # Async.query() only returns cached watched-command values; FUEL_TYPE is
+    # deliberately never watched, so the blocking OBD.query() is called directly.
+    r = obd.OBD.query(connection, obd.commands.FUEL_TYPE, force=True)
+    if not r.value:
+        logger.debug("Caught falsy value in _query_fuel_type_once")
+        return
+
+    ts = datetime.now(timezone.utc)
+    try:
+        measurement = str(r.command).split(":")[1]
+        measurement = measurement.replace(" ", "-")
+    except IndexError:
+        logger.debug("Caught IndexError in _query_fuel_type_once")
+        return
+
+    with pending_lock:
+        pending_points.append(
+            Point(measurement).field("value", r.value).time(ts)
+        )
+
+
 def connect():
     """Open an OBD-II connection on the configured serial port.
 

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -17,7 +17,8 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger('telem')
 
 EXCLUDED_PATTERNS = ["MIDS", "PIDS", "O2_SENSORS", "ELM", "OBD"]
-SKIP_NAMES = {"FREEZE_DTC", "GET_DTC", "CLEAR_DTC", "FUEL_TYPE"}
+SKIP_NAMES = {"FREEZE_DTC", "GET_DTC", "GET_CURRENT_DTC", "CLEAR_DTC", "FUEL_TYPE"}
+MAX_DTC_FETCH_FAILURES = 3
 STATUS_COMMANDS = {"STATUS", "STATUS_DRIVE_CYCLE"}
 
 FUEL_STATUS_MAP = {
@@ -39,7 +40,9 @@ pending_points = []
 pending_lock = threading.Lock()
 
 _connection = None  # set by main(); lets new_status trigger on-demand DTC lookups
-_last_dtc_count = 0  # only ever written from the Async callback thread; no lock needed
+# Both only ever written from the Async callback thread; no lock needed.
+_last_dtc_count = 0
+_dtc_fetch_failures = 0
 
 
 def _measurement_name(r):
@@ -163,10 +166,12 @@ def _fetch_and_store_dtcs():
     except Exception:
         logger.exception("GET_DTC query failed; skipping this fetch")
         return False
-    if not r.value:
-        logger.debug("Caught falsy value in _fetch_and_store_dtcs")
+    if r.value is None:
+        logger.debug("Caught null value in _fetch_and_store_dtcs")
         return False
 
+    # An empty list is a successful mode-03 answer ("no stored codes"), not a
+    # failure -- store it so a STATUS/GET_DTC disagreement doesn't retry forever.
     codes = ",".join(code for code, _ in r.value)
     ts = datetime.now(timezone.utc)
     with pending_lock:
@@ -180,6 +185,10 @@ def _route_command(command):
         return None
     if command.name in SKIP_NAMES:
         return None
+    # python-obd marks a DTC_-prefixed mode-2 freeze-frame twin as supported for
+    # every supported mode-1 PID; watching them would double per-cycle load.
+    if command.name.startswith("DTC_"):
+        return None
     if command.name in STATUS_COMMANDS:
         return new_status
     if command.name == "AIR_STATUS":
@@ -191,7 +200,7 @@ def _route_command(command):
 
 def new_status(r):
     """Queue MIL and DTC count for batch write to InfluxDB."""
-    global _last_dtc_count
+    global _last_dtc_count, _dtc_fetch_failures
 
     if r.value is None:
         logger.debug("Caught null value in new_status")
@@ -220,6 +229,17 @@ def new_status(r):
     if dtc_count > _last_dtc_count:
         if _fetch_and_store_dtcs():
             _last_dtc_count = dtc_count
+            _dtc_fetch_failures = 0
+        else:
+            # Each forced query costs a blocking serial round-trip on the Async
+            # thread; give up after a few misses rather than retry every STATUS.
+            _dtc_fetch_failures += 1
+            if _dtc_fetch_failures >= MAX_DTC_FETCH_FAILURES:
+                logger.warning(
+                    "Giving up on DTC fetch after %d failures", _dtc_fetch_failures
+                )
+                _last_dtc_count = dtc_count
+                _dtc_fetch_failures = 0
     else:
         _last_dtc_count = dtc_count
 

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -158,7 +158,11 @@ def _fetch_and_store_dtcs():
     if _connection is None:
         return False
 
-    r = obd.OBD.query(_connection, obd.commands.GET_DTC, force=True)
+    try:
+        r = obd.OBD.query(_connection, obd.commands.GET_DTC, force=True)
+    except Exception:
+        logger.exception("GET_DTC query failed; skipping this fetch")
+        return False
     if r.value is None:
         logger.debug("Caught null value in _fetch_and_store_dtcs")
         return False

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -16,7 +16,9 @@ from lemongrass import _influx
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger('telem')
 
-EXCLUDED_PATTERNS = ["DTC", "MIDS", "PIDS", "O2_SENSORS", "ELM", "OBD"]
+EXCLUDED_PATTERNS = ["MIDS", "PIDS", "O2_SENSORS", "ELM", "OBD"]
+SKIP_NAMES = {"FREEZE_DTC", "GET_DTC", "CLEAR_DTC", "FUEL_TYPE"}
+STATUS_COMMANDS = {"STATUS", "STATUS_DRIVE_CYCLE"}
 
 FUEL_STATUS_MAP = {
     "Open loop due to insufficient engine temperature": 0,
@@ -157,6 +159,21 @@ def _fetch_and_store_dtcs():
     ts = datetime.now(timezone.utc)
     with pending_lock:
         pending_points.append(Point("-Get-DTCs").field("value", codes).time(ts))
+
+
+def _route_command(command):
+    """Return the callback to watch a supported command with, or None to skip it."""
+    if any(pattern in command.name for pattern in EXCLUDED_PATTERNS):
+        return None
+    if command.name in SKIP_NAMES:
+        return None
+    if command.name in STATUS_COMMANDS:
+        return new_status
+    if command.name == "AIR_STATUS":
+        return new_air_status
+    if "FUEL_STATUS" in command.name:
+        return new_fuel_status
+    return new_value
 
 
 def new_status(r):

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -238,6 +238,8 @@ def flush_points(write_api):
 
 def main():
     """Main loop of OBD-II scraping"""
+    global _connection
+
     with _influx.connect() as influx_client:
         write_api = influx_client.write_api(write_options=SYNCHRONOUS)
 
@@ -253,15 +255,13 @@ def main():
 
         logger.debug(connection.status())
 
+        _connection = connection
+        _query_fuel_type_once(connection)
+
         for command in connection.supported_commands:
-            if any(pattern in command.name for pattern in EXCLUDED_PATTERNS):
-                continue
-            if command.name == "STATUS":
-                continue
-            if "FUEL_STATUS" in command.name:
-                connection.watch(command, callback=new_fuel_status)
-            else:
-                connection.watch(command, callback=new_value)
+            callback = _route_command(command)
+            if callback is not None:
+                connection.watch(command, callback=callback)
 
         try:
             connection.watch(obd.commands.ELM_VOLTAGE, callback=new_value)

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -42,13 +42,19 @@ _connection = None  # set by main(); lets new_status trigger on-demand DTC looku
 _last_dtc_count = 0  # only ever written from the Async callback thread; no lock needed
 
 
+def _measurement_name(r):
+    """Derive the InfluxDB measurement name from a response's command string."""
+    try:
+        return str(r.command).split(":")[1].replace(" ", "-")
+    except IndexError:
+        return None
+
+
 def new_value(r):
     """Queue new measurement for batch write to InfluxDB."""
     ts = datetime.now(timezone.utc)
-    try:
-        measurement = str(r.command).split(":")[1]
-        measurement = measurement.replace(" ", "-")
-    except IndexError:
+    measurement = _measurement_name(r)
+    if measurement is None:
         logger.debug("Caught IndexError in new_value")
         return
     try:
@@ -74,10 +80,8 @@ def new_fuel_status(r):
         return
 
     ts = datetime.now(timezone.utc)
-    try:
-        measurement = str(r.command).split(":")[1]
-        measurement = measurement.replace(" ", "-")
-    except IndexError:
+    measurement = _measurement_name(r)
+    if measurement is None:
         logger.debug("Caught IndexError in new_fuel_status")
         return
 
@@ -98,10 +102,8 @@ def new_air_status(r):
         return
 
     ts = datetime.now(timezone.utc)
-    try:
-        measurement = str(r.command).split(":")[1]
-        measurement = measurement.replace(" ", "-")
-    except IndexError:
+    measurement = _measurement_name(r)
+    if measurement is None:
         logger.debug("Caught IndexError in new_air_status")
         return
 
@@ -130,10 +132,8 @@ def _query_fuel_type_once(connection):
         return
 
     ts = datetime.now(timezone.utc)
-    try:
-        measurement = str(r.command).split(":")[1]
-        measurement = measurement.replace(" ", "-")
-    except IndexError:
+    measurement = _measurement_name(r)
+    if measurement is None:
         logger.debug("Caught IndexError in _query_fuel_type_once")
         return
 
@@ -163,8 +163,8 @@ def _fetch_and_store_dtcs():
     except Exception:
         logger.exception("GET_DTC query failed; skipping this fetch")
         return False
-    if r.value is None:
-        logger.debug("Caught null value in _fetch_and_store_dtcs")
+    if not r.value:
+        logger.debug("Caught falsy value in _fetch_and_store_dtcs")
         return False
 
     codes = ",".join(code for code, _ in r.value)
@@ -198,10 +198,8 @@ def new_status(r):
         return
 
     ts = datetime.now(timezone.utc)
-    try:
-        measurement = str(r.command).split(":")[1]
-        measurement = measurement.replace(" ", "-")
-    except IndexError:
+    measurement = _measurement_name(r)
+    if measurement is None:
         logger.debug("Caught IndexError in new_status")
         return
 

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -120,7 +120,11 @@ def _query_fuel_type_once(connection):
 
     # Async.query() only returns cached watched-command values; FUEL_TYPE is
     # deliberately never watched, so the blocking OBD.query() is called directly.
-    r = obd.OBD.query(connection, obd.commands.FUEL_TYPE, force=True)
+    try:
+        r = obd.OBD.query(connection, obd.commands.FUEL_TYPE, force=True)
+    except Exception:
+        logger.exception("Fuel-type query failed; continuing without it")
+        return
     if not r.value:
         logger.debug("Caught falsy value in _query_fuel_type_once")
         return
@@ -140,7 +144,11 @@ def _query_fuel_type_once(connection):
 
 
 def _fetch_and_store_dtcs():
-    """Force a live GET_DTC read and queue the active codes as one point."""
+    """Force a live GET_DTC read and queue the active codes as one point.
+
+    Returns True if a snapshot was queued, False otherwise, so callers know
+    whether it's safe to advance their own notion of the last-seen DTC count.
+    """
     # Async.query() only returns cached watched-command values, and GET_DTC is
     # deliberately never watched (see _route_command), so the blocking
     # OBD.query() is called directly -- the same technique Async's own
@@ -148,17 +156,18 @@ def _fetch_and_store_dtcs():
     # Safe here because this only ever runs from inside an Async callback,
     # which already executes on that same background thread.
     if _connection is None:
-        return
+        return False
 
     r = obd.OBD.query(_connection, obd.commands.GET_DTC, force=True)
     if r.value is None:
         logger.debug("Caught null value in _fetch_and_store_dtcs")
-        return
+        return False
 
     codes = ",".join(code for code, _ in r.value)
     ts = datetime.now(timezone.utc)
     with pending_lock:
         pending_points.append(Point("-Get-DTCs").field("value", codes).time(ts))
+    return True
 
 
 def _route_command(command):
@@ -207,8 +216,10 @@ def new_status(r):
 
     dtc_count = r.value.DTC_count
     if dtc_count > _last_dtc_count:
-        _fetch_and_store_dtcs()
-    _last_dtc_count = dtc_count
+        if _fetch_and_store_dtcs():
+            _last_dtc_count = dtc_count
+    else:
+        _last_dtc_count = dtc_count
 
 
 def connect():

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -26,6 +26,13 @@ FUEL_STATUS_MAP = {
     "Closed loop, using at least one oxygen sensor but there is a fault in the feedback system": 4,
 }
 
+AIR_STATUS_MAP = {
+    "Upstream": 0,
+    "Downstream of catalytic converter": 1,
+    "From the outside atmosphere or off": 2,
+    "Pump commanded on for diagnostics": 3,
+}
+
 pending_points = []
 pending_lock = threading.Lock()
 
@@ -76,6 +83,28 @@ def new_fuel_status(r):
     with pending_lock:
         pending_points.append(
             Point(measurement).field("value", fuel_status).time(ts)
+        )
+
+
+def new_air_status(r):
+    """Queue new secondary air status for batch write to InfluxDB."""
+    if not r.value:
+        logger.debug("Caught falsy value in new_air_status")
+        return
+
+    ts = datetime.now(timezone.utc)
+    try:
+        measurement = str(r.command).split(":")[1]
+        measurement = measurement.replace(" ", "-")
+    except IndexError:
+        logger.debug("Caught IndexError in new_air_status")
+        return
+
+    air_status = AIR_STATUS_MAP.get(r.value, 255)
+
+    with pending_lock:
+        pending_points.append(
+            Point(measurement).field("value", air_status).time(ts)
         )
 
 

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -134,6 +134,31 @@ def _query_fuel_type_once(connection):
         )
 
 
+def new_status(r):
+    """Queue MIL and DTC count for batch write to InfluxDB."""
+    if r.value is None:
+        logger.debug("Caught null value in new_status")
+        return
+
+    ts = datetime.now(timezone.utc)
+    try:
+        measurement = str(r.command).split(":")[1]
+        measurement = measurement.replace(" ", "-")
+    except IndexError:
+        logger.debug("Caught IndexError in new_status")
+        return
+
+    with pending_lock:
+        pending_points.append(
+            Point(f"{measurement}-MIL").field("value", int(r.value.MIL)).time(ts)
+        )
+        pending_points.append(
+            Point(f"{measurement}-DTC-Count").field(
+                "value", r.value.DTC_count
+            ).time(ts)
+        )
+
+
 def connect():
     """Open an OBD-II connection on the configured serial port.
 

--- a/tests/test_telem.py
+++ b/tests/test_telem.py
@@ -126,6 +126,54 @@ class TestNewFuelStatus:
         assert captured_name[0] == "-Fuel-System-Status"
 
 
+class TestNewAirStatus:
+    def setup_method(self):
+        _reset()
+
+    def test_appends_known_status(self):
+        r = MagicMock()
+        r.command = _Cmd("b'0112': Secondary Air Status")
+        r.value = "Upstream"
+        _mod.new_air_status(r)
+        assert len(_mod.pending_points) == 1
+
+    def test_skips_falsy_value(self):
+        r = MagicMock()
+        r.command = _Cmd("b'0112': Secondary Air Status")
+        r.value = None
+        _mod.new_air_status(r)
+        assert len(_mod.pending_points) == 0
+
+    def test_appends_for_unknown_status(self):
+        r = MagicMock()
+        r.command = _Cmd("b'0112': Secondary Air Status")
+        r.value = "Some new status ELM327 hasn't seen"
+        _mod.new_air_status(r)
+        assert len(_mod.pending_points) == 1
+
+    def test_returns_early_on_malformed_command(self):
+        r = MagicMock()
+        r.command = _Cmd("no colon here")
+        r.value = "Upstream"
+        _mod.new_air_status(r)
+        assert len(_mod.pending_points) == 0
+
+    def test_measurement_name_uses_description(self):
+        r = MagicMock()
+        r.command = _Cmd("b'0112': Secondary Air Status")
+        r.value = "Upstream"
+        captured_name = []
+        original_point = _mod.Point
+
+        def capture_point(name):
+            captured_name.append(name)
+            return original_point(name)
+
+        with patch.object(_mod, "Point", side_effect=capture_point):
+            _mod.new_air_status(r)
+        assert captured_name[0] == "-Secondary-Air-Status"
+
+
 class TestFlushPoints:
     def setup_method(self):
         _reset()

--- a/tests/test_telem.py
+++ b/tests/test_telem.py
@@ -377,3 +377,37 @@ class TestFlushPoints:
         _mod.flush_points(write_api)
         write_api.write.assert_called_once()
         assert len(_mod.pending_points) == 0
+
+
+class TestRouteCommand:
+    def test_excludes_pattern_matches(self):
+        for name in [
+            "PIDS_A", "MIDS_A", "O2_SENSORS", "O2_SENSORS_ALT",
+            "ELM_VERSION", "OBD_COMPLIANCE",
+        ]:
+            assert _mod._route_command(_Cmd(name)) is None
+
+    def test_excludes_skip_names(self):
+        for name in ["FREEZE_DTC", "GET_DTC", "CLEAR_DTC", "FUEL_TYPE"]:
+            assert _mod._route_command(_Cmd(name)) is None
+
+    def test_no_longer_excludes_dtc_substring_numeric_pids(self):
+        for name in [
+            "WARMUPS_SINCE_DTC_CLEAR",
+            "DISTANCE_SINCE_DTC_CLEAR",
+            "TIME_SINCE_DTC_CLEARED",
+        ]:
+            assert _mod._route_command(_Cmd(name)) is _mod.new_value
+
+    def test_routes_status_commands(self):
+        assert _mod._route_command(_Cmd("STATUS")) is _mod.new_status
+        assert _mod._route_command(_Cmd("STATUS_DRIVE_CYCLE")) is _mod.new_status
+
+    def test_routes_air_status(self):
+        assert _mod._route_command(_Cmd("AIR_STATUS")) is _mod.new_air_status
+
+    def test_routes_fuel_status(self):
+        assert _mod._route_command(_Cmd("FUEL_STATUS")) is _mod.new_fuel_status
+
+    def test_routes_generic_numeric_to_new_value(self):
+        assert _mod._route_command(_Cmd("RPM")) is _mod.new_value

--- a/tests/test_telem.py
+++ b/tests/test_telem.py
@@ -278,6 +278,76 @@ class TestNewStatus:
         ]
 
 
+class TestFetchAndStoreDtcs:
+    def setup_method(self):
+        _reset()
+        _mod._connection = None
+
+    def test_no_connection_set_does_nothing(self):
+        _mod._fetch_and_store_dtcs()
+        assert len(_mod.pending_points) == 0
+
+    def test_null_response_does_nothing(self):
+        _mod._connection = MagicMock()
+        r = MagicMock()
+        r.value = None
+        with patch.object(_mod.obd.OBD, "query", return_value=r) as mock_query:
+            _mod._fetch_and_store_dtcs()
+        mock_query.assert_called_once_with(
+            _mod._connection, _mod.obd.commands.GET_DTC, force=True
+        )
+        assert len(_mod.pending_points) == 0
+
+    def test_writes_joined_codes(self):
+        _mod._connection = MagicMock()
+        r = MagicMock()
+        r.value = [
+            ("P0104", "Mass or Volume Air Flow Circuit Intermittent"),
+            ("B0003", ""),
+        ]
+        with patch.object(_mod.obd.OBD, "query", return_value=r):
+            _mod._fetch_and_store_dtcs()
+        assert len(_mod.pending_points) == 1
+
+
+class TestNewStatusDtcTrigger:
+    def setup_method(self):
+        _reset()
+        _mod._last_dtc_count = 0
+        _mod._connection = MagicMock()
+
+    def test_triggers_fetch_on_status_dtc_count_increase(self):
+        r = MagicMock()
+        r.command = _Cmd("b'0101': Status since DTCs cleared", name="STATUS")
+        r.value.MIL = True
+        r.value.DTC_count = 1
+        with patch.object(_mod, "_fetch_and_store_dtcs") as mock_fetch:
+            _mod.new_status(r)
+        mock_fetch.assert_called_once()
+        assert _mod._last_dtc_count == 1
+
+    def test_no_trigger_when_count_unchanged(self):
+        _mod._last_dtc_count = 1
+        r = MagicMock()
+        r.command = _Cmd("b'0101': Status since DTCs cleared", name="STATUS")
+        r.value.MIL = True
+        r.value.DTC_count = 1
+        with patch.object(_mod, "_fetch_and_store_dtcs") as mock_fetch:
+            _mod.new_status(r)
+        mock_fetch.assert_not_called()
+
+    def test_no_trigger_for_status_drive_cycle(self):
+        r = MagicMock()
+        r.command = _Cmd(
+            "b'0141': Monitor status this drive cycle", name="STATUS_DRIVE_CYCLE"
+        )
+        r.value.MIL = True
+        r.value.DTC_count = 5
+        with patch.object(_mod, "_fetch_and_store_dtcs") as mock_fetch:
+            _mod.new_status(r)
+        mock_fetch.assert_not_called()
+
+
 class TestFlushPoints:
     def setup_method(self):
         _reset()

--- a/tests/test_telem.py
+++ b/tests/test_telem.py
@@ -137,6 +137,7 @@ class TestNewAirStatus:
         r.value = "Upstream"
         _mod.new_air_status(r)
         assert len(_mod.pending_points) == 1
+        assert _mod.pending_points[0]._fields == {"value": 0}
 
     def test_skips_falsy_value(self):
         r = MagicMock()
@@ -199,6 +200,7 @@ class TestQueryFuelTypeOnce:
             connection, _mod.obd.commands.FUEL_TYPE, force=True
         )
         assert len(_mod.pending_points) == 1
+        assert _mod.pending_points[0]._fields == {"value": "Gasoline"}
 
     def test_skips_on_falsy_value(self):
         connection = MagicMock()
@@ -243,10 +245,12 @@ class TestNewStatus:
     def test_writes_mil_and_dtc_count_points(self):
         r = MagicMock()
         r.command = _Cmd("b'0101': Status since DTCs cleared", name="STATUS")
-        r.value.MIL = False
+        r.value.MIL = True
         r.value.DTC_count = 0
         _mod.new_status(r)
         assert len(_mod.pending_points) == 2
+        assert _mod.pending_points[0]._fields == {"value": 1}
+        assert _mod.pending_points[1]._fields == {"value": 0}
 
     def test_returns_early_on_malformed_command(self):
         r = MagicMock()
@@ -284,7 +288,8 @@ class TestFetchAndStoreDtcs:
         _mod._connection = None
 
     def test_no_connection_set_does_nothing(self):
-        _mod._fetch_and_store_dtcs()
+        result = _mod._fetch_and_store_dtcs()
+        assert result is False
         assert len(_mod.pending_points) == 0
 
     def test_null_response_does_nothing(self):
@@ -292,10 +297,11 @@ class TestFetchAndStoreDtcs:
         r = MagicMock()
         r.value = None
         with patch.object(_mod.obd.OBD, "query", return_value=r) as mock_query:
-            _mod._fetch_and_store_dtcs()
+            result = _mod._fetch_and_store_dtcs()
         mock_query.assert_called_once_with(
             _mod._connection, _mod.obd.commands.GET_DTC, force=True
         )
+        assert result is False
         assert len(_mod.pending_points) == 0
 
     def test_writes_joined_codes(self):
@@ -306,8 +312,10 @@ class TestFetchAndStoreDtcs:
             ("B0003", ""),
         ]
         with patch.object(_mod.obd.OBD, "query", return_value=r):
-            _mod._fetch_and_store_dtcs()
+            result = _mod._fetch_and_store_dtcs()
+        assert result is True
         assert len(_mod.pending_points) == 1
+        assert _mod.pending_points[0]._fields == {"value": "P0104,B0003"}
 
 
 class TestNewStatusDtcTrigger:
@@ -325,6 +333,15 @@ class TestNewStatusDtcTrigger:
             _mod.new_status(r)
         mock_fetch.assert_called_once()
         assert _mod._last_dtc_count == 1
+
+    def test_does_not_advance_count_when_fetch_fails(self):
+        r = MagicMock()
+        r.command = _Cmd("b'0101': Status since DTCs cleared", name="STATUS")
+        r.value.MIL = True
+        r.value.DTC_count = 1
+        with patch.object(_mod, "_fetch_and_store_dtcs", return_value=False):
+            _mod.new_status(r)
+        assert _mod._last_dtc_count == 0
 
     def test_no_trigger_when_count_unchanged(self):
         _mod._last_dtc_count = 1

--- a/tests/test_telem.py
+++ b/tests/test_telem.py
@@ -1,3 +1,5 @@
+import importlib
+import sys
 from unittest.mock import MagicMock, patch
 
 import lemongrass.telem as _mod
@@ -15,6 +17,7 @@ class _Cmd:
 def _reset():
     _mod.pending_points.clear()
     _mod._last_dtc_count = 0
+    _mod._dtc_fetch_failures = 0
     _mod._connection = None
 
 
@@ -306,14 +309,17 @@ class TestFetchAndStoreDtcs:
         assert result is False
         assert len(_mod.pending_points) == 0
 
-    def test_empty_list_response_does_nothing(self):
+    def test_empty_list_response_queues_empty_snapshot(self):
+        # [] is a successful mode-03 answer ("no stored codes"), not a failure;
+        # treating it as failure would retry the forced query on every STATUS.
         _mod._connection = MagicMock()
         r = MagicMock()
         r.value = []
         with patch.object(_mod.obd.OBD, "query", return_value=r):
             result = _mod._fetch_and_store_dtcs()
-        assert result is False
-        assert len(_mod.pending_points) == 0
+        assert result is True
+        assert len(_mod.pending_points) == 1
+        assert _mod.pending_points[0]._fields == {"value": ""}
 
     def test_writes_joined_codes(self):
         _mod._connection = MagicMock()
@@ -362,6 +368,29 @@ class TestNewStatusDtcTrigger:
         with patch.object(_mod, "_fetch_and_store_dtcs") as mock_fetch:
             _mod.new_status(r)
         mock_fetch.assert_not_called()
+
+    def test_gives_up_after_max_consecutive_fetch_failures(self):
+        r = MagicMock()
+        r.command = _Cmd("b'0101': Status since DTCs cleared", name="STATUS")
+        r.value.MIL = True
+        r.value.DTC_count = 1
+        with patch.object(_mod, "_fetch_and_store_dtcs", return_value=False) as mock_fetch:
+            for _ in range(3):
+                _mod.new_status(r)
+            assert _mod._last_dtc_count == 1  # gave up; stop hammering the adapter
+            _mod.new_status(r)
+        assert mock_fetch.call_count == 3
+
+    def test_failure_count_resets_on_successful_fetch(self):
+        r = MagicMock()
+        r.command = _Cmd("b'0101': Status since DTCs cleared", name="STATUS")
+        r.value.MIL = True
+        r.value.DTC_count = 1
+        with patch.object(_mod, "_fetch_and_store_dtcs", side_effect=[False, False, True]):
+            for _ in range(3):
+                _mod.new_status(r)
+        assert _mod._last_dtc_count == 1
+        assert _mod._dtc_fetch_failures == 0
 
     def test_no_trigger_for_status_drive_cycle(self):
         r = MagicMock()
@@ -438,3 +467,34 @@ class TestRouteCommand:
 
     def test_routes_generic_numeric_to_new_value(self):
         assert _mod._route_command(_Cmd("RPM")) is _mod.new_value
+
+    def test_excludes_mode2_freeze_frame_twins(self):
+        # python-obd adds a DTC_-prefixed mode-2 twin for every supported
+        # mode-1 PID; watching them doubles per-cycle adapter load.
+        for name in ["DTC_RPM", "DTC_FUEL_STATUS", "DTC_STATUS", "DTC_COOLANT_TEMP"]:
+            assert _mod._route_command(_Cmd(name)) is None
+
+    def test_excludes_get_current_dtc(self):
+        assert _mod._route_command(_Cmd("GET_CURRENT_DTC")) is None
+
+    def test_no_real_dtc_command_is_watched(self):
+        # Guard against the real library inventory, not just names we expect:
+        # no mode-2 freeze-frame twin and no mode-03/07 DTC command may route
+        # to a callback. conftest mocks obd suite-wide, so temporarily import
+        # the real module (same pop/restore idiom conftest uses for race_monitor).
+        mock_obd = sys.modules.pop("obd")
+        try:
+            real_obd = importlib.import_module("obd")
+        finally:
+            sys.modules["obd"] = mock_obd
+
+        dtc_commands = {"GET_DTC", "GET_CURRENT_DTC", "CLEAR_DTC", "FREEZE_DTC"}
+        checked = 0
+        for mode in real_obd.commands.modes:
+            for command in mode:
+                if command is None:
+                    continue
+                if command.name.startswith("DTC_") or command.name in dtc_commands:
+                    assert _mod._route_command(command) is None, command.name
+                    checked += 1
+        assert checked > 90  # the mode-2 twins alone number ~96; 0 means vacuous

--- a/tests/test_telem.py
+++ b/tests/test_telem.py
@@ -14,6 +14,8 @@ class _Cmd:
 
 def _reset():
     _mod.pending_points.clear()
+    _mod._last_dtc_count = 0
+    _mod._connection = None
 
 
 class TestConnect:
@@ -152,6 +154,7 @@ class TestNewAirStatus:
         r.value = "Some new status ELM327 hasn't seen"
         _mod.new_air_status(r)
         assert len(_mod.pending_points) == 1
+        assert _mod.pending_points[0]._fields == {"value": 255}
 
     def test_returns_early_on_malformed_command(self):
         r = MagicMock()
@@ -285,7 +288,6 @@ class TestNewStatus:
 class TestFetchAndStoreDtcs:
     def setup_method(self):
         _reset()
-        _mod._connection = None
 
     def test_no_connection_set_does_nothing(self):
         result = _mod._fetch_and_store_dtcs()
@@ -301,6 +303,15 @@ class TestFetchAndStoreDtcs:
         mock_query.assert_called_once_with(
             _mod._connection, _mod.obd.commands.GET_DTC, force=True
         )
+        assert result is False
+        assert len(_mod.pending_points) == 0
+
+    def test_empty_list_response_does_nothing(self):
+        _mod._connection = MagicMock()
+        r = MagicMock()
+        r.value = []
+        with patch.object(_mod.obd.OBD, "query", return_value=r):
+            result = _mod._fetch_and_store_dtcs()
         assert result is False
         assert len(_mod.pending_points) == 0
 
@@ -321,7 +332,6 @@ class TestFetchAndStoreDtcs:
 class TestNewStatusDtcTrigger:
     def setup_method(self):
         _reset()
-        _mod._last_dtc_count = 0
         _mod._connection = MagicMock()
 
     def test_triggers_fetch_on_status_dtc_count_increase(self):

--- a/tests/test_telem.py
+++ b/tests/test_telem.py
@@ -174,6 +174,60 @@ class TestNewAirStatus:
         assert captured_name[0] == "-Secondary-Air-Status"
 
 
+class TestQueryFuelTypeOnce:
+    def setup_method(self):
+        _reset()
+
+    def test_skips_when_unsupported(self):
+        connection = MagicMock()
+        connection.supports.return_value = False
+        with patch.object(_mod.obd.OBD, "query") as mock_query:
+            _mod._query_fuel_type_once(connection)
+        mock_query.assert_not_called()
+        assert len(_mod.pending_points) == 0
+
+    def test_writes_point_when_supported(self):
+        connection = MagicMock()
+        connection.supports.return_value = True
+        r = MagicMock()
+        r.command = _Cmd("b'0151': Fuel Type")
+        r.value = "Gasoline"
+        with patch.object(_mod.obd.OBD, "query", return_value=r) as mock_query:
+            _mod._query_fuel_type_once(connection)
+        mock_query.assert_called_once_with(
+            connection, _mod.obd.commands.FUEL_TYPE, force=True
+        )
+        assert len(_mod.pending_points) == 1
+
+    def test_skips_on_falsy_value(self):
+        connection = MagicMock()
+        connection.supports.return_value = True
+        r = MagicMock()
+        r.command = _Cmd("b'0151': Fuel Type")
+        r.value = None
+        with patch.object(_mod.obd.OBD, "query", return_value=r):
+            _mod._query_fuel_type_once(connection)
+        assert len(_mod.pending_points) == 0
+
+    def test_measurement_name_uses_description(self):
+        connection = MagicMock()
+        connection.supports.return_value = True
+        r = MagicMock()
+        r.command = _Cmd("b'0151': Fuel Type")
+        r.value = "Gasoline"
+        captured_name = []
+        original_point = _mod.Point
+
+        def capture_point(name):
+            captured_name.append(name)
+            return original_point(name)
+
+        with patch.object(_mod.obd.OBD, "query", return_value=r), \
+                patch.object(_mod, "Point", side_effect=capture_point):
+            _mod._query_fuel_type_once(connection)
+        assert captured_name[0] == "-Fuel-Type"
+
+
 class TestFlushPoints:
     def setup_method(self):
         _reset()

--- a/tests/test_telem.py
+++ b/tests/test_telem.py
@@ -4,8 +4,9 @@ import lemongrass.telem as _mod
 
 
 class _Cmd:
-    def __init__(self, s):
+    def __init__(self, s, name=None):
         self._s = s
+        self.name = name if name is not None else s
 
     def __str__(self):
         return self._s
@@ -226,6 +227,55 @@ class TestQueryFuelTypeOnce:
                 patch.object(_mod, "Point", side_effect=capture_point):
             _mod._query_fuel_type_once(connection)
         assert captured_name[0] == "-Fuel-Type"
+
+
+class TestNewStatus:
+    def setup_method(self):
+        _reset()
+
+    def test_skips_null_value(self):
+        r = MagicMock()
+        r.command = _Cmd("b'0101': Status since DTCs cleared", name="STATUS")
+        r.value = None
+        _mod.new_status(r)
+        assert len(_mod.pending_points) == 0
+
+    def test_writes_mil_and_dtc_count_points(self):
+        r = MagicMock()
+        r.command = _Cmd("b'0101': Status since DTCs cleared", name="STATUS")
+        r.value.MIL = False
+        r.value.DTC_count = 0
+        _mod.new_status(r)
+        assert len(_mod.pending_points) == 2
+
+    def test_returns_early_on_malformed_command(self):
+        r = MagicMock()
+        r.command = _Cmd("no colon here", name="STATUS")
+        r.value.MIL = False
+        r.value.DTC_count = 0
+        _mod.new_status(r)
+        assert len(_mod.pending_points) == 0
+
+    def test_measurement_names_use_description(self):
+        r = MagicMock()
+        r.command = _Cmd(
+            "b'0141': Monitor status this drive cycle", name="STATUS_DRIVE_CYCLE"
+        )
+        r.value.MIL = True
+        r.value.DTC_count = 2
+        captured_names = []
+        original_point = _mod.Point
+
+        def capture_point(name):
+            captured_names.append(name)
+            return original_point(name)
+
+        with patch.object(_mod, "Point", side_effect=capture_point):
+            _mod.new_status(r)
+        assert captured_names == [
+            "-Monitor-status-this-drive-cycle-MIL",
+            "-Monitor-status-this-drive-cycle-DTC-Count",
+        ]
 
 
 class TestFlushPoints:


### PR DESCRIPTION
## Summary
- Fix a real bug: the blanket `"DTC"` substring exclusion was wrongly dropping storable numeric PIDs (`WARMUPS_SINCE_DTC_CLEAR`, `DISTANCE_SINCE_DTC_CLEAR`, `TIME_SINCE_DTC_CLEARED`) every cycle. Replaced with a precise `_route_command` dispatch table that still excludes the ~90 `DTC_`-prefixed mode-2 freeze-frame twins and `GET_CURRENT_DTC` (python-obd marks a mode-2 twin supported for every supported mode-1 PID; watching them would double per-cycle adapter load), guarded by a test against python-obd's real command inventory.
- Stop wasting serial round-trips on non-numeric PIDs that `new_value` always discarded (`AIR_STATUS`, `FUEL_TYPE`, `STATUS_DRIVE_CYCLE`), and instead capture them usefully:
  - `AIR_STATUS` → mapped-enum measurement (same pattern as `FUEL_STATUS`)
  - `FUEL_TYPE` → queried once at connect time instead of watched every cycle (it never changes mid-session)
  - `STATUS`/`STATUS_DRIVE_CYCLE` → MIL (check-engine light) and DTC count as live points
  - Event-driven live `GET_DTC` lookup whenever `STATUS`'s DTC count rises, bypassing `Async`'s cached `query()` to force a real serial read — verified safe against the pinned `obd~=0.7` source (callback runs on the same single background thread, no lock needed)
- Keep the forced `GET_DTC` path bounded: an empty list is recorded as a successful "no stored codes" snapshot (only a null response is a failure), and after 3 consecutive failed fetches the trigger gives up instead of retrying a blocking serial query on every `STATUS` callback.

Full design rationale: `docs/superpowers/specs/2026-07-01-obd-telemetry-watch-list-optimization-design.md` (not committed — gitignored per this project's convention).

## Test plan
- [x] `uv run pytest` — 452/452 passing
- [x] `uv run ruff check` — clean
- [x] Implemented via subagent-driven-development: 6 tasks, each independently reviewed for spec compliance + code quality
- [x] Whole-branch review (Opus) after task 6, then a second whole-branch review (Fable) that verified its claims against the installed python-obd source; the second review found 1 Critical (mode-2 `DTC_*` twins + `GET_CURRENT_DTC` admitted to the watch list) and 1 Important (unbounded forced-`GET_DTC` retry on persistent failure/empty-list disagreement), both fixed test-first in the final commit
- [ ] Manual/hardware verification on real OBD-II adapter (not done in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added expanded telemetry capture for air-system status, fuel type, and active diagnostic trouble codes.
  * Enhanced status reporting to consistently publish MIL and DTC-count data, with DTC snapshots triggered when DTC counts rise.
* **Bug Fixes**
  * Improved command handling by routing supported OBD commands through a centralized dispatcher with better filtering to avoid irrelevant commands.
* **Tests**
  * Expanded automated coverage for routing, air/fuel/status callbacks, and DTC snapshot trigger logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
