### PR TITLE
feat: adopt race-monitor 0.7.0 and resolve codebase review findings

### DIFF
--- a/.github/workflows/python-syntax.yml
+++ b/.github/workflows/python-syntax.yml
@@ -18,4 +18,4 @@ jobs:
           version: "0.11.24"
 
       - name: Check syntax and style
-        run: uv run --with ruff ruff check .
+        run: uv run ruff check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "obd~=0.7",
     "pandas~=2.3",
     "race-monitor>=0.6.1,<1",
+    "urllib3>=2",
 ]
 
 [project.urls]
@@ -50,4 +51,4 @@ select = ["E", "F", "W", "D1", "I", "B", "UP", "RUF", "N", "C4", "SIM"]
 "tests/**" = ["D1", "SIM117"]
 
 [dependency-groups]
-dev = ["pytest>=8"]
+dev = ["pytest>=8", "ruff>=0.14"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "influxdb-client~=1.47",
     "obd~=0.7",
     "pandas~=2.3",
-    "race-monitor>=0.6.1,<1",
+    "race-monitor>=0.7.0,<1",
     "urllib3>=2",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,4 +51,4 @@ select = ["E", "F", "W", "D1", "I", "B", "UP", "RUF", "N", "C4", "SIM"]
 "tests/**" = ["D1", "SIM117"]
 
 [dependency-groups]
-dev = ["pytest>=8", "ruff>=0.14"]
+dev = ["pytest>=8", "ruff>=0.14,<1.0"]

--- a/src/lemongrass/_influx.py
+++ b/src/lemongrass/_influx.py
@@ -51,6 +51,13 @@ def connect():
     )
 
 
+# Lap timestamps are session-anchored and Flux `stop` is exclusive, so laps can
+# legitimately fall outside the nominal race bounds; pad the window instead of
+# trusting Start/EndDateEpoc exactly. The race_id tag filter stays the exact selector.
+# Shared by race_backfill and race_diagnose so the two padding windows can't drift.
+WINDOW_PAD_S = 86400
+
+
 _FLUX_ID_RE = re.compile(r'^[A-Za-z0-9_-]+$')
 
 

--- a/src/lemongrass/_influx.py
+++ b/src/lemongrass/_influx.py
@@ -6,6 +6,7 @@ InfluxDBClient the same way.
 """
 import logging
 import os
+import re
 import sys
 
 from urllib3 import Retry
@@ -48,3 +49,16 @@ def connect():
     return InfluxDBClient(
         url=INFLUX_URL, token=token, org=INFLUX_ORG, retries=INFLUX_RETRIES
     )
+
+
+_FLUX_ID_RE = re.compile(r'^[A-Za-z0-9_-]+$')
+
+
+def invalid_flux_ids(values):
+    """Return the values unsafe to interpolate into a Flux string literal.
+
+    Race/car identifiers are interpolated into Flux queries and delete
+    predicates; restricting them to [A-Za-z0-9_-] rules out quotes and other
+    metacharacters that would break (or alter) the query.
+    """
+    return [v for v in values if not _FLUX_ID_RE.fullmatch(str(v))]

--- a/src/lemongrass/cli.py
+++ b/src/lemongrass/cli.py
@@ -72,7 +72,7 @@ def main():
     # any ApiException/HTTPError is an InfluxDB failure. Report it cleanly (no
     # traceback), distinguishing "unreachable" from a reached-but-rejected request.
     try:
-        importlib.import_module(_COMMANDS[cmd]).main()
+        result = importlib.import_module(_COMMANDS[cmd]).main()
     except (ApiException, HTTPError) as exc:
         if _influx_unreachable(exc):
             print(f"Error: cannot reach InfluxDB at {_influx.INFLUX_URL}", file=sys.stderr)
@@ -80,3 +80,4 @@ def main():
             print(f"Error: InfluxDB request failed at {_influx.INFLUX_URL}", file=sys.stderr)
         print(f"  {_format_influx_error(exc)}", file=sys.stderr)
         sys.exit(1)
+    sys.exit(result)

--- a/src/lemongrass/cli.py
+++ b/src/lemongrass/cli.py
@@ -4,6 +4,7 @@ import json
 import sys
 
 from influxdb_client.rest import ApiException
+from race_monitor import RaceMonitorError, RaceMonitorHTTPError
 from urllib3.exceptions import HTTPError
 
 from lemongrass import _influx
@@ -54,6 +55,24 @@ def _format_influx_error(exc):
     return str(exc) or exc.__class__.__name__
 
 
+def _report_race_monitor_error(exc):
+    """Print a one-line reason for a RaceMonitor API failure (no traceback).
+
+    race-monitor 0.7.0 bounds 429 retries by max_retries and raises
+    RaceMonitorHTTPError once they're exhausted instead of retrying forever, so
+    the CLI must surface rate-limit exhaustion cleanly rather than crashing."""
+    if isinstance(exc, RaceMonitorHTTPError) and exc.status_code == 429:
+        print("Error: RaceMonitor rate limit exceeded (HTTP 429) — retries "
+              "exhausted. Try again in a minute.", file=sys.stderr)
+    elif isinstance(exc, RaceMonitorHTTPError):
+        print(f"Error: RaceMonitor request failed (HTTP {exc.status_code})",
+              file=sys.stderr)
+        if exc.body:
+            print(f"  {' '.join(str(exc.body).split())}", file=sys.stderr)
+    else:
+        print(f"Error: RaceMonitor client error: {exc}", file=sys.stderr)
+
+
 def main():
     """Dispatch to the subcommand named by the first CLI argument."""
     if len(sys.argv) >= 2 and sys.argv[1] in ("-h", "--help"):
@@ -68,9 +87,10 @@ def main():
 
     cmd = sys.argv.pop(1)
     sys.argv[0] = f"lemongrass-{cmd}"
-    # The only urllib3/HTTP traffic in these commands is the InfluxDB client, so
-    # any ApiException/HTTPError is an InfluxDB failure. Report it cleanly (no
-    # traceback), distinguishing "unreachable" from a reached-but-rejected request.
+    # Two HTTP clients can fail here: the InfluxDB client (ApiException/HTTPError)
+    # and the RaceMonitor client (RaceMonitorError). Report either cleanly (no
+    # traceback); for Influx, distinguish "unreachable" from a reached-but-rejected
+    # request.
     try:
         result = importlib.import_module(_COMMANDS[cmd]).main()
     except (ApiException, HTTPError) as exc:
@@ -79,5 +99,8 @@ def main():
         else:
             print(f"Error: InfluxDB request failed at {_influx.INFLUX_URL}", file=sys.stderr)
         print(f"  {_format_influx_error(exc)}", file=sys.stderr)
+        sys.exit(1)
+    except RaceMonitorError as exc:
+        _report_race_monitor_error(exc)
         sys.exit(1)
     sys.exit(result)

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -625,7 +625,11 @@ def monitor_routine(ctx, laps, opts, competitor_name=None, car_info=None, _stop_
             poll_count += 1
 
             if opts.network_mode and ctx.start_epoc == 0:
-                race_details = ctx.client.race.details(ctx.race_id)
+                try:
+                    race_details = ctx.client.race.details(ctx.race_id)
+                except Exception:
+                    logging.debug("race details refresh failed; skipping epoch recheck")
+                    race_details = {'Successful': False}
                 if race_details.get('Successful'):
                     new_epoc = race_details['Race'].get('StartDateEpoc', 0)
                     if new_epoc != 0:
@@ -665,7 +669,11 @@ def monitor_routine(ctx, laps, opts, competitor_name=None, car_info=None, _stop_
                 except Exception:
                     logging.debug("is_live check failed; skipping")
 
-            current_competitor_lap_times = refresh_competitor(ctx)
+            try:
+                current_competitor_lap_times = refresh_competitor(ctx)
+            except Exception:
+                logging.debug("refresh_competitor failed; skipping this poll")
+                continue
             if not current_competitor_lap_times:
                 continue
 

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -401,6 +401,7 @@ def old_race(ctx, opts):
                 'start_epoc': start_epoc,
                 'competitors': [],
             }
+            class_index = _build_class_index(session_details)
             for competitor in sorted_competitors:
                 comp_laps = competitor.get('LapTimes', [])
                 if not comp_laps:
@@ -439,7 +440,7 @@ def old_race(ctx, opts):
                         'FlagStatus': flag_map.get(lap['FlagStatus'], str(lap['FlagStatus'])),
                     })
                 class_name, class_positions = _resolve_class_historical(
-                    comp_number, session_details)
+                    comp_number, session_details, class_index)
                 session_entry['competitors'].append({
                     'influx_laps': influx_laps,
                     'competitor_name': comp_name,
@@ -1052,25 +1053,48 @@ def existing_standings_counts_fieldwide(ctx):
     return total, current
 
 
-def _resolve_class_historical(car_number, session_details):
-    """Return (class_name, {lap_num: class_position}) for the given car_number."""
+def _build_class_index(session_details):
+    """Precompute per-session class-position data shared by every competitor.
+
+    Returns (categories, category_by_car, laps_by_car, positions_by_category):
+    laps_by_car maps car_number -> {lap_num: overall_position} and
+    positions_by_category maps category -> {lap_num: [overall_positions]} across
+    all cars in that category. Built once per session so resolving N competitors
+    is O(total laps), not O(N * total laps).
+    """
     session = session_details['Session']
-    competitors = session['SortedCompetitors']
     categories = session['Categories']
+    category_by_car = {}
+    laps_by_car = {}
+    positions_by_category = defaultdict(lambda: defaultdict(list))
+    for competitor in session['SortedCompetitors']:
+        number = competitor['Number']
+        category_by_car[number] = competitor['Category']
+        lap_positions = {}
+        for lap in competitor['LapTimes']:
+            try:
+                lap_positions[int(lap['Lap'])] = int(lap['Position'])
+            except (ValueError, TypeError):
+                logging.debug("%s in class resolution; skipping",
+                              _describe_bad_value(lap['Lap'], 'Lap'))
+        laps_by_car[number] = lap_positions
+        for lap_num, pos in lap_positions.items():
+            positions_by_category[competitor['Category']][lap_num].append(pos)
+    return categories, category_by_car, laps_by_car, positions_by_category
 
-    tracked_category = None
-    tracked_laps = {}
-    for competitor in competitors:
-        if competitor['Number'] == car_number:
-            tracked_category = competitor['Category']
-            for lap in competitor['LapTimes']:
-                try:
-                    tracked_laps[int(lap['Lap'])] = int(lap['Position'])
-                except (ValueError, TypeError):
-                    logging.debug("%s in class resolution; skipping",
-                                  _describe_bad_value(lap['Lap'], 'Lap'))
-            break
 
+def _resolve_class_historical(car_number, session_details, index=None):
+    """Return (class_name, {lap_num: class_position}) for the given car_number.
+
+    index is the result of _build_class_index for this session; callers resolving
+    many cars should build it once and pass it in. When omitted it is built on
+    the fly (single-car callers and tests).
+    """
+    if index is None:
+        index = _build_class_index(session_details)
+    categories, category_by_car, laps_by_car, positions_by_category = index
+
+    tracked_category = category_by_car.get(car_number)
     if tracked_category is None:
         return None, {}
 
@@ -1079,20 +1103,12 @@ def _resolve_class_historical(car_number, session_details):
         .get('Name', tracked_category)
     )
 
-    class_lap_positions = defaultdict(list)
-    for competitor in competitors:
-        if competitor['Number'] == car_number or competitor['Category'] != tracked_category:
-            continue
-        for lap in competitor['LapTimes']:
-            try:
-                class_lap_positions[int(lap['Lap'])].append(int(lap['Position']))
-            except (ValueError, TypeError):
-                logging.debug("%s in class position resolution; skipping",
-                              _describe_bad_value(lap['Lap'], 'Lap'))
-
+    # The tracked car's own position is never < itself, so including it in the
+    # per-category lists (unlike the old per-car rescan) does not change counts.
+    class_lap_positions = positions_by_category[tracked_category]
     class_positions = {
         lap_num: 1 + sum(1 for pos in class_lap_positions.get(lap_num, []) if pos < tracked_pos)
-        for lap_num, tracked_pos in tracked_laps.items()
+        for lap_num, tracked_pos in laps_by_car[car_number].items()
     }
 
     return class_name, class_positions

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -71,6 +71,7 @@ class MonitorStatus(enum.Enum):
 
     RACE_ENDED = "race_ended"
     INTERRUPTED = "interrupted"
+    NO_LIVE_DATA = "no_live_data"
 
 
 @dataclass
@@ -256,8 +257,11 @@ def _run_race(ctx, opts, response):
             old_race(ctx, opts)
         else:
             logging.info("Race %s is currently live.", ctx.race_id)
-            if live_race(ctx, opts) is MonitorStatus.INTERRUPTED:
+            result = live_race(ctx, opts)
+            if result is MonitorStatus.INTERRUPTED:
                 sys.exit(130)
+            if result is MonitorStatus.NO_LIVE_DATA:
+                return 1
         return 0
     except KeyboardInterrupt:
         logging.info("Interrupted, exiting.")
@@ -278,24 +282,23 @@ def live_race(ctx, opts):
 
     print_rankings([], True, opts.selected_class, {})
 
-    competitor_details = {}
-    laps = []
-
     # Get lap times from live racer
     logging.debug("Getting lap times for %s from race %s.", ctx.car_number, ctx.race_id)
     response = ctx.client.live.get_racer(ctx.race_id, ctx.car_number)
 
-    if response['Successful']:
-        laps = response['Details']['Laps']
-        competitor_details = response['Details']['Competitor']
+    if not response['Successful']:
+        logging.error(
+            "No live data for car %s in race %s — check that the car number is "
+            "registered in the live feed", ctx.car_number, ctx.race_id)
+        return MonitorStatus.NO_LIVE_DATA
 
-    # Make name
-    competitor_details['Name'] = (
-        competitor_details['FirstName'] + ' ' + competitor_details['LastName'])
+    laps = response['Details']['Laps']
+    competitor_details = response['Details']['Competitor']
 
     first = competitor_details.get('FirstName', '')
     last = competitor_details.get('LastName', '')
-    competitor_name = f"{first} {last}".strip() or None
+    competitor_details['Name'] = f"{first} {last}".strip()
+    competitor_name = competitor_details['Name'] or None
     car_info = competitor_details.get('AdditionalData') or None
     class_name, class_position = _resolve_class_live(session_response, ctx.car_number)
 

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -72,6 +72,7 @@ class MonitorStatus(enum.Enum):
     RACE_ENDED = "race_ended"
     INTERRUPTED = "interrupted"
     NO_LIVE_DATA = "no_live_data"
+    WRITE_FAILED = "write_failed"
 
 
 @dataclass
@@ -275,6 +276,8 @@ def _run_race(ctx, opts, response):
                 sys.exit(130)
             if result is MonitorStatus.NO_LIVE_DATA:
                 return 1
+            if result is MonitorStatus.WRITE_FAILED:
+                return 1
         return 0
     except KeyboardInterrupt:
         logging.info("Interrupted, exiting.")
@@ -339,9 +342,10 @@ def live_race(ctx, opts):
     print(lap_time_df.to_string(index=False))
     print(UNDERLINE)
 
+    race_meta_written = True
     if opts.network_mode:
         race_ts_ms = ctx.start_epoc * 1000 if ctx.start_epoc != 0 else int(time.time() * 1000)
-        push_influx_race(ctx, race_ts_ms)
+        race_meta_written = push_influx_race(ctx, race_ts_ms)
         if live_session_id is not None:
             push_influx_session(ctx, live_session_id, live_session_name, None)
         if laps:
@@ -360,7 +364,12 @@ def live_race(ctx, opts):
 
     if opts.monitor_mode:
         return monitor_routine(ctx, laps, opts, competitor_name=competitor_name, car_info=car_info,
-                               session_id=live_session_id)
+                               session_id=live_session_id, race_meta_written=race_meta_written)
+
+    if opts.network_mode and not race_meta_written:
+        # No monitor loop to retry in; signal a failed run so a rerun restores
+        # the (possibly deleted) race metadata point.
+        return MonitorStatus.WRITE_FAILED
 
 
 def old_race(ctx, opts):
@@ -448,6 +457,14 @@ def old_race(ctx, opts):
                         **lap,
                         'FlagStatus': flag_map.get(lap['FlagStatus'], str(lap['FlagStatus'])),
                     })
+                if not influx_laps:
+                    # Every lap was filtered out; appending an empty competitor would
+                    # leave expected==0 and let the write path delete existing laps
+                    # without writing replacements.
+                    logging.warning(
+                        "No parseable laps for car %s; excluding competitor from backfill",
+                        comp_number)
+                    continue
                 class_name, class_positions = _resolve_class_historical(
                     comp_number, session_details, class_index)
                 session_entry['competitors'].append({
@@ -652,7 +669,7 @@ def write_csv(filename, competitor_lap_times):
 
 
 def monitor_routine(ctx, laps, opts, competitor_name=None, car_info=None, _stop_event=None,
-                    session_id=None) -> MonitorStatus | None:
+                    session_id=None, race_meta_written=True) -> MonitorStatus | None:
     """Poll for new laps during a live race, printing and optionally pushing each to InfluxDB.
 
     Returns MonitorStatus.RACE_ENDED when the race ends naturally, or
@@ -660,6 +677,10 @@ def monitor_routine(ctx, laps, opts, competitor_name=None, car_info=None, _stop_
     _stop_event may be injected for testing; defaults to a new threading.Event.
     session_id is tracked across polls and tags each written lap point; a new
     session push fires whenever the live session ID changes.
+    race_meta_written reflects whether the caller's initial push_influx_race
+    succeeded; when False (or after the epoch is corrected below) the metadata
+    write is retried each poll until it lands, so a transient delete/write
+    failure self-heals without aborting lap capture.
     """
     logging.info("Monitoring car %s...", ctx.car_number)
     print(UNDERLINE)
@@ -688,7 +709,12 @@ def monitor_routine(ctx, laps, opts, competitor_name=None, car_info=None, _stop_
                         if ctx.metadata is not None:
                             ctx.metadata.end_time_epoc = race_details['Race'].get(
                                 'EndDateEpoc', ctx.metadata.end_time_epoc)
-                        push_influx_race(ctx, ctx.start_epoc * 1000)
+                        # Force a rewrite with the corrected timestamp; the retry
+                        # block below performs it and re-attempts on failure.
+                        race_meta_written = False
+
+            if opts.network_mode and ctx.start_epoc != 0 and not race_meta_written:
+                race_meta_written = push_influx_race(ctx, ctx.start_epoc * 1000)
 
             try:
                 session_response = ctx.client.live.get_session(ctx.race_id)
@@ -1085,12 +1111,12 @@ def _build_class_index(session_details):
         number = competitor['Number']
         category_by_car[number] = competitor['Category']
         lap_positions = {}
-        for lap in competitor['LapTimes']:
+        for lap in competitor.get('LapTimes', []):
             try:
                 lap_positions[int(lap['Lap'])] = int(lap['Position'])
-            except (ValueError, TypeError):
+            except (KeyError, ValueError, TypeError):
                 logging.debug("%s in class resolution; skipping",
-                              _describe_bad_value(lap['Lap'], 'Lap'))
+                              _describe_bad_value(lap.get('Lap'), 'Lap'))
         laps_by_car[number] = lap_positions
         for lap_num, pos in lap_positions.items():
             positions_by_category[competitor['Category']][lap_num].append(pos)

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -161,6 +161,18 @@ def main():
     # Pandas default max rows truncating lap times. I don't expect a team to do more than 1024 laps.
     pandas.set_option("display.max_rows", 1024)
 
+    race_id = str(args.race_id[0])
+    car_number = str(args.car_number) if args.car_number is not None else None
+
+    # Validate user-supplied identifiers before touching RaceMonitor/Influx —
+    # race_id and car_number are interpolated into Flux delete predicates and
+    # queries below, so an unsafe value must not reach token resolution.
+    ids_to_check = [race_id] if car_number is None else [race_id, car_number]
+    bad_ids = _influx.invalid_flux_ids(ids_to_check)
+    if bad_ids:
+        logging.error("invalid identifier(s): %s", ", ".join(f'"{b}"' for b in bad_ids))
+        sys.exit(1)
+
     tokens = resolve_tokens()
     if not tokens:
         logging.error("RACEMONITOR_TOKENS or RACEMONITOR_TOKEN environment variable not set")
@@ -172,9 +184,6 @@ def main():
             and not os.environ.get('INFLUX_TELEMETRY_TOKEN')):
         logging.error("INFLUX_TELEMETRY_TOKEN environment variable not set")
         sys.exit(1)
-
-    race_id = str(args.race_id[0])
-    car_number = str(args.car_number) if args.car_number is not None else None
 
     opts = RaceOptions(
         network_mode=args.network_mode or args.dry_run,

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -363,11 +363,21 @@ def old_race(ctx, opts):
     logging.debug("Getting sessions for race for %s", ctx.race_id)
     race_details = ctx.client.results.sessions_for_race(ctx.race_id)
 
-    session_ids_for_race = [s['ID'] for s in race_details['Sessions']]
+    session_ids_for_race = [s['ID'] for s in race_details.get('Sessions', [])]
+
+    if not session_ids_for_race:
+        logging.warning(
+            "No sessions found for race %s — nothing to display or write", ctx.race_id)
+        return
 
     logging.debug(
         "Race %s has %s sessions, %s",
         ctx.race_id, len(session_ids_for_race), session_ids_for_race)
+
+    if not opts.network_mode:
+        # Display mode prints only the final session's rankings; fetching the
+        # earlier sessions would spend RaceMonitor rate limit on discarded data.
+        session_ids_for_race = session_ids_for_race[-1:]
 
     pending_writes = []
 

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -582,7 +582,7 @@ def old_race(ctx, opts):
             if delete_existing_standings(ctx):
                 logging.error(
                     "Standings incomplete for race %s — cleared partial standings; "
-                    "the next backfill will rewrite them", ctx.race_id)
+                    "failing the run so the next backfill rewrites them", ctx.race_id)
             else:
                 logging.error(
                     "Standings incomplete for race %s and the cleanup delete failed; "
@@ -713,8 +713,15 @@ def monitor_routine(ctx, laps, opts, competitor_name=None, car_info=None, _stop_
                         # block below performs it and re-attempts on failure.
                         race_meta_written = False
 
-            if opts.network_mode and ctx.start_epoc != 0 and not race_meta_written:
-                race_meta_written = push_influx_race(ctx, ctx.start_epoc * 1000)
+            if opts.network_mode and not race_meta_written:
+                # Fall back to wall-clock (like live_race's initial write) when
+                # RaceMonitor still hasn't posted a start epoch — the point must
+                # not stay missing just because the epoch never arrives; the
+                # epoch recheck above forces a rewrite if it shows up later.
+                race_ts_ms = (
+                    ctx.start_epoc * 1000 if ctx.start_epoc != 0 else int(time.time() * 1000)
+                )
+                race_meta_written = push_influx_race(ctx, race_ts_ms)
 
             try:
                 session_response = ctx.client.live.get_session(ctx.race_id)

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -587,6 +587,7 @@ def old_race(ctx, opts):
                 logging.error(
                     "Standings incomplete for race %s and the cleanup delete failed; "
                     "rerun with --force to rewrite standings", ctx.race_id)
+            return 1
 
     print_rankings(sorted_competitors, False, opts.selected_class,
                    session_details['Session']['Categories'])

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -818,7 +818,12 @@ def _build_lap_points(ctx, laps, competitor_name, car_info, class_name, class_po
     start_epoc_ms = effective_epoc * 1000
     points = []
     for lap in laps:
-        time_lap_completed_ms = start_epoc_ms + (_time_to_ms(lap['TotalTime']) or 0)
+        total_time_ms = _time_to_ms(lap['TotalTime'])
+        if total_time_ms is None:
+            logging.warning("%s for %s; skipping lap",
+                            _describe_bad_value(lap['TotalTime'], 'TotalTime'), competitor_name)
+            continue
+        time_lap_completed_ms = start_epoc_ms + total_time_ms
         lap_time_ms = _time_to_ms(lap['LapTime'])
         try:
             lap_num = int(lap['Lap'])

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -257,6 +257,10 @@ def _run_race(ctx, opts, response):
             old_race(ctx, opts)
         else:
             logging.info("Race %s is currently live.", ctx.race_id)
+            if opts.dry_run:
+                logging.error(
+                    "--dry-run is historical-only; race %s is live", ctx.race_id)
+                return 1
             result = live_race(ctx, opts)
             if result is MonitorStatus.INTERRUPTED:
                 sys.exit(130)

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -254,7 +254,7 @@ def _run_race(ctx, opts, response):
             logging.info("Race %s is not live. Monitor mode disabled.", ctx.race_id)
             if opts.monitor_mode:
                 return 0
-            old_race(ctx, opts)
+            return old_race(ctx, opts) or 0
         else:
             logging.info("Race %s is currently live.", ctx.race_id)
             if opts.dry_run:
@@ -479,7 +479,11 @@ def old_race(ctx, opts):
                     race_ts_ms = (
                         ctx.start_epoc * 1000 if ctx.start_epoc != 0 else int(time.time() * 1000)
                     )
-                    push_influx_race(ctx, race_ts_ms)
+                    if not push_influx_race(ctx, race_ts_ms):
+                        logging.error(
+                            "Race metadata write failed for race %s — failing the "
+                            "run so the next backfill retries", ctx.race_id)
+                        return 1
                     logging.info(
                         "SKIP: race %s already complete and current (%d laps, schema v%d)",
                         ctx.race_id, total, SCHEMA_VERSION)
@@ -505,11 +509,16 @@ def old_race(ctx, opts):
                         comp['car_number'], session['session_id']))
                 _write_points_chunked(ctx.write_api, session_points)
             logging.info("All lap data written successfully")
-            push_influx_race(ctx, race_ts_ms)
         except Exception as e:
             logging.error("Writing laps failed for race %s: %s", ctx.race_id, e)
             logging.warning("Skipping race stamp so next run will re-backfill")
-            return
+            return 1
+
+        if not push_influx_race(ctx, race_ts_ms):
+            logging.error(
+                "Race metadata write failed for race %s — failing the run so the "
+                "next backfill retries", ctx.race_id)
+            return 1
 
         for session in pending_writes:
             push_influx_session(
@@ -859,10 +868,16 @@ def push_influx(ctx, laps, monitor_mode, competitor_name=None, car_info=None,
 
 
 def push_influx_race(ctx, timestamp_ms):
-    """Write one race metadata point to the races bucket, replacing any prior point."""
+    """Write one race metadata point to the races bucket, replacing any prior point.
+
+    Returns True on success. Returns False when metadata is missing or the
+    delete/write fails — the delete may have already removed the old point, so
+    a False return means the race may now be absent from the races bucket and
+    the caller must treat the run as failed so a retry restores it.
+    """
     if ctx.metadata is None:
         logging.warning("push_influx_race called with no metadata for race %s", ctx.race_id)
-        return
+        return False
     try:
         ctx.delete_api.delete(
             start='1970-01-01T00:00:00Z',
@@ -881,8 +896,10 @@ def push_influx_race(ctx, timestamp_ms):
             .time(timestamp_ms, WritePrecision.MS)
         )
         ctx.write_api.write(bucket=_influx.BUCKET_RACES, record=point)
+        return True
     except Exception as e:
         logging.error("Writing race failed: %s", e)
+        return False
 
 
 def push_influx_session(ctx, session_id, session_name, start_epoc):

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -416,10 +416,28 @@ def old_race(ctx, opts):
                     or None
                 )
                 comp_car_info = competitor.get('AdditionalData') or None
-                influx_laps = [
-                    {**lap, 'FlagStatus': flag_map.get(lap['FlagStatus'], str(lap['FlagStatus']))}
-                    for lap in comp_laps
-                ]
+                influx_laps = []
+                for lap in comp_laps:
+                    # Filter here — not only in _build_lap_points — so the expected
+                    # count used by --skip-if-complete matches what actually gets
+                    # written; otherwise one garbage lap re-triggers the delete+
+                    # rewrite on every backfill run.
+                    try:
+                        int(lap['Lap'])
+                    except (ValueError, TypeError):
+                        logging.warning(
+                            "%s for car %s; excluding lap from backfill",
+                            _describe_bad_value(lap['Lap'], 'Lap'), comp_number)
+                        continue
+                    if _time_to_ms(lap['TotalTime']) is None:
+                        logging.warning(
+                            "%s for car %s; excluding lap from backfill",
+                            _describe_bad_value(lap['TotalTime'], 'TotalTime'), comp_number)
+                        continue
+                    influx_laps.append({
+                        **lap,
+                        'FlagStatus': flag_map.get(lap['FlagStatus'], str(lap['FlagStatus'])),
+                    })
                 class_name, class_positions = _resolve_class_historical(
                     comp_number, session_details)
                 session_entry['competitors'].append({

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -713,19 +713,24 @@ def _time_to_ms(value):
     """Parse a RaceMonitor time string to milliseconds.
 
     Accepts variable precision: 'H:MM:SS.mmm', 'MM:SS.mmm', or 'SS.mmm', with the
-    fractional '.mmm' part optional. RaceMonitor omits the hours component when a
-    value is under an hour, so we right-align the colon-separated parts.
+    fractional part optional and of any length (padded/truncated to milliseconds).
+    RaceMonitor omits the hours component when a value is under an hour, so we
+    right-align the colon-separated parts.
 
-    Returns None for unparseable values, which causes the field to be omitted
-    from the InfluxDB point. The API occasionally returns garbage for invalid
-    or pit laps.
+    Returns None for empty input (a competitor with no lap yet — common, so not
+    logged) and for unparseable values (logged; the API occasionally returns
+    garbage for invalid or pit laps), causing the field to be omitted from the
+    InfluxDB point.
     """
+    if not value:
+        return None
     try:
         parts = value.split(':')
         sec, _, ms = parts[-1].partition('.')
         hours = int(parts[-3]) if len(parts) >= 3 else 0
         minutes = int(parts[-2]) if len(parts) >= 2 else 0
-        return hours * 3600000 + minutes * 60000 + int(sec) * 1000 + int(ms or 0)
+        return (hours * 3600000 + minutes * 60000 + int(sec) * 1000
+                + int(ms.ljust(3, '0')[:3]))
     except (ValueError, AttributeError):
         logging.warning("%s; omitting field", _describe_bad_value(value, 'time'))
         return None

--- a/src/lemongrass/pisugar_monitor.py
+++ b/src/lemongrass/pisugar_monitor.py
@@ -23,6 +23,7 @@ logger = logging.getLogger('pisugar-monitor')
 PISUGAR_API = "http://localhost:8421"
 PISUGAR_CONFIG = "/etc/pisugar-server/config.json"
 TOKEN_REFRESH_MARGIN = 300  # seconds before expiry to proactively refresh
+HTTP_TIMEOUT_S = 5  # a wedged pisugar-server must not hang the monitor forever
 
 
 def read_credentials():
@@ -43,7 +44,7 @@ def login(username, password):
         data=b"",
         method="POST",
     )
-    with urllib.request.urlopen(req) as resp:
+    with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_S) as resp:
         return resp.read().decode().strip()
 
 
@@ -52,7 +53,7 @@ def token_expiry(token):
     try:
         payload_b64 = token.split('.')[1]
         payload_b64 += '=' * (-len(payload_b64) % 4)
-        payload = json.loads(base64.b64decode(payload_b64))
+        payload = json.loads(base64.urlsafe_b64decode(payload_b64))
         return payload.get('exp')
     except Exception:
         return None
@@ -69,7 +70,7 @@ def exec_command(command, token=None):
         headers=headers,
         method="POST",
     )
-    with urllib.request.urlopen(req) as resp:
+    with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_S) as resp:
         raw = resp.read().decode().strip()
     _, sep, value = raw.partition(": ")
     if sep:

--- a/src/lemongrass/pisugar_monitor.py
+++ b/src/lemongrass/pisugar_monitor.py
@@ -24,6 +24,7 @@ PISUGAR_API = "http://localhost:8421"
 PISUGAR_CONFIG = "/etc/pisugar-server/config.json"
 TOKEN_REFRESH_MARGIN = 300  # seconds before expiry to proactively refresh
 HTTP_TIMEOUT_S = 5  # a wedged pisugar-server must not hang the monitor forever
+STARTUP_RETRY_DELAY_S = 5
 
 
 def read_credentials():
@@ -59,8 +60,12 @@ def token_expiry(token):
         return None
 
 
-def exec_command(command, token=None):
-    """Send a command to the PiSugar HTTP API and return the parsed value."""
+def exec_command(command, token=None, coerce=True):
+    """Send a command to the PiSugar HTTP API and return the parsed value.
+
+    coerce=False returns the raw string — used for device tags, where numeric
+    coercion would mangle version strings like "1.10" into 1.1.
+    """
     headers = {"Content-Type": "text/plain"}
     if token:
         headers["x-pisugar-token"] = token
@@ -75,6 +80,8 @@ def exec_command(command, token=None):
     _, sep, value = raw.partition(": ")
     if sep:
         raw = value
+    if not coerce:
+        return raw
     if raw.lower() == "true":
         return True
     if raw.lower() == "false":
@@ -83,6 +90,31 @@ def exec_command(command, token=None):
         return float(raw)
     except ValueError:
         return raw
+
+
+def _startup_connect(username, password):
+    """Log in and read device tags, retrying until pisugar-server responds.
+
+    At Pi boot this service can start before pisugar-server binds :8421; the
+    monitor is useless without these reads and startup is idempotent, so retry
+    forever rather than die with a traceback.
+    """
+    while True:
+        try:
+            token = None
+            if username and password:
+                token = login(username, password)
+                logger.info("Authenticated with pisugar-server")
+            tags = {
+                "server_version": exec_command("get version", token, coerce=False),
+                "model": exec_command("get model", token, coerce=False),
+                "firmware_version": exec_command("get firmware_version", token, coerce=False),
+            }
+            return token, tags
+        except Exception:
+            logger.exception(
+                "pisugar-server not reachable; retrying in %ds", STARTUP_RETRY_DELAY_S)
+            sleep(STARTUP_RETRY_DELAY_S)
 
 
 def build_point(measurement, value, tags=None):
@@ -119,21 +151,12 @@ def main():
         logger.error("INFLUX_TELEMETRY_TOKEN environment variable not set")
         sys.exit(1)
 
-    pisugar_token = None
     username, password = read_credentials()
-    if username and password:
-        pisugar_token = login(username, password)
-        logger.info("Authenticated with pisugar-server")
+    pisugar_token, device_tags = _startup_connect(username, password)
+    logger.info("PiSugar device: %s", device_tags)
 
     with _influx.connect() as influx_client:
         write_api = influx_client.write_api(write_options=SYNCHRONOUS)
-
-        device_tags = {
-            "server_version": exec_command("get version", pisugar_token),
-            "model": exec_command("get model", pisugar_token),
-            "firmware_version": exec_command("get firmware_version", pisugar_token),
-        }
-        logger.info("PiSugar device: %s", device_tags)
 
         while True:
             if pisugar_token and username and password:

--- a/src/lemongrass/race_backfill.py
+++ b/src/lemongrass/race_backfill.py
@@ -44,7 +44,7 @@ import argparse
 import logging
 import subprocess
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from race_monitor import RaceMonitorClient
 
@@ -55,6 +55,11 @@ LEMONS_SEARCH_TERMS = ['Real Hoopties', 'GP du Lac', 'Halloween Hoop']
 DEFAULT_CAR_NUMBER = '252'
 DEFAULT_START_YEAR = 2017
 EPOCH_START = '1970-01-01T00:00:00Z'
+
+# Lap timestamps are session-anchored and Flux `stop` is exclusive, so laps can
+# legitimately fall outside the nominal race bounds; pad the window instead of
+# trusting Start/EndDateEpoc exactly. The race_id tag filter stays the exact selector.
+WINDOW_PAD_S = 86400
 
 
 class _OverrideAction(argparse.Action):
@@ -144,13 +149,16 @@ def validate_backfill(pairs, query_api):
             continue
 
         race_name = race_records[0].values.get('race_name', 'unknown')
-        range_start = race_records[0].get_time().strftime('%Y-%m-%dT%H:%M:%SZ')
+        range_start = (
+            race_records[0].get_time() - timedelta(seconds=WINDOW_PAD_S)
+        ).strftime('%Y-%m-%dT%H:%M:%SZ')
         end_epoc = race_records[0].get_value()
         if not end_epoc:
             logging.warning("race %s: end_time_epoc=0 in races bucket, using now() as range stop",
                             race_id)
         range_stop = (
-            datetime.fromtimestamp(end_epoc, tz=timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+            datetime.fromtimestamp(end_epoc + WINDOW_PAD_S, tz=timezone.utc)
+            .strftime('%Y-%m-%dT%H:%M:%SZ')
             if end_epoc else datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
         )
 

--- a/src/lemongrass/race_backfill.py
+++ b/src/lemongrass/race_backfill.py
@@ -56,10 +56,7 @@ DEFAULT_CAR_NUMBER = '252'
 DEFAULT_START_YEAR = 2017
 EPOCH_START = '1970-01-01T00:00:00Z'
 
-# Lap timestamps are session-anchored and Flux `stop` is exclusive, so laps can
-# legitimately fall outside the nominal race bounds; pad the window instead of
-# trusting Start/EndDateEpoc exactly. The race_id tag filter stays the exact selector.
-WINDOW_PAD_S = 86400
+WINDOW_PAD_S = _influx.WINDOW_PAD_S
 
 
 class _OverrideAction(argparse.Action):

--- a/src/lemongrass/race_backfill.py
+++ b/src/lemongrass/race_backfill.py
@@ -320,6 +320,12 @@ def main():
     """Entry point: parse args, discover races, then backfill or validate."""
     args = _build_parser().parse_args()
 
+    bad = _influx.invalid_flux_ids(
+        [args.car_number, *args.overrides.keys(), *args.overrides.values()])
+    if bad:
+        logging.error("invalid identifier(s): %s", ", ".join(repr(b) for b in bad))
+        sys.exit(1)
+
     if args.upgrade_stored:
         exclusive = [
             bool(args.overrides),

--- a/src/lemongrass/race_diagnose.py
+++ b/src/lemongrass/race_diagnose.py
@@ -122,6 +122,11 @@ def main():
 
     race_id, car_number = sys.argv[1], sys.argv[2]
 
+    bad = _influx.invalid_flux_ids([race_id, car_number])
+    if bad:
+        print("invalid identifier(s):", ", ".join(f'"{b}"' for b in bad), file=sys.stderr)
+        sys.exit(1)
+
     rm_token = resolve_tokens()
     influx_token = os.environ.get('INFLUX_TELEMETRY_TOKEN')
 

--- a/src/lemongrass/race_diagnose.py
+++ b/src/lemongrass/race_diagnose.py
@@ -31,6 +31,11 @@ from lemongrass._env import resolve_tokens
 
 EPOCH_START = '1970-01-01T00:00:00Z'
 
+# Lap timestamps are session-anchored and Flux `stop` is exclusive, so laps can
+# legitimately fall outside the nominal race bounds; pad the window instead of
+# trusting Start/EndDateEpoc exactly. The race_id tag filter stays the exact selector.
+WINDOW_PAD_S = 86400
+
 
 def epoc_to_str(epoc):
     """Convert a Unix epoch integer to a human-readable UTC string."""
@@ -86,13 +91,16 @@ def diagnose_influx(query_api, race_id, car_number, start_epoc=0, end_epoc=0):
     print(f'\n=== InfluxDB: race {race_id}, car {car_number} ===')
 
     range_start = (
-        datetime.fromtimestamp(start_epoc, tz=timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+        datetime.fromtimestamp(start_epoc - WINDOW_PAD_S, tz=timezone.utc)
+        .strftime('%Y-%m-%dT%H:%M:%SZ')
         if start_epoc else EPOCH_START
     )
     if not end_epoc:
         print(f"  Warning: end_time_epoc not set for race {race_id}, using now() as range stop")
-    range_stop = (datetime.fromtimestamp(end_epoc, tz=timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
-                  if end_epoc else datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'))
+    range_stop = (
+        datetime.fromtimestamp(end_epoc + WINDOW_PAD_S, tz=timezone.utc)
+        .strftime('%Y-%m-%dT%H:%M:%SZ')
+        if end_epoc else datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'))
 
     tables = query_api.query(
         f'from(bucket: "{_influx.BUCKET_LAPS}")\n'

--- a/src/lemongrass/race_diagnose.py
+++ b/src/lemongrass/race_diagnose.py
@@ -31,10 +31,7 @@ from lemongrass._env import resolve_tokens
 
 EPOCH_START = '1970-01-01T00:00:00Z'
 
-# Lap timestamps are session-anchored and Flux `stop` is exclusive, so laps can
-# legitimately fall outside the nominal race bounds; pad the window instead of
-# trusting Start/EndDateEpoc exactly. The race_id tag filter stays the exact selector.
-WINDOW_PAD_S = 86400
+WINDOW_PAD_S = _influx.WINDOW_PAD_S
 
 
 def epoc_to_str(epoc):

--- a/src/lemongrass/races.py
+++ b/src/lemongrass/races.py
@@ -6,7 +6,6 @@ Run `lemongrass races <subcommand> --help` for per-subcommand options.
 """
 
 import argparse
-import re
 import sys
 from datetime import datetime, timezone
 
@@ -15,7 +14,6 @@ from lemongrass import _influx
 EPOCH_START = '1970-01-01T00:00:00Z'
 
 _SUBCOMMANDS = ('list', 'prune', 'backfill', 'diagnose')
-_RACE_ID_RE = re.compile(r'^[A-Za-z0-9_-]+$')
 
 
 def main():
@@ -108,7 +106,7 @@ def _handle_prune():
     args = parser.parse_args()
     race_ids = list(dict.fromkeys(args.race_id))
 
-    invalid_ids = [rid for rid in race_ids if not _RACE_ID_RE.fullmatch(rid)]
+    invalid_ids = _influx.invalid_flux_ids(race_ids)
     if invalid_ids:
         print("invalid race ID(s):", ", ".join(f'"{r}"' for r in invalid_ids), file=sys.stderr)
         sys.exit(1)

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -356,8 +356,8 @@ def main():
             flush_points(write_api)
             if not _connection_healthy(connection):
                 # Exit nonzero so the container/systemd restart policy re-runs
-                # the well-tested startup connect sequence; flush what's left.
-                flush_points(write_api)
+                # the well-tested startup connect sequence; the flush at the top
+                # of this iteration already covers pending points.
                 logger.error("Exiting for supervisor restart")
                 sys.exit(1)
 

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -19,6 +19,11 @@ logger = logging.getLogger('telem')
 EXCLUDED_PATTERNS = ["MIDS", "PIDS", "O2_SENSORS", "ELM", "OBD"]
 SKIP_NAMES = {"FREEZE_DTC", "GET_DTC", "GET_CURRENT_DTC", "CLEAR_DTC", "FUEL_TYPE"}
 MAX_DTC_FETCH_FAILURES = 3
+
+# Backlog bound for InfluxDB outages: callbacks keep queueing while writes fail;
+# beyond this many points the oldest are dropped rather than OOM-ing the Pi.
+MAX_PENDING_POINTS = 50_000
+FLUSH_BATCH_SIZE = 5_000
 STATUS_COMMANDS = {"STATUS", "STATUS_DRIVE_CYCLE"}
 
 FUEL_STATUS_MAP = {
@@ -263,20 +268,36 @@ def _configure_obd_logging():
         obd.logger.setLevel(obd.logging.DEBUG)
 
 
-def flush_points(write_api):
-    """Write all pending points to InfluxDB in a single request."""
+def flush_points(write_api, batch_size=FLUSH_BATCH_SIZE):
+    """Write all pending points to InfluxDB in batches of batch_size.
+
+    On a failed write the unwritten remainder is re-queued, capped at
+    MAX_PENDING_POINTS with the oldest dropped, so an extended outage cannot
+    grow the backlog without bound — and recovery after the outage goes out in
+    bounded requests instead of one giant write.
+    """
     with pending_lock:
         if not pending_points:
             return
         batch = pending_points.copy()
         pending_points.clear()
+    written = 0
     try:
-        write_api.write(bucket='stats_252/autogen', record=batch)
-        logger.info("Flushed %d points to InfluxDB", len(batch))
+        for i in range(0, len(batch), batch_size):
+            write_api.write(bucket='stats_252/autogen', record=batch[i:i + batch_size])
+            written += len(batch[i:i + batch_size])
+        logger.info("Flushed %d points to InfluxDB", written)
     except Exception as e:
-        logger.error('Failed to write %d points to InfluxDB: %s', len(batch), e)
+        unwritten = batch[written:]
+        logger.error('Failed to write %d points to InfluxDB: %s', len(unwritten), e)
         with pending_lock:
-            pending_points[:0] = batch
+            pending_points[:0] = unwritten
+            overflow = len(pending_points) - MAX_PENDING_POINTS
+            if overflow > 0:
+                del pending_points[:overflow]
+                logger.warning(
+                    "Backlog exceeded %d points; dropped %d oldest",
+                    MAX_PENDING_POINTS, overflow)
 
 
 def main():

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -88,7 +88,7 @@ def new_fuel_status(r):
         logger.debug("Caught IndexError in new_fuel_status")
         return
 
-    fuel_status = next((v for k, v in FUEL_STATUS_MAP.items() if k in r.value), 255)
+    fuel_status = FUEL_STATUS_MAP.get(r.value[0], 255)
     if fuel_status == 3:
         logger.warning("Caught open loop due to system failure")
 
@@ -253,6 +253,16 @@ def connect():
     return obd.Async(portstr=os.environ.get('OBD_PORT', '/dev/obd'))
 
 
+def _configure_obd_logging():
+    """Enable python-obd DEBUG logging only when OBD_DEBUG is set.
+
+    DEBUG logs every serial send/receive; with dozens of watched PIDs cycling
+    continuously that is sustained journald I/O and SD-card wear on the Pi.
+    """
+    if os.environ.get('OBD_DEBUG'):
+        obd.logger.setLevel(obd.logging.DEBUG)
+
+
 def flush_points(write_api):
     """Write all pending points to InfluxDB in a single request."""
     with pending_lock:
@@ -276,7 +286,7 @@ def main():
     with _influx.connect() as influx_client:
         write_api = influx_client.write_api(write_options=SYNCHRONOUS)
 
-        obd.logger.setLevel(obd.logging.DEBUG)
+        _configure_obd_logging()
         connection = connect()
         status = connection.status()
         while "Car Connected" not in status:

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -54,10 +54,16 @@ _dtc_fetch_failures = 0
 STALE_DATA_TIMEOUT_S = 60
 _last_append_monotonic = 0.0
 
+# Enqueue-side drops happen once per callback while saturated; warn at most
+# this often (with a cumulative count) instead of once per dropped point.
+_DROP_WARN_INTERVAL_S = 60
+_dropped_since_warn = 0
+_last_drop_warn_monotonic = float('-inf')
+
 
 def _queue_point(point):
     """Append a point to the pending batch and mark data as flowing."""
-    global _last_append_monotonic
+    global _last_append_monotonic, _dropped_since_warn, _last_drop_warn_monotonic
     with pending_lock:
         pending_points.append(point)
         overflow = len(pending_points) - MAX_PENDING_POINTS
@@ -65,6 +71,14 @@ def _queue_point(point):
             # Producers can outpace a hung or delayed flush; cap here too so
             # callbacks can't grow memory unbounded before flush_points requeues.
             del pending_points[:overflow]
+            _dropped_since_warn += overflow
+            now = monotonic()
+            if now - _last_drop_warn_monotonic >= _DROP_WARN_INTERVAL_S:
+                logger.warning(
+                    "Backlog exceeded %d points; dropped %d oldest on enqueue",
+                    MAX_PENDING_POINTS, _dropped_since_warn)
+                _dropped_since_warn = 0
+                _last_drop_warn_monotonic = now
         _last_append_monotonic = monotonic()
 
 

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -3,9 +3,10 @@
 
 import logging
 import os
+import sys
 import threading
 from datetime import datetime, timezone
-from time import sleep
+from time import monotonic, sleep
 
 import obd
 from influxdb_client import Point
@@ -49,6 +50,18 @@ _connection = None  # set by main(); lets new_status trigger on-demand DTC looku
 _last_dtc_count = 0
 _dtc_fetch_failures = 0
 
+# Watchdog: exit (for a supervisor restart) when no data has arrived this long.
+STALE_DATA_TIMEOUT_S = 60
+_last_append_monotonic = 0.0
+
+
+def _queue_point(point):
+    """Append a point to the pending batch and mark data as flowing."""
+    global _last_append_monotonic
+    with pending_lock:
+        pending_points.append(point)
+        _last_append_monotonic = monotonic()
+
 
 def _measurement_name(r):
     """Derive the InfluxDB measurement name from a response's command string."""
@@ -73,8 +86,7 @@ def new_value(r):
     except AttributeError:
         logger.debug("Caught AttributeError in new_value")
         return
-    with pending_lock:
-        pending_points.append(point)
+    _queue_point(point)
 
 
 def new_fuel_status(r):
@@ -97,10 +109,7 @@ def new_fuel_status(r):
     if fuel_status == 3:
         logger.warning("Caught open loop due to system failure")
 
-    with pending_lock:
-        pending_points.append(
-            Point(measurement).field("value", fuel_status).time(ts)
-        )
+    _queue_point(Point(measurement).field("value", fuel_status).time(ts))
 
 
 def new_air_status(r):
@@ -117,10 +126,7 @@ def new_air_status(r):
 
     air_status = AIR_STATUS_MAP.get(r.value, 255)
 
-    with pending_lock:
-        pending_points.append(
-            Point(measurement).field("value", air_status).time(ts)
-        )
+    _queue_point(Point(measurement).field("value", air_status).time(ts))
 
 
 def _query_fuel_type_once(connection):
@@ -145,10 +151,7 @@ def _query_fuel_type_once(connection):
         logger.debug("Caught IndexError in _query_fuel_type_once")
         return
 
-    with pending_lock:
-        pending_points.append(
-            Point(measurement).field("value", r.value).time(ts)
-        )
+    _queue_point(Point(measurement).field("value", r.value).time(ts))
 
 
 def _fetch_and_store_dtcs():
@@ -179,8 +182,7 @@ def _fetch_and_store_dtcs():
     # failure -- store it so a STATUS/GET_DTC disagreement doesn't retry forever.
     codes = ",".join(code for code, _ in r.value)
     ts = datetime.now(timezone.utc)
-    with pending_lock:
-        pending_points.append(Point("-Get-DTCs").field("value", codes).time(ts))
+    _queue_point(Point("-Get-DTCs").field("value", codes).time(ts))
     return True
 
 
@@ -217,13 +219,10 @@ def new_status(r):
         logger.debug("Caught IndexError in new_status")
         return
 
-    with pending_lock:
-        pending_points.append(
-            Point(f"{measurement}-MIL").field("value", int(r.value.MIL)).time(ts)
-        )
-        pending_points.append(
-            Point(f"{measurement}-DTC-Count").field("value", r.value.DTC_count).time(ts)
-        )
+    _queue_point(Point(f"{measurement}-MIL").field("value", int(r.value.MIL)).time(ts))
+    _queue_point(
+        Point(f"{measurement}-DTC-Count").field("value", r.value.DTC_count).time(ts)
+    )
 
     # Only the primary STATUS command drives the on-demand DTC lookup;
     # STATUS_DRIVE_CYCLE just records its own MIL/count.
@@ -268,6 +267,23 @@ def _configure_obd_logging():
         obd.logger.setLevel(obd.logging.DEBUG)
 
 
+def _connection_healthy(connection):
+    """False when the OBD link is gone or no data has arrived recently.
+
+    python-obd's Async loop keeps running after the adapter browns out or the
+    ignition cycles, delivering only null responses — every callback then
+    early-returns and telemetry silently stops. Both signals are checked: the
+    reported connection status, and time since a callback last queued a point.
+    """
+    if not connection.is_connected():
+        logger.error("OBD connection lost")
+        return False
+    if monotonic() - _last_append_monotonic > STALE_DATA_TIMEOUT_S:
+        logger.error("No OBD data received for %ds", STALE_DATA_TIMEOUT_S)
+        return False
+    return True
+
+
 def flush_points(write_api, batch_size=FLUSH_BATCH_SIZE):
     """Write all pending points to InfluxDB in batches of batch_size.
 
@@ -302,7 +318,7 @@ def flush_points(write_api, batch_size=FLUSH_BATCH_SIZE):
 
 def main():
     """Main loop of OBD-II scraping"""
-    global _connection
+    global _connection, _last_append_monotonic
 
     with _influx.connect() as influx_client:
         write_api = influx_client.write_api(write_options=SYNCHRONOUS)
@@ -333,10 +349,17 @@ def main():
             logger.warning("Could not find voltage monitoring command - skipping")
 
         connection.start()
+        _last_append_monotonic = monotonic()
 
         while True:
             sleep(0.5)
             flush_points(write_api)
+            if not _connection_healthy(connection):
+                # Exit nonzero so the container/systemd restart policy re-runs
+                # the well-tested startup connect sequence; flush what's left.
+                flush_points(write_api)
+                logger.error("Exiting for supervisor restart")
+                sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -60,6 +60,11 @@ def _queue_point(point):
     global _last_append_monotonic
     with pending_lock:
         pending_points.append(point)
+        overflow = len(pending_points) - MAX_PENDING_POINTS
+        if overflow > 0:
+            # Producers can outpace a hung or delayed flush; cap here too so
+            # callbacks can't grow memory unbounded before flush_points requeues.
+            del pending_points[:overflow]
         _last_append_monotonic = monotonic()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,13 +8,17 @@ for _mod in [
 ]:
     sys.modules.setdefault(_mod, MagicMock())
 
-# The real get_streaming_command is needed for _describe_bad_value tests.
-# Temporarily remove the mock, import the real module, copy the function, restore.
+# The real get_streaming_command is needed for _describe_bad_value tests, and the
+# real exception classes are needed so cli.py can `except RaceMonitorError` (a
+# MagicMock attribute is not a valid exception type). Temporarily remove the mock,
+# import the real module, copy the needed symbols onto the mock, restore.
 _race_monitor_mock = sys.modules.pop('race_monitor')
 try:
     import race_monitor as _real_race_monitor
 
     _race_monitor_mock.get_streaming_command = _real_race_monitor.get_streaming_command
+    _race_monitor_mock.RaceMonitorError = _real_race_monitor.RaceMonitorError
+    _race_monitor_mock.RaceMonitorHTTPError = _real_race_monitor.RaceMonitorHTTPError
     del _real_race_monitor
 except ImportError:
     sys.modules['race_monitor'] = _race_monitor_mock

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -161,6 +161,53 @@ class TestInfluxErrorHandling:
         assert 'bucket "laps" not found' in err
 
 
+class TestRaceMonitorErrors:
+    def test_429_exhaustion_exits_1_with_rate_limit_message(self, capsys):
+        """race-monitor 0.7.0 raises RaceMonitorHTTPError(429) once retries are
+        exhausted; the CLI must report it cleanly, not crash with a traceback."""
+        from race_monitor import RaceMonitorHTTPError
+
+        def raise_429():
+            raise RaceMonitorHTTPError(429, "Too Many Requests")
+
+        with patch.object(sys, 'argv', ['lemongrass', 'races', 'list']):
+            with patch('lemongrass.races.main', raise_429):
+                with pytest.raises(SystemExit) as wrapped:
+                    cli.main()
+        assert wrapped.value.code == 1
+        err = capsys.readouterr().err
+        assert 'rate limit' in err.lower()
+        assert '429' in err
+
+    def test_other_http_error_exits_1_with_status(self, capsys):
+        from race_monitor import RaceMonitorHTTPError
+
+        def raise_500():
+            raise RaceMonitorHTTPError(500, "boom")
+
+        with patch.object(sys, 'argv', ['lemongrass', 'races', 'list']):
+            with patch('lemongrass.races.main', raise_500):
+                with pytest.raises(SystemExit) as wrapped:
+                    cli.main()
+        assert wrapped.value.code == 1
+        err = capsys.readouterr().err
+        assert '500' in err
+        assert 'rate limit' not in err.lower()
+
+    def test_base_error_exits_1_without_traceback(self, capsys):
+        from race_monitor import RaceMonitorError
+
+        def raise_base():
+            raise RaceMonitorError("no tokens configured")
+
+        with patch.object(sys, 'argv', ['lemongrass', 'races', 'list']):
+            with patch('lemongrass.races.main', raise_base):
+                with pytest.raises(SystemExit) as wrapped:
+                    cli.main()
+        assert wrapped.value.code == 1
+        assert 'no tokens configured' in capsys.readouterr().err
+
+
 class TestExitCodePropagation:
     def test_subcommand_return_value_becomes_exit_code(self):
         """laps.main() returns 1 on failure; the dispatcher must not swallow it."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,17 +20,20 @@ class TestDispatcher:
         assert exc.value.code != 0
 
     def test_routes_to_laps(self):
-        mock_main = MagicMock()
+        mock_main = MagicMock(return_value=None)
         with patch.object(sys, 'argv', ['lemongrass', 'laps', '--help']):
             with patch('lemongrass.laps.main', mock_main):
-                cli.main()
+                with pytest.raises(SystemExit) as exc:
+                    cli.main()
+        assert exc.value.code is None
         mock_main.assert_called_once()
 
     def test_routes_to_telem(self):
-        mock_main = MagicMock()
+        mock_main = MagicMock(return_value=None)
         with patch.object(sys, 'argv', ['lemongrass', 'telem']):
             with patch('lemongrass.telem.main', mock_main):
-                cli.main()
+                with pytest.raises(SystemExit):
+                    cli.main()
         mock_main.assert_called_once()
 
     def test_shifts_argv_for_subcommand(self):
@@ -42,7 +45,8 @@ class TestDispatcher:
 
         with patch.object(sys, 'argv', ['lemongrass', 'race-diagnose', 'R001', '42']):
             with patch('lemongrass.race_diagnose.main', capture_main):
-                cli.main()
+                with pytest.raises(SystemExit):
+                    cli.main()
 
         assert captured['argv'][1] == 'R001'
         assert captured['argv'][2] == '42'
@@ -155,3 +159,20 @@ class TestInfluxErrorHandling:
                     cli.main()
         err = capsys.readouterr().err
         assert 'bucket "laps" not found' in err
+
+
+class TestExitCodePropagation:
+    def test_subcommand_return_value_becomes_exit_code(self):
+        """laps.main() returns 1 on failure; the dispatcher must not swallow it."""
+        with patch.object(sys, 'argv', ['lemongrass', 'laps', '123']):
+            with patch('lemongrass.laps.main', return_value=1):
+                with pytest.raises(SystemExit) as exc:
+                    cli.main()
+        assert exc.value.code == 1
+
+    def test_none_return_exits_zero(self):
+        with patch.object(sys, 'argv', ['lemongrass', 'laps', '123']):
+            with patch('lemongrass.laps.main', return_value=None):
+                with pytest.raises(SystemExit) as exc:
+                    cli.main()
+        assert exc.value.code is None  # sys.exit(None) == process exit status 0

--- a/tests/test_influx.py
+++ b/tests/test_influx.py
@@ -60,3 +60,17 @@ def test_connect_builds_client_with_shared_settings(monkeypatch):
         org=influx_mod.INFLUX_ORG,
         retries=influx_mod.INFLUX_RETRIES,
     )
+
+
+class TestInvalidFluxIds:
+    def test_clean_ids_pass(self):
+        from lemongrass import _influx
+        assert _influx.invalid_flux_ids(['144185', 'car_25-2']) == []
+
+    def test_metacharacters_rejected(self):
+        from lemongrass import _influx
+        assert _influx.invalid_flux_ids(['ok', 'bad"id', 'a b']) == ['bad"id', 'a b']
+
+    def test_non_strings_coerced(self):
+        from lemongrass import _influx
+        assert _influx.invalid_flux_ids([144185]) == []

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -2721,6 +2721,18 @@ class TestDryRun:
         assert 'car 42' in out
         assert '2 laps' in out
 
+    def test_dry_run_refuses_live_race(self, caplog):
+        """--dry-run is historical-only; entering the live path with write_api=None
+        produces swallowed AttributeErrors instead of writes."""
+        ctx = self._ctx()
+        opts = _mod.RaceOptions(network_mode=True, dry_run=True)
+        with patch.object(_mod, 'live_race') as mock_live:
+            with caplog.at_level(logging.ERROR):
+                result = _mod._run_race(ctx, opts, {'Successful': True, 'IsLive': True})
+        assert result == 1
+        mock_live.assert_not_called()
+        assert any('dry-run' in r.message.lower() for r in caplog.records)
+
 
 class TestComputeClassPositionsLive:
     def _resp(self, competitors, classes=None):

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -820,13 +820,15 @@ class TestPushInfluxClassInfo:
         _mod.push_influx(ctx, laps, False)
         assert 'lap_time' not in self._record(write_api)
 
-    def test_unparseable_total_time_anchors_to_start_epoc(self):
+    def test_unparseable_total_time_skips_lap_entirely(self):
+        """A lap with unparseable TotalTime must not be written at all — anchoring
+        it at start_epoc_ms + 0 would silently collide/dedupe with any other lap
+        legitimately timestamped at session start."""
         ctx, write_api = self._ctx()  # start_epoc=0
         laps = [{'Lap': '1', 'LapTime': '1:30.000', 'Position': '1',
                  'FlagStatus': 'Green', 'TotalTime': '3$H'}]
         _mod.push_influx(ctx, laps, False)
-        # TotalTime unparseable → falls back to 0; timestamp = start_epoc_ms + 0 = 0
-        assert self._record(write_api).endswith(' 0')
+        write_api.write.assert_not_called()
 
     def test_explicit_car_number_overrides_ctx(self):
         ctx, write_api = self._ctx()  # ctx.car_number = '42'
@@ -3327,6 +3329,38 @@ class TestBuildLapPointsStreamingToken:
             points = _mod._build_lap_points(ctx, laps, 'Driver', None, None, None, 1000000, '42')
         assert len(points) == 1  # lap still written, position omitted
         assert 'Race Information' in caplog.text
+
+
+class TestBuildLapPointsBadTotalTime:
+    """A lap whose TotalTime can't be parsed would otherwise be silently anchored
+    at session start (start_epoc_ms + 0); the live/monitor path must skip it like
+    the historical backfill path already does (old_race pre-filters there)."""
+
+    def test_lap_with_garbage_total_time_excluded_from_points(self):
+        laps = [{'Lap': '1', 'LapTime': '0:01:30.000', 'Position': '1',
+                 'FlagStatus': 'Green', 'TotalTime': '$F'}]
+        ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 1000000)
+        points = _mod._build_lap_points(ctx, laps, 'Driver', None, None, None, 1000000, '42')
+        assert points == []
+
+    def test_logs_warning_for_garbage_total_time(self, caplog):
+        laps = [{'Lap': '1', 'LapTime': '0:01:30.000', 'Position': '1',
+                 'FlagStatus': 'Green', 'TotalTime': '$F'}]
+        ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 1000000)
+        with caplog.at_level(logging.WARNING):
+            _mod._build_lap_points(ctx, laps, 'Driver', None, None, None, 1000000, '42')
+        assert any('$F' in r.message for r in caplog.records)
+
+    def test_other_laps_still_written_when_one_has_bad_total_time(self):
+        good = {'Lap': '1', 'LapTime': '0:01:30.000', 'Position': '1',
+                'FlagStatus': 'Green', 'TotalTime': '0:01:30.000'}
+        bad = {'Lap': '2', 'LapTime': '0:01:31.000', 'Position': '1',
+               'FlagStatus': 'Green', 'TotalTime': '$F'}
+        ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 1000000)
+        points = _mod._build_lap_points(ctx, [good, bad], 'Driver', None, None, None,
+                                         1000000, '42')
+        assert len(points) == 1
+        assert 'lap_no=1i' in points[0].to_line_protocol()
 
 
 class TestMainMissingToken:

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -374,6 +374,46 @@ class TestMonitorRoutine:
 
         assert 'Passing Information' in caplog.text
 
+    def test_refresh_competitor_exception_does_not_kill_monitor(self):
+        """A transient network error mid-poll must cost one poll, not the race."""
+        stop = threading.Event()
+        ctx = _mod.RaceContext('123', '42', MagicMock(), None, 0)
+        opts = _mod.RaceOptions(network_mode=False, interval=0)
+
+        calls = 0
+
+        def flaky_refresh(c):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise ConnectionError("wifi blip")
+            stop.set()
+            return []
+
+        with patch.object(_mod, 'refresh_competitor', side_effect=flaky_refresh):
+            with patch.object(ctx.client.live, 'get_session',
+                              return_value={'Successful': False}):
+                result = _mod.monitor_routine(ctx, [], opts, _stop_event=stop)
+        assert calls == 2  # survived the first failure and polled again
+        assert result is None
+
+    def test_race_details_exception_does_not_kill_monitor(self):
+        stop = threading.Event()
+        ctx = _mod.RaceContext('123', '42', MagicMock(), MagicMock(), 0)
+        opts = _mod.RaceOptions(network_mode=True, interval=0)
+        ctx.client.race.details.side_effect = ConnectionError("wifi blip")
+
+        def fake_refresh(c):
+            stop.set()
+            return []
+
+        with patch.object(_mod, 'refresh_competitor', side_effect=fake_refresh):
+            with patch.object(ctx.client.live, 'get_session',
+                              return_value={'Successful': False}):
+                with patch.object(_mod, 'push_influx_standings_live', return_value={}):
+                    _mod.monitor_routine(ctx, [], opts, _stop_event=stop)
+        # no exception raised is the assertion
+
 
 class TestWriteCSV:
     def test_opens_file_with_correct_name(self):

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -608,6 +608,24 @@ class TestTimeToMs:
         assert result is None
         assert 'unparseable' in caplog.text
 
+    def test_empty_string_returns_none_without_warning(self, caplog):
+        import logging
+        with caplog.at_level(logging.WARNING):
+            assert _mod._time_to_ms('') is None
+        assert caplog.text == ''
+
+    def test_none_returns_none_without_warning(self, caplog):
+        import logging
+        with caplog.at_level(logging.WARNING):
+            assert _mod._time_to_ms(None) is None
+        assert caplog.text == ''
+
+    def test_short_fraction_is_padded_not_misread(self):
+        assert _mod._time_to_ms('1:23.4') == 1 * 60000 + 23 * 1000 + 400
+
+    def test_long_fraction_is_truncated_to_ms(self):
+        assert _mod._time_to_ms('23.4567') == 23 * 1000 + 456
+
 
 class TestPushInfluxClassInfo:
     def _laps(self):

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -3201,3 +3201,33 @@ class TestMainMissingToken:
         assert exc_info.value.code == 1
         assert any('RACEMONITOR_TOKENS' in r.message and 'RACEMONITOR_TOKEN' in r.message
                    for r in caplog.records)
+
+
+class TestLiveRaceNoData:
+    def _ctx(self):
+        ctx = _mod.RaceContext('123', '99', MagicMock(), None, 0)
+        ctx.client.live.get_session.return_value = {'Successful': False}
+        ctx.client.live.get_racer.return_value = {'Successful': False}
+        return ctx
+
+    def test_unsuccessful_get_racer_returns_no_live_data(self):
+        """A car number missing from the live feed must fail cleanly, not KeyError."""
+        opts = _mod.RaceOptions()
+        with patch.object(_mod, 'print_rankings'):
+            result = _mod.live_race(self._ctx(), opts)
+        assert result is _mod.MonitorStatus.NO_LIVE_DATA
+
+    def test_unsuccessful_get_racer_logs_error(self, caplog):
+        opts = _mod.RaceOptions()
+        with patch.object(_mod, 'print_rankings'):
+            with caplog.at_level(logging.ERROR):
+                _mod.live_race(self._ctx(), opts)
+        assert any('99' in r.message for r in caplog.records)
+
+    def test_run_race_returns_1_on_no_live_data(self):
+        ctx = self._ctx()
+        opts = _mod.RaceOptions()
+        with patch.object(_mod, 'live_race',
+                          return_value=_mod.MonitorStatus.NO_LIVE_DATA):
+            result = _mod._run_race(ctx, opts, {'Successful': True, 'IsLive': True})
+        assert result == 1

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -2398,6 +2398,31 @@ class TestOldRaceMetadataFailure:
             result = _mod._run_race(ctx, opts, {'Successful': True, 'IsLive': False})
         assert result == 1
 
+    def test_standings_write_failure_fails_run(self):
+        """Standings were wiped after a partial write and need a rewrite — the
+        run must report failure so race-backfill retries, matching the
+        metadata-write path above."""
+        ctx = self._ctx()
+        opts = _mod.RaceOptions(network_mode=True)
+        with patch.object(_mod, 'push_influx_race', return_value=True):
+            with patch.object(_mod, 'push_influx_standings_historical',
+                              return_value=False):
+                with patch.object(_mod, 'delete_existing_standings', return_value=True):
+                    with patch.object(_mod, 'print_rankings'):
+                        result = _mod.old_race(ctx, opts)
+        assert result == 1
+
+    def test_standings_cleanup_delete_failure_also_fails_run(self):
+        ctx = self._ctx()
+        opts = _mod.RaceOptions(network_mode=True)
+        with patch.object(_mod, 'push_influx_race', return_value=True):
+            with patch.object(_mod, 'push_influx_standings_historical',
+                              return_value=False):
+                with patch.object(_mod, 'delete_existing_standings', return_value=False):
+                    with patch.object(_mod, 'print_rankings'):
+                        result = _mod.old_race(ctx, opts)
+        assert result == 1
+
 
 class TestPushInfluxSession:
     def _ctx(self):

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -3283,3 +3283,58 @@ class TestLiveRaceNoData:
                           return_value=_mod.MonitorStatus.NO_LIVE_DATA):
             result = _mod._run_race(ctx, opts, {'Successful': True, 'IsLive': True})
         assert result == 1
+
+
+class TestOldRaceSessionFetching:
+    def _session_details(self, sid=1):
+        return {
+            'Successful': True,
+            'Session': {
+                'ID': sid, 'Name': f'S{sid}', 'SessionStartDateEpoc': 1000,
+                'Categories': {'1': {'ID': '1', 'Name': 'A'}},
+                'SortedCompetitors': [{
+                    'Number': '42', 'Category': '1', 'FirstName': 'Jane',
+                    'LastName': 'Doe', 'Position': '1', 'Laps': '1',
+                    'BestLapTime': '', 'LastLapTime': '', 'Transponder': '',
+                    'AdditionalData': '',
+                    'LapTimes': [{'Lap': '1', 'LapTime': '0:01:30.000',
+                                  'Position': '1', 'FlagStatus': 0,
+                                  'TotalTime': '0:01:30.000'}],
+                }],
+            },
+        }
+
+    def test_zero_sessions_returns_cleanly(self, caplog):
+        """A race with no posted sessions must log and return, not UnboundLocalError."""
+        ctx = _mod.RaceContext('999', None, MagicMock(), None, 0)
+        ctx.client.results.sessions_for_race.return_value = {'Sessions': []}
+        opts = _mod.RaceOptions(network_mode=False)
+        with caplog.at_level(logging.WARNING):
+            _mod.old_race(ctx, opts)  # must not raise
+        assert any('999' in r.message for r in caplog.records)
+
+    def test_display_mode_fetches_only_final_session(self):
+        """Non-network mode prints one rankings table; fetching every session
+        burns the RaceMonitor rate limit for data that is discarded."""
+        ctx = _mod.RaceContext('999', None, MagicMock(), None, 0)
+        ctx.client.results.sessions_for_race.return_value = {
+            'Sessions': [{'ID': 1}, {'ID': 2}, {'ID': 3}]}
+        ctx.client.results.session_details.return_value = self._session_details(3)
+        opts = _mod.RaceOptions(network_mode=False)
+        with patch.object(_mod, 'print_rankings'):
+            _mod.old_race(ctx, opts)
+        ctx.client.results.session_details.assert_called_once_with(
+            3, include_lap_times=True)
+
+    def test_network_mode_still_fetches_all_sessions(self):
+        ctx = _mod.RaceContext('999', None, MagicMock(), MagicMock(), 0)
+        ctx.query_api = MagicMock()
+        ctx.client.results.sessions_for_race.return_value = {
+            'Sessions': [{'ID': 1}, {'ID': 2}]}
+        ctx.client.results.session_details.side_effect = [
+            self._session_details(1), self._session_details(2)]
+        opts = _mod.RaceOptions(network_mode=True)
+        with patch.object(_mod, 'push_influx_race', return_value=True):
+            with patch.object(_mod, 'print_rankings'):
+                _mod.old_race(ctx, opts)
+        assert ctx.client.results.session_details.call_count == 2

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -1306,6 +1306,75 @@ class TestLiveRaceStandingsWrite:
         mock_standings.assert_not_called()
 
 
+class TestLiveRaceMetadataFailure:
+    def _ctx(self):
+        ctx = _mod.RaceContext('123', '42', MagicMock(), MagicMock(), 1000)
+        ctx.metadata = _mod.RaceMetadata('Race', 'Track', None, 9999)
+        ctx.client.live.get_session.return_value = {'Successful': True, 'Session': {
+            'ID': 'sess-1', 'Name': 'S', 'Competitors': {}, 'Classes': {}}}
+        ctx.client.live.get_racer.return_value = {
+            'Successful': True,
+            'Details': {
+                'Competitor': {
+                    'FirstName': 'Ben', 'LastName': 'K', 'Number': '42',
+                    'Transponder': 'T', 'BestPosition': '1', 'Position': '1',
+                    'Laps': '5', 'BestLap': '3', 'BestLapTime': '1:30.000',
+                    'TotalTime': '10:00.000', 'AdditionalData': None,
+                },
+                'Laps': [],
+            },
+        }
+        return ctx
+
+    def test_non_monitor_returns_write_failed_when_metadata_write_fails(self):
+        ctx = self._ctx()
+        opts = _mod.RaceOptions(network_mode=True, monitor_mode=False, interval=30)
+        with patch.object(_mod, 'push_influx_race', return_value=False):
+            with patch.object(_mod, 'push_influx_session'):
+                with patch.object(_mod, 'push_influx'):
+                    with patch.object(_mod, 'push_influx_standings_live'):
+                        result = _mod.live_race(ctx, opts)
+        assert result is _mod.MonitorStatus.WRITE_FAILED
+
+    def test_non_monitor_returns_none_when_metadata_write_succeeds(self):
+        ctx = self._ctx()
+        opts = _mod.RaceOptions(network_mode=True, monitor_mode=False, interval=30)
+        with patch.object(_mod, 'push_influx_race', return_value=True):
+            with patch.object(_mod, 'push_influx_session'):
+                with patch.object(_mod, 'push_influx'):
+                    with patch.object(_mod, 'push_influx_standings_live'):
+                        result = _mod.live_race(ctx, opts)
+        assert result is None
+
+    def test_monitor_retries_metadata_write_until_success(self):
+        """A failed metadata write must be retried on later polls, not abort
+        the loop or be dropped after one attempt."""
+        stop = threading.Event()
+        ctx = _mod.RaceContext('123', '42', MagicMock(), MagicMock(), 1000)
+        ctx.metadata = _mod.RaceMetadata('Race', 'Track', None, 9999)
+        opts = _mod.RaceOptions(network_mode=True, interval=0)
+
+        call_count = 0
+        def fake_get_session(race_id):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 3:
+                stop.set()
+            return {'Successful': True, 'Session': {
+                'ID': 'sess-1', 'Name': 'S', 'Competitors': {}, 'Classes': {}}}
+
+        ctx.client.live.get_session.side_effect = fake_get_session
+
+        # First write fails, second succeeds; a third poll must not push again.
+        with patch.object(_mod, 'push_influx_race', side_effect=[False, True]) as mock_race:
+            with patch.object(_mod, 'refresh_competitor', return_value=[]):
+                with patch.object(_mod, 'push_influx_standings_live', return_value={}):
+                    _mod.monitor_routine(ctx, [], opts, _stop_event=stop,
+                                         race_meta_written=False)
+
+        assert mock_race.call_count == 2
+
+
 class TestOldRaceClassWiring:
     def _session_details(self, car_number='42', cat_id='1', cat_name='A'):
         return {
@@ -3589,6 +3658,11 @@ class TestClassIndex:
     def test_index_matches_per_car_resolution(self):
         details = self._session_details()
         index = _mod._build_class_index(details)
+        # Hard-coded expected class positions catch regressions the self-comparison
+        # below would miss (the no-index path builds the same index internally).
+        assert _mod._resolve_class_historical('10', details, index) == ('A', {1: 1, 2: 1})
+        assert _mod._resolve_class_historical('11', details, index) == ('A', {1: 2, 2: 2})
+        assert _mod._resolve_class_historical('20', details, index) == ('B', {1: 1, 2: 1})
         for number in ('10', '11', '20'):
             assert (_mod._resolve_class_historical(number, details)
                     == _mod._resolve_class_historical(number, details, index))

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -1374,6 +1374,31 @@ class TestLiveRaceMetadataFailure:
 
         assert mock_race.call_count == 2
 
+    def test_monitor_retries_metadata_write_with_wallclock_when_epoch_unknown(self):
+        """A failed initial write must still be retried when RaceMonitor never
+        posts a start epoch; otherwise the metadata point stays missing while
+        the monitor ends RACE_ENDED and the run exits 0."""
+        stop = threading.Event()
+        ctx = _mod.RaceContext('123', '42', MagicMock(), MagicMock(), 0)
+        ctx.metadata = _mod.RaceMetadata('Race', 'Track', None, 9999)
+        ctx.client.race.details.return_value = {'Successful': False}
+        opts = _mod.RaceOptions(network_mode=True, interval=0)
+
+        def fake_get_session(race_id):
+            stop.set()
+            return {'Successful': False}
+
+        ctx.client.live.get_session.side_effect = fake_get_session
+
+        with patch.object(_mod, 'push_influx_race', return_value=True) as mock_race:
+            with patch.object(_mod, 'refresh_competitor', return_value=[]):
+                with patch.object(_mod, 'push_influx_standings_live', return_value={}):
+                    _mod.monitor_routine(ctx, [], opts, _stop_event=stop,
+                                         race_meta_written=False)
+
+        assert mock_race.call_count == 1
+        assert mock_race.call_args[0][1] > 1_000_000_000_000  # wall-clock ms, not 0
+
 
 class TestOldRaceClassWiring:
     def _session_details(self, car_number='42', cat_id='1', cat_name='A'):

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -2216,6 +2216,90 @@ class TestPushInfluxRace:
         delete_api.delete.assert_not_called()
         write_api.write.assert_not_called()
 
+    def test_returns_true_on_success(self):
+        ctx, _write_api, _delete_api = self._ctx()
+        assert _mod.push_influx_race(ctx, 5000000) is True
+
+    def test_returns_false_when_delete_fails(self):
+        ctx, _write_api, delete_api = self._ctx()
+        delete_api.delete.side_effect = Exception("network error")
+        assert _mod.push_influx_race(ctx, 5000000) is False
+
+    def test_returns_false_when_write_fails(self):
+        """Delete succeeded, write failed: the metadata point is now gone from
+        Influx — the caller must know so it can fail the run and retry."""
+        ctx, write_api, _delete_api = self._ctx()
+        write_api.write.side_effect = Exception("network error")
+        assert _mod.push_influx_race(ctx, 5000000) is False
+
+    def test_returns_false_when_metadata_none(self):
+        ctx, _write_api, _delete_api = self._ctx()
+        ctx.metadata = None
+        assert _mod.push_influx_race(ctx, 1000) is False
+
+
+class TestOldRaceMetadataFailure:
+    def _session_details(self):
+        return {
+            'Successful': True,
+            'Session': {
+                'ID': 1, 'Name': 'S1', 'SessionStartDateEpoc': 1000,
+                'Categories': {'1': {'ID': '1', 'Name': 'A'}},
+                'SortedCompetitors': [{
+                    'Number': '42', 'Category': '1', 'FirstName': 'Jane',
+                    'LastName': 'Doe', 'Position': '1', 'Laps': '1',
+                    'BestLapTime': '', 'LastLapTime': '', 'Transponder': '',
+                    'AdditionalData': '',
+                    'LapTimes': [{'Lap': '1', 'LapTime': '0:01:30.000',
+                                  'Position': '1', 'FlagStatus': 0,
+                                  'TotalTime': '0:01:30.000'}],
+                }],
+            },
+        }
+
+    def _ctx(self):
+        ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
+        ctx.query_api = MagicMock()
+        ctx.delete_api = MagicMock()
+        ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
+        ctx.client.results.session_details.return_value = self._session_details()
+        return ctx
+
+    def test_skip_path_fails_run_when_metadata_write_fails(self):
+        """The skip path deletes-then-rewrites metadata too; a silent failure
+        there erases the race from the races bucket while reporting success."""
+        ctx = self._ctx()
+        opts = _mod.RaceOptions(network_mode=True, skip_if_complete=True)
+        with patch.object(_mod, 'existing_lap_counts_fieldwide', return_value=(1, 1)):
+            with patch.object(_mod, 'existing_standings_counts_fieldwide',
+                              return_value=(1, 1)):
+                with patch.object(_mod, 'push_influx_race', return_value=False):
+                    result = _mod.old_race(ctx, opts)
+        assert result == 1
+
+    def test_write_path_fails_run_when_metadata_write_fails(self):
+        ctx = self._ctx()
+        opts = _mod.RaceOptions(network_mode=True)
+        with patch.object(_mod, 'push_influx_race', return_value=False):
+            with patch.object(_mod, 'print_rankings'):
+                result = _mod.old_race(ctx, opts)
+        assert result == 1
+
+    def test_lap_write_failure_fails_run(self):
+        ctx = self._ctx()
+        ctx.write_api.write.side_effect = Exception("boom")
+        opts = _mod.RaceOptions(network_mode=True)
+        with patch.object(_mod, 'push_influx_race', return_value=True):
+            result = _mod.old_race(ctx, opts)
+        assert result == 1
+
+    def test_run_race_propagates_old_race_failure(self):
+        ctx = self._ctx()
+        opts = _mod.RaceOptions(network_mode=True)
+        with patch.object(_mod, 'old_race', return_value=1):
+            result = _mod._run_race(ctx, opts, {'Successful': True, 'IsLive': False})
+        assert result == 1
+
 
 class TestPushInfluxSession:
     def _ctx(self):

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -3422,3 +3422,62 @@ class TestOldRaceSessionFetching:
             with patch.object(_mod, 'print_rankings'):
                 _mod.old_race(ctx, opts)
         assert ctx.client.results.session_details.call_count == 2
+
+
+class TestOldRaceExpectedCountFiltering:
+    """One garbage lap must not make expected != written forever, which defeats
+    --skip-if-complete and re-deletes/rewrites the race on every backfill run."""
+
+    def _session_details(self, lap_times):
+        return {
+            'Successful': True,
+            'Session': {
+                'ID': 1, 'Name': 'S1', 'SessionStartDateEpoc': 1000,
+                'Categories': {'1': {'ID': '1', 'Name': 'A'}},
+                'SortedCompetitors': [{
+                    'Number': '42', 'Category': '1', 'FirstName': 'Jane',
+                    'LastName': 'Doe', 'Position': '1', 'Laps': '2',
+                    'BestLapTime': '', 'LastLapTime': '', 'Transponder': '',
+                    'AdditionalData': '', 'LapTimes': lap_times,
+                }],
+            },
+        }
+
+    def _ctx(self, lap_times):
+        ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
+        ctx.query_api = MagicMock()
+        ctx.delete_api = MagicMock()
+        ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
+        ctx.client.results.session_details.return_value = self._session_details(lap_times)
+        return ctx
+
+    def test_garbage_lap_number_excluded_from_expected_count(self):
+        """Stored: 1 lap (the good one). Expected must also be 1 → SKIP."""
+        good = {'Lap': '1', 'LapTime': '0:01:30.000', 'Position': '1',
+                'FlagStatus': 0, 'TotalTime': '0:01:30.000'}
+        garbage = {'Lap': '$F', 'LapTime': '0:01:31.000', 'Position': '2',
+                   'FlagStatus': 0, 'TotalTime': '0:03:01.000'}
+        ctx = self._ctx([good, garbage])
+        opts = _mod.RaceOptions(network_mode=True, skip_if_complete=True)
+        with patch.object(_mod, 'existing_lap_counts_fieldwide', return_value=(1, 1)):
+            with patch.object(_mod, 'existing_standings_counts_fieldwide',
+                              return_value=(1, 1)):
+                with patch.object(_mod, 'push_influx_race', return_value=True):
+                    with patch.object(_mod, 'delete_existing_laps') as mock_del:
+                        _mod.old_race(ctx, opts)
+        mock_del.assert_not_called()
+
+    def test_garbage_total_time_excluded_from_write(self):
+        """A lap whose TotalTime cannot anchor a timestamp would collide at the
+        session start and be silently deduplicated by InfluxDB — exclude it."""
+        good = {'Lap': '1', 'LapTime': '0:01:30.000', 'Position': '1',
+                'FlagStatus': 0, 'TotalTime': '0:01:30.000'}
+        bad_time = {'Lap': '2', 'LapTime': '0:01:31.000', 'Position': '1',
+                    'FlagStatus': 0, 'TotalTime': '$F'}
+        ctx = self._ctx([good, bad_time])
+        opts = _mod.RaceOptions(network_mode=True)
+        with patch.object(_mod, 'push_influx_race', return_value=True):
+            with patch.object(_mod, 'print_rankings'):
+                _mod.old_race(ctx, opts)
+        lap_write = ctx.write_api.write.call_args_list[0]
+        assert len(lap_write.kwargs['record']) == 1

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -1340,7 +1340,8 @@ class TestOldRaceClassWiring:
                 with patch.object(_mod, 'push_influx_race'):
                     with patch.object(_mod, 'print_rankings'):
                         _mod.old_race(ctx, opts)
-        mock_resolve.assert_any_call('42', self._session_details())
+        expected_index = _mod._build_class_index(self._session_details())
+        mock_resolve.assert_any_call('42', self._session_details(), expected_index)
 
     def test_passes_class_name_to_build_lap_points(self):
         ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
@@ -3481,3 +3482,64 @@ class TestOldRaceExpectedCountFiltering:
                 _mod.old_race(ctx, opts)
         lap_write = ctx.write_api.write.call_args_list[0]
         assert len(lap_write.kwargs['record']) == 1
+
+
+class TestClassIndex:
+    def _session_details(self):
+        def comp(number, category, laps):
+            return {'Number': number, 'Category': category,
+                    'LapTimes': [{'Lap': str(ln), 'Position': str(p)}
+                                 for ln, p in laps]}
+        return {
+            'Session': {
+                'Categories': {'1': {'Name': 'A'}, '2': {'Name': 'B'}},
+                'SortedCompetitors': [
+                    comp('10', '1', [(1, 1), (2, 1)]),
+                    comp('11', '1', [(1, 3), (2, 2)]),
+                    comp('20', '2', [(1, 2), (2, 3)]),
+                ],
+            },
+        }
+
+    def test_index_matches_per_car_resolution(self):
+        details = self._session_details()
+        index = _mod._build_class_index(details)
+        for number in ('10', '11', '20'):
+            assert (_mod._resolve_class_historical(number, details)
+                    == _mod._resolve_class_historical(number, details, index))
+
+    def test_unknown_car_returns_none(self):
+        details = self._session_details()
+        index = _mod._build_class_index(details)
+        assert _mod._resolve_class_historical('99', details, index) == (None, {})
+
+    def test_old_race_builds_index_once_per_session(self):
+        session = {
+            'Successful': True,
+            'Session': {
+                'ID': 1, 'Name': 'S1', 'SessionStartDateEpoc': 1000,
+                'Categories': {'1': {'ID': '1', 'Name': 'A'}},
+                'SortedCompetitors': [
+                    {'Number': str(n), 'Category': '1', 'FirstName': 'F',
+                     'LastName': f'L{n}', 'Position': str(n), 'Laps': '1',
+                     'BestLapTime': '', 'LastLapTime': '', 'Transponder': '',
+                     'AdditionalData': '',
+                     'LapTimes': [{'Lap': '1', 'LapTime': '0:01:30.000',
+                                   'Position': str(n), 'FlagStatus': 0,
+                                   'TotalTime': '0:01:30.000'}]}
+                    for n in (1, 2, 3)
+                ],
+            },
+        }
+        ctx = _mod.RaceContext('999', None, MagicMock(), MagicMock(), 0)
+        ctx.query_api = MagicMock()
+        ctx.delete_api = MagicMock()
+        ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
+        ctx.client.results.session_details.return_value = session
+        opts = _mod.RaceOptions(network_mode=True)
+        with patch.object(_mod, '_build_class_index',
+                          wraps=_mod._build_class_index) as mock_index:
+            with patch.object(_mod, 'push_influx_race', return_value=True):
+                with patch.object(_mod, 'print_rankings'):
+                    _mod.old_race(ctx, opts)
+        assert mock_index.call_count == 1  # once per session, not per competitor

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import threading
+from types import SimpleNamespace
 from typing import ClassVar
 from unittest.mock import MagicMock, call, mock_open, patch
 
@@ -3338,6 +3339,56 @@ class TestMainMissingToken:
         assert exc_info.value.code == 1
         assert any('RACEMONITOR_TOKENS' in r.message and 'RACEMONITOR_TOKEN' in r.message
                    for r in caplog.records)
+
+
+class TestMainFluxIdValidation:
+    """laps.main() interpolates race_id/car_number into Flux delete predicates and
+    queries, so it must reject unsafe identifiers before touching RaceMonitor/Influx,
+    same as race_diagnose.main() and race_backfill.main() already do."""
+
+    def _fake_args(self, race_id, car_number=None):
+        return SimpleNamespace(
+            race_id=[race_id], car_number=car_number, verbose=False,
+            network_mode=False, monitor_mode=False, save_file=False,
+            selected_class=None, interval=30, skip_if_complete=False, dry_run=False,
+        )
+
+    def test_race_id_with_quote_exits_1_before_racemonitor_client(self):
+        with patch.object(_mod, '_build_parser') as mock_parser_factory:
+            mock_parser_factory.return_value.parse_args.return_value = (
+                self._fake_args('x"y'))
+            with patch.dict(os.environ, {'RACEMONITOR_TOKENS': 'TOKEN'}, clear=True):
+                with patch.object(_mod, 'RaceMonitorClient') as mock_client:
+                    mock_client.side_effect = AssertionError(
+                        'must not reach RaceMonitorClient with an invalid id')
+                    with pytest.raises(SystemExit) as exc_info:
+                        _mod.main()
+        assert exc_info.value.code == 1
+        mock_client.assert_not_called()
+
+    def test_car_number_with_quote_exits_1_before_racemonitor_client(self):
+        with patch.object(_mod, '_build_parser') as mock_parser_factory:
+            mock_parser_factory.return_value.parse_args.return_value = (
+                self._fake_args('12345', car_number='4"2'))
+            with patch.dict(os.environ, {'RACEMONITOR_TOKENS': 'TOKEN'}, clear=True):
+                with patch.object(_mod, 'RaceMonitorClient') as mock_client:
+                    mock_client.side_effect = AssertionError(
+                        'must not reach RaceMonitorClient with an invalid id')
+                    with pytest.raises(SystemExit) as exc_info:
+                        _mod.main()
+        assert exc_info.value.code == 1
+        mock_client.assert_not_called()
+
+    def test_logs_invalid_identifier_error(self, caplog):
+        with patch.object(_mod, '_build_parser') as mock_parser_factory:
+            mock_parser_factory.return_value.parse_args.return_value = (
+                self._fake_args('x"y'))
+            with patch.dict(os.environ, {'RACEMONITOR_TOKENS': 'TOKEN'}, clear=True):
+                with patch.object(_mod, 'RaceMonitorClient'):
+                    with caplog.at_level(logging.ERROR):
+                        with pytest.raises(SystemExit):
+                            _mod.main()
+        assert any('x"y' in r.message for r in caplog.records)
 
 
 class TestLiveRaceNoData:

--- a/tests/test_pisugar_monitor.py
+++ b/tests/test_pisugar_monitor.py
@@ -34,6 +34,14 @@ class TestTokenExpiry:
             payload = {"exp": 9999, "pad": extra}
             assert token_expiry(_make_jwt(payload)) == 9999
 
+    def test_base64url_payload_decoded(self):
+        """JWT payloads are base64url; b64decode silently drops '-'/'_' and
+        corrupts the payload, permanently disabling proactive refresh."""
+        payload = {"exp": 4102444800, "k": ">>>"}
+        body = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=").decode()
+        assert "-" in body or "_" in body  # guard: must exercise base64url chars
+        assert token_expiry(f"header.{body}.sig") == 4102444800
+
 
 class TestReadCredentials:
     def test_returns_credentials_from_config(self):
@@ -53,6 +61,20 @@ class TestReadCredentials:
         data = json.dumps({"other": "value"})
         with patch("builtins.open", mock_open(read_data=data)):
             assert read_credentials() == (None, None)
+
+
+class TestHttpTimeouts:
+    def test_login_passes_timeout(self):
+        with patch.object(_mod.urllib.request, "urlopen") as mock_open:
+            mock_open.return_value.__enter__.return_value.read.return_value = b"tok"
+            _mod.login("u", "p")
+        assert mock_open.call_args.kwargs["timeout"] == _mod.HTTP_TIMEOUT_S
+
+    def test_exec_command_passes_timeout(self):
+        with patch.object(_mod.urllib.request, "urlopen") as mock_open:
+            mock_open.return_value.__enter__.return_value.read.return_value = b"battery: 84.5"
+            _mod.exec_command("get battery")
+        assert mock_open.call_args.kwargs["timeout"] == _mod.HTTP_TIMEOUT_S
 
 
 class TestMain:

--- a/tests/test_pisugar_monitor.py
+++ b/tests/test_pisugar_monitor.py
@@ -1,6 +1,6 @@
 import base64
 import json
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock, call, mock_open, patch
 from urllib.error import URLError
 
 import pytest
@@ -113,7 +113,7 @@ class TestStartupConnect:
         """The monitor often boots before pisugar-server binds :8421; it must
         retry instead of dying with a traceback."""
         with patch.object(_mod, "login", side_effect=[URLError("refused"), "tok"]) as mock_login:
-            with patch.object(_mod, "exec_command", return_value="PiSugar 3"):
+            with patch.object(_mod, "exec_command", return_value="PiSugar 3") as mock_exec:
                 with patch.object(_mod, "sleep") as mock_sleep:
                     token, tags = _mod._startup_connect("u", "p")
         assert token == "tok"
@@ -121,6 +121,13 @@ class TestStartupConnect:
         mock_sleep.assert_called_once_with(_mod.STARTUP_RETRY_DELAY_S)
         assert tags == {"server_version": "PiSugar 3", "model": "PiSugar 3",
                         "firmware_version": "PiSugar 3"}
+        # Device tags must be read raw; coerce=False keeps "PiSugar 3" from being
+        # numerically mangled.
+        assert mock_exec.call_args_list == [
+            call("get version", "tok", coerce=False),
+            call("get model", "tok", coerce=False),
+            call("get firmware_version", "tok", coerce=False),
+        ]
 
     def test_no_credentials_skips_login(self):
         with patch.object(_mod, "login") as mock_login:

--- a/tests/test_pisugar_monitor.py
+++ b/tests/test_pisugar_monitor.py
@@ -1,6 +1,7 @@
 import base64
 import json
 from unittest.mock import MagicMock, mock_open, patch
+from urllib.error import URLError
 
 import pytest
 
@@ -90,3 +91,40 @@ class TestMain:
                         _mod.main()
         assert exc.value.code == 1
         login.assert_not_called()
+
+
+class TestExecCommandCoercion:
+    def test_raw_mode_preserves_version_strings(self):
+        """Firmware '1.10' must not become the float 1.1 in device tags."""
+        with patch.object(_mod.urllib.request, "urlopen") as mock_open:
+            mock_open.return_value.__enter__.return_value.read.return_value = \
+                b"firmware_version: 1.10"
+            assert _mod.exec_command("get firmware_version", coerce=False) == "1.10"
+
+    def test_default_mode_still_coerces_floats(self):
+        with patch.object(_mod.urllib.request, "urlopen") as mock_open:
+            mock_open.return_value.__enter__.return_value.read.return_value = \
+                b"battery: 84.5"
+            assert _mod.exec_command("get battery") == 84.5
+
+
+class TestStartupConnect:
+    def test_retries_until_server_reachable(self):
+        """The monitor often boots before pisugar-server binds :8421; it must
+        retry instead of dying with a traceback."""
+        with patch.object(_mod, "login", side_effect=[URLError("refused"), "tok"]) as mock_login:
+            with patch.object(_mod, "exec_command", return_value="PiSugar 3"):
+                with patch.object(_mod, "sleep") as mock_sleep:
+                    token, tags = _mod._startup_connect("u", "p")
+        assert token == "tok"
+        assert mock_login.call_count == 2
+        mock_sleep.assert_called_once_with(_mod.STARTUP_RETRY_DELAY_S)
+        assert tags == {"server_version": "PiSugar 3", "model": "PiSugar 3",
+                        "firmware_version": "PiSugar 3"}
+
+    def test_no_credentials_skips_login(self):
+        with patch.object(_mod, "login") as mock_login:
+            with patch.object(_mod, "exec_command", return_value="PiSugar 3"):
+                token, _tags = _mod._startup_connect(None, None)
+        assert token is None
+        mock_login.assert_not_called()

--- a/tests/test_race_backfill.py
+++ b/tests/test_race_backfill.py
@@ -270,7 +270,7 @@ class TestValidateBackfill:
         _mod.validate_backfill([('101', '42')], query_api)
         laps_flux = query_api.query.call_args_list[1].args[0]
         assert '1970-01-01' not in laps_flux
-        assert '2022-06-01' in laps_flux
+        assert '2022-05-31' in laps_flux  # race_start (2022-06-01) padded back one day
 
     def test_races_query_filters_by_end_time_epoc_field(self):
         query_api = self._make_query_api(actual_cars={'42': 10})
@@ -609,4 +609,27 @@ class TestInputValidation:
             with pytest.raises(SystemExit) as exc:
                 rb.main()
         assert exc.value.code == 1
+
+
+class TestValidateWindowPadding:
+    def test_lap_query_padded_one_day_each_side(self):
+        import lemongrass.race_backfill as rb
+        query_api = MagicMock()
+
+        race_record = MagicMock()
+        race_record.values = {'race_name': 'Test Race', 'race_id': '999'}
+        race_record.get_time.return_value = datetime(2020, 1, 2, tzinfo=timezone.utc)
+        race_record.get_value.return_value = int(
+            datetime(2020, 1, 4, tzinfo=timezone.utc).timestamp())
+        race_table = MagicMock()
+        race_table.records = [race_record]
+
+        lap_table = MagicMock()
+        lap_table.records = []
+        query_api.query.side_effect = [[race_table], [lap_table]]
+
+        rb.validate_backfill([('999', '42')], query_api)
+        lap_flux = query_api.query.call_args_list[1].args[0]
+        assert 'start: 2020-01-01T00:00:00Z' in lap_flux
+        assert 'stop: 2020-01-05T00:00:00Z' in lap_flux
 

--- a/tests/test_race_backfill.py
+++ b/tests/test_race_backfill.py
@@ -593,3 +593,20 @@ class TestMainTokenResolution:
                     _mod.main()
         assert exc_info.value.code == 1
 
+
+class TestInputValidation:
+    def test_car_number_with_quote_exits_1(self):
+        import lemongrass.race_backfill as rb
+        with patch.object(sys, 'argv', ['lemongrass-race-backfill', '--car', 'x"y']):
+            with pytest.raises(SystemExit) as exc:
+                rb.main()
+        assert exc.value.code == 1
+
+    def test_override_with_quote_exits_1(self):
+        import lemongrass.race_backfill as rb
+        with patch.object(sys, 'argv',
+                          ['lemongrass-race-backfill', '--override', '123:x"y']):
+            with pytest.raises(SystemExit) as exc:
+                rb.main()
+        assert exc.value.code == 1
+

--- a/tests/test_race_diagnose.py
+++ b/tests/test_race_diagnose.py
@@ -69,3 +69,19 @@ class TestInputValidation:
             with pytest.raises(SystemExit) as exc:
                 rd.main()
         assert exc.value.code == 1
+
+
+class TestWindowPadding:
+    def test_range_padded_one_day_each_side(self):
+        """Flux stop is exclusive and lap timestamps are session-anchored, so a
+        session running past the nominal EndDateEpoc would be invisible to
+        diagnose, mis-reporting a write bug."""
+        import lemongrass.race_diagnose as rd
+        query_api = MagicMock()
+        query_api.query.return_value = []
+        start = 864000   # 1970-01-11
+        end = 950400     # 1970-01-12
+        rd.diagnose_influx(query_api, '999', '42', start_epoc=start, end_epoc=end)
+        flux = query_api.query.call_args.args[0]
+        assert 'start: 1970-01-10T00:00:00Z' in flux
+        assert 'stop: 1970-01-13T00:00:00Z' in flux

--- a/tests/test_race_diagnose.py
+++ b/tests/test_race_diagnose.py
@@ -60,3 +60,12 @@ class TestMainTokenResolution:
         out = capsys.readouterr().out
         assert 'RACEMONITOR_TOKENS' in out
         assert 'RACEMONITOR_TOKEN' in out
+
+
+class TestInputValidation:
+    def test_race_id_with_quote_exits_before_any_query(self):
+        import lemongrass.race_diagnose as rd
+        with patch.object(sys, 'argv', ['lemongrass-race-diagnose', 'x"y', '42']):
+            with pytest.raises(SystemExit) as exc:
+                rd.main()
+        assert exc.value.code == 1

--- a/tests/test_telem.py
+++ b/tests/test_telem.py
@@ -547,3 +547,36 @@ class TestRouteCommand:
                     assert _mod._route_command(command) is None, command.name
                     checked += 1
         assert checked > 90  # the mode-2 twins alone number ~96; 0 means vacuous
+
+
+class TestQueuePoint:
+    def setup_method(self):
+        _reset()
+        _mod._last_append_monotonic = 0.0
+
+    def test_appends_and_stamps_last_append_time(self):
+        _mod._queue_point("p")
+        assert _mod.pending_points == ["p"]
+        assert _mod._last_append_monotonic > 0
+
+
+class TestConnectionHealthy:
+    def test_healthy_when_connected_and_data_recent(self):
+        conn = MagicMock()
+        conn.is_connected.return_value = True
+        _mod._last_append_monotonic = _mod.monotonic()
+        assert _mod._connection_healthy(conn) is True
+
+    def test_unhealthy_when_disconnected(self):
+        conn = MagicMock()
+        conn.is_connected.return_value = False
+        _mod._last_append_monotonic = _mod.monotonic()
+        assert _mod._connection_healthy(conn) is False
+
+    def test_unhealthy_when_data_stale(self):
+        """ELM adapter alive but ECU silent (ignition off): no callback has
+        queued a point for over STALE_DATA_TIMEOUT_S — treat as dead."""
+        conn = MagicMock()
+        conn.is_connected.return_value = True
+        _mod._last_append_monotonic = _mod.monotonic() - (_mod.STALE_DATA_TIMEOUT_S + 1)
+        assert _mod._connection_healthy(conn) is False

--- a/tests/test_telem.py
+++ b/tests/test_telem.py
@@ -1,4 +1,5 @@
 import importlib
+import logging
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -558,6 +559,30 @@ class TestQueuePoint:
         _mod._queue_point("p")
         assert _mod.pending_points == ["p"]
         assert _mod._last_append_monotonic > 0
+
+    def test_enqueue_capped_dropping_oldest_with_warning(self, caplog):
+        """A hung flush must not let callbacks grow memory unbounded — and the
+        drop must leave a trace in the logs, matching flush_points."""
+        _mod._dropped_since_warn = 0
+        _mod._last_drop_warn_monotonic = float('-inf')
+        with patch.object(_mod, "MAX_PENDING_POINTS", 3):
+            _mod.pending_points.extend(["p1", "p2", "p3"])
+            with caplog.at_level(logging.WARNING):
+                _mod._queue_point("p4")
+        assert _mod.pending_points == ["p2", "p3", "p4"]
+        assert any("dropped" in r.message.lower() for r in caplog.records)
+
+    def test_enqueue_drop_warning_is_rate_limited(self, caplog):
+        """One warning per interval, not one per dropped point — sustained
+        saturation would otherwise flood journald with a line per callback."""
+        _mod._dropped_since_warn = 0
+        _mod._last_drop_warn_monotonic = float('-inf')
+        with patch.object(_mod, "MAX_PENDING_POINTS", 3):
+            _mod.pending_points.extend(["p1", "p2", "p3"])
+            with caplog.at_level(logging.WARNING):
+                _mod._queue_point("p4")
+                _mod._queue_point("p5")
+        assert sum("dropped" in r.message.lower() for r in caplog.records) == 1
 
 
 class TestConnectionHealthy:

--- a/tests/test_telem.py
+++ b/tests/test_telem.py
@@ -460,6 +460,29 @@ class TestFlushPoints:
         write_api.write.assert_called_once()
         assert len(_mod.pending_points) == 0
 
+    def test_flushes_in_batches(self):
+        _mod.pending_points.extend(f"p{i}" for i in range(5))
+        write_api = MagicMock()
+        _mod.flush_points(write_api, batch_size=2)
+        assert write_api.write.call_count == 3
+        assert len(_mod.pending_points) == 0
+
+    def test_requeues_only_unwritten_on_midbatch_failure(self):
+        _mod.pending_points.extend(["p1", "p2", "p3", "p4", "p5"])
+        write_api = MagicMock()
+        write_api.write.side_effect = [None, Exception("boom")]
+        _mod.flush_points(write_api, batch_size=2)
+        assert _mod.pending_points == ["p3", "p4", "p5"]
+
+    def test_backlog_capped_dropping_oldest(self):
+        """A multi-hour outage must not grow the backlog until the Pi OOMs."""
+        write_api = MagicMock()
+        write_api.write.side_effect = Exception("boom")
+        with patch.object(_mod, "MAX_PENDING_POINTS", 3):
+            _mod.pending_points.extend(["p1", "p2", "p3", "p4"])
+            _mod.flush_points(write_api)
+        assert _mod.pending_points == ["p2", "p3", "p4"]
+
 
 class TestRouteCommand:
     def test_excludes_pattern_matches(self):

--- a/tests/test_telem.py
+++ b/tests/test_telem.py
@@ -131,6 +131,32 @@ class TestNewFuelStatus:
             _mod.new_fuel_status(r)
         assert captured_name[0] == "-Fuel-System-Status"
 
+    def test_uses_system_1_status_when_systems_differ(self):
+        """Dual-bank ECU: system 1 in failure mode must not be masked by
+        system 2's closed-loop status (dict order used to decide the winner)."""
+        r = MagicMock()
+        r.command = _Cmd("b'0103': Fuel System Status")
+        r.value = [
+            "Open loop due to system failure",
+            "Closed loop, using oxygen sensor feedback to determine fuel mix",
+        ]
+        _mod.new_fuel_status(r)
+        assert _mod.pending_points[0]._fields == {"value": 3}
+
+
+class TestConfigureObdLogging:
+    def test_no_debug_by_default(self, monkeypatch):
+        monkeypatch.delenv("OBD_DEBUG", raising=False)
+        _mod.obd.logger.setLevel.reset_mock()
+        _mod._configure_obd_logging()
+        _mod.obd.logger.setLevel.assert_not_called()
+
+    def test_debug_enabled_via_env(self, monkeypatch):
+        monkeypatch.setenv("OBD_DEBUG", "1")
+        _mod.obd.logger.setLevel.reset_mock()
+        _mod._configure_obd_logging()
+        _mod.obd.logger.setLevel.assert_called_once_with(_mod.obd.logging.DEBUG)
+
 
 class TestNewAirStatus:
     def setup_method(self):

--- a/uv.lock
+++ b/uv.lock
@@ -44,7 +44,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -154,11 +154,13 @@ dependencies = [
     { name = "obd" },
     { name = "pandas" },
     { name = "race-monitor" },
+    { name = "urllib3" },
 ]
 
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -167,10 +169,14 @@ requires-dist = [
     { name = "obd", specifier = "~=0.7" },
     { name = "pandas", specifier = "~=2.3" },
     { name = "race-monitor", specifier = ">=0.6.1,<1" },
+    { name = "urllib3", specifier = ">=2" },
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8" }]
+dev = [
+    { name = "pytest", specifier = ">=8" },
+    { name = "ruff", specifier = ">=0.14" },
+]
 
 [[package]]
 name = "numpy"
@@ -571,6 +577,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b6/af/38a4b62468e4c5bd50acf511d86fe62e65a466aa6abb55b1d59a4a9e57f3/reactivex-4.1.0.tar.gz", hash = "sha256:c7499e3c802bccaa20839b3e17355a7d939573fded3f38ba3d4796278a169a3d", size = 113482, upload-time = "2025-11-05T21:44:24.557Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/9e/3c2f5d3abb6c5d82f7696e1e3c69b7279049e928596ce82ed25ca97a08f3/reactivex-4.1.0-py3-none-any.whl", hash = "sha256:485750ec8d9b34bcc8ff4318971d234dc4f595058a1b4435a74aefef4b2bc9bd", size = 218588, upload-time = "2025-11-05T21:44:23.015Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/dc/35b341fc554ba02f217fc10da57d1a75168cfbcf75b0ef2202176d4c4f2d/ruff-0.15.20.tar.gz", hash = "sha256:1416eb04349192646b54de98f146c4f59afe37d0decfc02c3cbbf396f3a28566", size = 4755489, upload-time = "2026-06-25T17:20:37.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/d9/2d5014f0253ba541d2061d9fa7193f48e941c8b21bb88a7ff9bbe0bd0596/ruff-0.15.20-py3-none-linux_armv6l.whl", hash = "sha256:00e188c53e499c3c1637f73c91dcf2fb56d576cab76ce1be50a27c4e80e37078", size = 10839665, upload-time = "2026-06-25T17:19:44.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d3/ac1798ba64f670698867fcfc591d50e7e421bef137db564858f619a30fcf/ruff-0.15.20-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9ebd1fd9b9c95fc0bd7b2761aebec1f030013d2e193a2901b224af68fe47251b", size = 11208649, upload-time = "2026-06-25T17:19:48.787Z" },
+    { url = "https://files.pythonhosted.org/packages/47/47/d3ac899991202095dfcf3d5176be4272642be3cf981a2f1a30f72a2afb95/ruff-0.15.20-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5b16cdd67ca108185cd36dce98c576350c03b1660a751de725fb049193a0632", size = 10622638, upload-time = "2026-06-25T17:19:51.354Z" },
+    { url = "https://files.pythonhosted.org/packages/33/13/4e043fe30aa94d4ff5213a9881fc296d12960f5971b234a5263fdc225312/ruff-0.15.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3413bb3c3d2ca6a8208f1f4809cd2dca3c6de6d0b491c0e70847672bde6e6efd", size = 10984227, upload-time = "2026-06-25T17:19:54.044Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e6/92e7bf40388bc5800073b96564f56264f7e48bfd1a498f5ced6ae6d5a769/ruff-0.15.20-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd7ec42b3bb3da066488db093308a69c4ac5ee6d2af333a86ba6e2eb2e7dd44b", size = 10622882, upload-time = "2026-06-25T17:19:57.037Z" },
+    { url = "https://files.pythonhosted.org/packages/13/7a/43460be3f24495a3aa46d4b16873e2c4941b3b5f0b00cf88c03b7b94b339/ruff-0.15.20-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1a36ad0eb77fba9aabfb69ede54de6f376d04ac18ebea022847046d340a8267", size = 11474808, upload-time = "2026-06-25T17:20:00.357Z" },
+    { url = "https://files.pythonhosted.org/packages/27/a0/f37077884873221c6b33b4ab49eb18f9f88e54a16a25a5bca59bef46dd66/ruff-0.15.20-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b6df3b1e4610432f0386dba04d853b5f08cbbc903410c6fcc02f620f05aff53c", size = 12293094, upload-time = "2026-06-25T17:20:03.446Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/74/165545b60256a9704c21ac0ec4a0d07933b320812f9584836c9f4aca4292/ruff-0.15.20-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e89f198a1ea6ef0d727c1cf16088bc91a6cb0ab947dedc966715691647186eae", size = 11526176, upload-time = "2026-06-25T17:20:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b1/a976a136d40ade83ce743578399865f57001003a409acadc0ecbb3051082/ruff-0.15.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309809086c2acb67624950a3c8133e80f32d0d3e27106c0cd60ff26657c9f24b", size = 11520767, upload-time = "2026-06-25T17:20:09.191Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0f/f032696cb01c9b54c0263fa393474d7758f1cdc021a01b04e3cbc2500999/ruff-0.15.20-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2d2374caa2f2c2f9e2b7da0a50802cfb8b79f55a9b5e49379f564544fbf56487", size = 11500132, upload-time = "2026-06-25T17:20:13.602Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f4/51b1a14bc69e8c224b15dab9cce8e99b425e0455d462caa2b3c9be2b6a8e/ruff-0.15.20-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a1ed17b65293e0c2f22fc387bc13198a5de94bf4429589b0ff6946b0feaf21a3", size = 10943828, upload-time = "2026-06-25T17:20:16.635Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4b/fe267640783cd02bf6c5cc290b1df1051be2ec294c678b5c15fe19e52343/ruff-0.15.20-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f701305e66b38ea6c91882490eb73459796808e4c6362a1b765255e0cdcd4053", size = 10645418, upload-time = "2026-06-25T17:20:19.4Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c0/a65aa4ec2f5e87a1df32dc3ec1fede434fe3dfd5cbcf3b503cafc676ab54/ruff-0.15.20-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b9c0c367ad8e5d0d5b5b8537864c469a0a0e55417aadfbeca41fa61333be9f4", size = 11211770, upload-time = "2026-06-25T17:20:22.033Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a4/0caa331d954ae2723d729d351c989cb4ca8b6077d5c6c2cb6de75e98c041/ruff-0.15.20-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:01cc00dd58f0df339d0e902219dd53990ea99996a0344e5d9cc8d45d5307e460", size = 11618698, upload-time = "2026-06-25T17:20:25.259Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9b/5f14927848d2fd4aa891fd88d883788c5a7baba561c7874732364045708c/ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21", size = 10857322, upload-time = "2026-06-25T17:20:28.612Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415", size = 11993274, upload-time = "2026-06-25T17:20:31.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca", size = 11343498, upload-time = "2026-06-25T17:20:35.03Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -168,7 +168,7 @@ requires-dist = [
     { name = "influxdb-client", specifier = "~=1.47" },
     { name = "obd", specifier = "~=0.7" },
     { name = "pandas", specifier = "~=2.3" },
-    { name = "race-monitor", specifier = ">=0.6.1,<1" },
+    { name = "race-monitor", specifier = ">=0.7.0,<1" },
     { name = "urllib3", specifier = ">=2" },
 ]
 
@@ -556,15 +556,15 @@ wheels = [
 
 [[package]]
 name = "race-monitor"
-version = "0.6.1"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "idna" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/87/ae/2d78c5c9672f433bb85fcddd1b563782986adee70405f89f587b5ad0dde3/race_monitor-0.6.1.tar.gz", hash = "sha256:3ecd79287fc9beef3a69a2e28d2c9aee8a70052376ba09800d8499289568c2f9", size = 14434, upload-time = "2026-06-29T02:56:00.864Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/02/6a9a67ef45f9ba96e2c927d734548f24dfd7aca4f176f6735eaca202bed9/race_monitor-0.7.0.tar.gz", hash = "sha256:b5e11b645e1ea818c937793261ba7ad0a926f818b26693ebf322d53726650512", size = 16179, upload-time = "2026-07-03T17:22:09.156Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/6a/58c88bcf2ffbcadbaf2af18df6ee613b421e071eee9613ca42e6b9ee4112/race_monitor-0.6.1-py3-none-any.whl", hash = "sha256:33ee95fe41e4b88dffbcbd538566854e1cecd518ea6bd8b3ef0c5c39e3cf2440", size = 20313, upload-time = "2026-06-29T02:55:59.526Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/91/7ff9ff7a3bdcd7513843054e53f3e97a8935475c6562b7005926a7e73e4d/race_monitor-0.7.0-py3-none-any.whl", hash = "sha256:427e1a761d0ad5732e523d4fb76fc130e403d4098c945595706764a2e3d2f220", size = 22720, upload-time = "2026-07-03T17:22:08.043Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -175,7 +175,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=8" },
-    { name = "ruff", specifier = ">=0.14" },
+    { name = "ruff", specifier = ">=0.14,<1.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
Upgrades to **race-monitor 0.7.0** and resolves all findings from the
full-codebase review.

## race-monitor 0.7.0

0.7.0 bounds 429 retries by `max_retries` (default 5) instead of retrying
forever, raising `RaceMonitorHTTPError` once they're exhausted. Bumping the floor
to `>=0.7.0` means the CLI no longer hangs indefinitely under a sustained rate
limit. The now-possible `RaceMonitorError` is translated at the `cli.main`
boundary into a one-line message + exit 1 (special-casing 429), mirroring the
existing InfluxDB error handling instead of dumping a traceback.

The other 0.7.0 breaking change — honoring a user-supplied httpx `timeout` — does
not affect lemongrass: no call site passes a custom timeout, so the 30s default
still applies.

## Codebase review fixes

Resolves the findings from the full-codebase review:

- **Crash bugs**: live_race KeyError, monitor-loop network blips, zero-session
  UnboundLocalError, pisugar startup race, and `_build_class_index` /
  `_build_lap_points` tolerating competitors without `LapTimes` or an
  unparseable TotalTime.
- **Data integrity**: silent race-metadata erasure, expected-count mismatch
  defeating `--skip-if-complete`, swallowed exit codes, skipping backfill
  competitors whose laps all filter out (so an all-empty field can't delete
  existing laps without writing replacements), and failing the run when
  standings writes fail so the next backfill rewrites them.
- **Live race-metadata durability**: `monitor_routine` re-attempts the metadata
  write each poll until it lands (and after an epoch correction) — falling back
  to a wall-clock timestamp while RaceMonitor hasn't posted a start epoch — so
  a transient delete/write failure self-heals without aborting lap capture; the
  non-monitor path returns `MonitorStatus.WRITE_FAILED` (exit 1) so a rerun
  restores a possibly-deleted record.
- **Robustness**: OBD watchdog, bounded telem backlog (`pending_points` capped on
  enqueue — with a rate-limited drop warning — not just on requeue), HTTP
  timeouts, base64url JWT decode, Flux-id validation (including `laps.main()`),
  and padded diagnose windows via a centralized `WINDOW_PAD_S` in `_influx`.
- **Performance**: per-session class index, display-mode over-fetch, OBD debug
  logging, and warning spam.
- **Tests**: expanded coverage for validation, time parsing, batching/requeue,
  and failure modes.

522 tests pass, ruff clean.

The backfill short-circuit (skip answered from Influx without API fetches) is
deferred to the follow-up issue: #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)