### PR TITLE
feat(telem): ELM327 emulator for hardware-free local testing + CI integration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,3 +27,9 @@ tests
 *.md
 *.txt
 LICENSE
+
+# Re-include files the Dockerfile COPYs (Dockerfile:4). Without these, the
+# *.md / LICENSE excludes above make `docker build .` fail on BuildKit with
+# "COPY ... not found".
+!README.md
+!LICENSE

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -32,8 +32,11 @@ jobs:
 
   integration:
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -29,3 +29,22 @@ jobs:
 
       - name: Run tests
         run: uv run --frozen --with pytest pytest tests/
+
+  integration:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          version: "0.11.24"
+          python-version: "3.14"
+
+      - name: Sync project (frozen)
+        run: uv sync --frozen
+
+      - name: Install ELM327 emulator
+        run: bash local-testing/install-emulator.sh
+
+      - name: Run integration tests
+        run: uv run --no-sync pytest -m integration tests/

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,6 +9,7 @@ on:
       - 'Dockerfile'
       - 'pyproject.toml'
       - 'uv.lock'
+      - 'local-testing/**'
 
 jobs:
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,8 @@ activemq-data/
 
 # Environments
 .env
+# Non-secret: the local test stack's single source for the emulator port.
+!local-testing/.env
 .envrc
 .venv
 env/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,8 +56,8 @@ When prod is unavailable, run the full pipeline against a local InfluxDB.
    or open Grafana at http://localhost:3000 (login `admin` / `local-dev-password`)
    — the InfluxDB datasource and lemongrass dashboards (**laps**, **race-control**, **standings**)
    are pre-provisioned. The OBD dashboards (**telegraf**, **car252-pisugar-ups**) and OBD panels
-   in **race-control** show no data locally because OBD/`stats_252` collection is not configured
-   for local testing.
+   in **race-control** show no data until you start the emulator-backed telem stack (see
+   "Emulated OBD telemetry" below).
 
 5. Tear down (add `-v` to wipe data and re-trigger bucket init next start):
 
@@ -68,8 +68,46 @@ When prod is unavailable, run the full pipeline against a local InfluxDB.
    Storage is persistent named Docker volumes, so a plain `down` keeps your seeded
    data across restarts; pass `-v` only when you want a clean reset.
 
-**Note:** telemetry/OBD commands (`telem`, `pisugar-monitor`) are out of scope for
-local testing — they write to a `stats_252` bucket that this stack does not create.
+### Emulated OBD telemetry
+
+The `telem` service normally reads a physical ELM327 adapter. For local testing, a
+virtual ELM327 ([`ELM327-emulator`](https://pypi.org/project/ELM327-emulator/)) runs as
+the `elm327` service and telem connects to it over TCP (`socket://elm327:35000`). Both
+live behind a `telem` compose profile, so the default `up` still starts only InfluxDB +
+Grafana.
+
+Run the "car in a box" stack:
+
+```bash
+docker compose -f local-testing/docker-compose.yml --profile telem up --build -d
+```
+
+telem writes emulated data to the `stats_252` bucket (seeded by the InfluxDB init
+scripts), so the **telegraf** dashboard and the OBD panels in **race-control** show live
+data. The `stats_252` bucket and its DBRP are created only on a **fresh** InfluxDB volume,
+so if you added them to an existing stack, recreate the volume:
+
+```bash
+docker compose -f local-testing/docker-compose.yml --profile telem down -v
+docker compose -f local-testing/docker-compose.yml --profile telem up --build -d
+```
+
+(`pisugar-monitor` remains out of scope for local testing — it needs PiSugar UPS hardware.)
+
+### Running the OBD integration tests
+
+The default `uv run pytest` run is mock-only and fast. The integration tests drive telem's
+real OBD path against the emulator and are excluded by the `integration` marker. The
+emulator is installed imperatively (kept out of `uv.lock`):
+
+```bash
+uv sync
+bash local-testing/install-emulator.sh
+uv run --no-sync pytest -m integration tests/
+```
+
+`--no-sync` prevents `uv run` from pruning the imperatively-installed emulator. CI runs
+this same sequence in the `integration` job.
 
 **Unreachable InfluxDB:** if the server is down or unreachable, commands retry a few
 times, then exit non-zero with a one-line `cannot reach InfluxDB at …` message

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,15 +17,17 @@ green lint — run both before pushing.
 
 When prod is unavailable, run the full pipeline against a local InfluxDB.
 
-1. Start the stack (InfluxDB on `:8086`, Grafana on `:3000`):
+1. Start the stack (InfluxDB on `:8086`, Grafana on `:3000`, plus the emulated
+   OBD car — an ELM327 emulator + `telem`):
 
    ```bash
-   docker compose -f local-testing/docker-compose.yml up -d
+   docker compose -f local-testing/docker-compose.yml up --build -d
    ```
 
-   First start creates org `lemongrass`, a pinned operator token
-   (`local-dev-token`), and the `laps`, `races`, and `race_sessions` buckets.
-   These are non-secret, local-only values.
+   `--build` builds the `elm327` and `telem` images on first start (and after
+   changes). First start creates org `lemongrass`, a pinned operator token
+   (`local-dev-token`), and the `laps`, `races`, `race_sessions`, and
+   `stats_252/autogen` buckets. These are non-secret, local-only values.
 
 2. Point the CLI at the local stack by sourcing the committed app env:
 
@@ -55,9 +57,10 @@ When prod is unavailable, run the full pipeline against a local InfluxDB.
 
    or open Grafana at http://localhost:3000 (login `admin` / `local-dev-password`)
    — the InfluxDB datasource and lemongrass dashboards (**laps**, **race-control**, **standings**)
-   are pre-provisioned. The OBD dashboards (**telegraf**, **car252-pisugar-ups**) and OBD panels
-   in **race-control** show no data until you start the emulator-backed telem stack (see
-   "Emulated OBD telemetry" below).
+   are pre-provisioned. The **telegraf** dashboard and the OBD panels in **race-control** render
+   emulated telemetry from the `telem` service, which starts with the default stack (see
+   "Emulated OBD telemetry" below). **car252-pisugar-ups** stays empty — it needs PiSugar UPS
+   hardware.
 
 5. Tear down (add `-v` to wipe data and re-trigger bucket init next start):
 
@@ -73,23 +76,17 @@ When prod is unavailable, run the full pipeline against a local InfluxDB.
 The `telem` service normally reads a physical ELM327 adapter. For local testing, a
 virtual ELM327 ([`ELM327-emulator`](https://pypi.org/project/ELM327-emulator/)) runs as
 the `elm327` service and telem connects to it over TCP (`socket://elm327:35000`). Both
-live behind a `telem` compose profile, so the default `up` still starts only InfluxDB +
-Grafana.
+start as part of the default stack (step 1), so telem streams emulated OBD data with no
+extra flags.
 
-Run the "car in a box" stack:
-
-```bash
-docker compose -f local-testing/docker-compose.yml --profile telem up --build -d
-```
-
-telem writes emulated data to the `stats_252` bucket (seeded by the InfluxDB init
+telem writes emulated data to the `stats_252/autogen` bucket (seeded by the InfluxDB init
 scripts), so the **telegraf** dashboard and the OBD panels in **race-control** show live
-data. The `stats_252` bucket and its DBRP are created only on a **fresh** InfluxDB volume,
-so if you added them to an existing stack, recreate the volume:
+data. That bucket and its DBRP are created only on a **fresh** InfluxDB volume, so if you
+had a stack running before these were added, recreate the volume:
 
 ```bash
-docker compose -f local-testing/docker-compose.yml --profile telem down -v
-docker compose -f local-testing/docker-compose.yml --profile telem up --build -d
+docker compose -f local-testing/docker-compose.yml down -v
+docker compose -f local-testing/docker-compose.yml up --build -d
 ```
 
 (`pisugar-monitor` remains out of scope for local testing — it needs PiSugar UPS hardware.)

--- a/local-testing/.env
+++ b/local-testing/.env
@@ -1,0 +1,4 @@
+# Single source of truth for the emulator's TCP port. Compose auto-loads this
+# file (it sits next to docker-compose.yml), so no --env-file flag is needed.
+# Referenced by the elm327 command, its healthcheck, and telem's OBD_PORT URL.
+OBD_EMULATOR_PORT=35000

--- a/local-testing/docker-compose.yml
+++ b/local-testing/docker-compose.yml
@@ -37,6 +37,30 @@ services:
       - grafana-data:/var/lib/grafana
       - ./grafana/provisioning:/etc/grafana/provisioning:ro
 
+  elm327:
+    build:
+      context: elm327
+    profiles: ["telem"]
+    stdin_open: true   # emulator's cmd console exits on stdin EOF
+
+  telem:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    profiles: ["telem"]
+    command: ["lemongrass", "telem"]
+    environment:
+      OBD_PORT: socket://elm327:35000
+      OBD_BAUDRATE: "38400"
+      INFLUX_URL: http://influxdb:8086
+      INFLUX_ORG: lemongrass
+      INFLUX_TELEMETRY_TOKEN: local-dev-token
+    depends_on:
+      influxdb:
+        condition: service_healthy
+      elm327:
+        condition: service_started
+
 volumes:
   influxdb-data:
   grafana-data:

--- a/local-testing/docker-compose.yml
+++ b/local-testing/docker-compose.yml
@@ -40,14 +40,12 @@ services:
   elm327:
     build:
       context: elm327
-    profiles: ["telem"]
     stdin_open: true   # emulator's cmd console exits on stdin EOF
 
   telem:
     build:
       context: ..
       dockerfile: Dockerfile
-    profiles: ["telem"]
     command: ["lemongrass", "telem"]
     environment:
       OBD_PORT: socket://elm327:35000

--- a/local-testing/docker-compose.yml
+++ b/local-testing/docker-compose.yml
@@ -40,7 +40,18 @@ services:
   elm327:
     build:
       context: elm327
+    # Port comes from OBD_EMULATOR_PORT (.env); compose interpolates it into
+    # this exec-form command, overriding the image's default CMD.
+    command: ["python", "-m", "elm", "-s", "car", "-n", "${OBD_EMULATOR_PORT}"]
     stdin_open: true   # emulator's cmd console exits on stdin EOF
+    healthcheck:
+      # Healthy only once the emulator socket accepts connections, so telem
+      # doesn't race the listener. python is present in the uv base image.
+      test: ["CMD", "python", "-c", "import socket; socket.create_connection(('localhost', ${OBD_EMULATOR_PORT}), timeout=2).close()"]
+      interval: 3s
+      timeout: 3s
+      retries: 10
+      start_period: 2s
 
   telem:
     build:
@@ -48,7 +59,7 @@ services:
       dockerfile: Dockerfile
     command: ["lemongrass", "telem"]
     environment:
-      OBD_PORT: socket://elm327:35000
+      OBD_PORT: socket://elm327:${OBD_EMULATOR_PORT}
       OBD_BAUDRATE: "38400"
       INFLUX_URL: http://influxdb:8086
       INFLUX_ORG: lemongrass
@@ -57,7 +68,7 @@ services:
       influxdb:
         condition: service_healthy
       elm327:
-        condition: service_started
+        condition: service_healthy
 
 volumes:
   influxdb-data:

--- a/local-testing/elm327/Dockerfile
+++ b/local-testing/elm327/Dockerfile
@@ -1,0 +1,10 @@
+# Virtual ELM327 OBD-II adapter for the local test stack. Reuses the repo's
+# pinned uv base image. Two sequential installs guarantee setuptools<81 (which
+# still ships pkg_resources) is present before the sdist builds.
+FROM ghcr.io/astral-sh/uv:0.11.21-python3.14-trixie@sha256:05abd865132ddbe8b607b7063514f8debacbc98e60a01823a8abdacbdd61e0d7
+RUN uv pip install --system 'setuptools<81'
+RUN uv pip install --system --no-build-isolation 'ELM327-emulator==3.0.5'
+# `car` scenario = Toyota Auris Hybrid (realistic PID/DTC set). The emulator
+# runs a cmd console on the main thread and needs stdin held open (compose
+# sets stdin_open: true) or it prints "Terminating..." and exits.
+CMD ["python", "-m", "elm", "-s", "car", "-n", "35000"]

--- a/local-testing/elm327/Dockerfile
+++ b/local-testing/elm327/Dockerfile
@@ -4,7 +4,16 @@
 FROM ghcr.io/astral-sh/uv:0.11.21-python3.14-trixie@sha256:05abd865132ddbe8b607b7063514f8debacbc98e60a01823a8abdacbdd61e0d7
 RUN uv pip install --system 'setuptools<81'
 RUN uv pip install --system --no-build-isolation 'ELM327-emulator==3.0.5'
+# Log to stdout (visible via `docker logs`) instead of the stock rotating
+# elm.log, which a non-root, read-only-cwd container can't create.
+COPY logging.yaml /etc/elm327/logging.yaml
+ENV ELM_LOG_CFG=/etc/elm327/logging.yaml
+# Drop to a non-root user; port 35000 is unprivileged so no cap needed.
+RUN useradd --uid 10001 --no-create-home elm
+USER elm
 # `car` scenario = Toyota Auris Hybrid (realistic PID/DTC set). The emulator
 # runs a cmd console on the main thread and needs stdin held open (compose
 # sets stdin_open: true) or it prints "Terminating..." and exits.
+# Compose overrides this command to inject the TCP port from OBD_EMULATOR_PORT;
+# the -n here is only the default for a bare `docker run`.
 CMD ["python", "-m", "elm", "-s", "car", "-n", "35000"]

--- a/local-testing/elm327/logging.yaml
+++ b/local-testing/elm327/logging.yaml
@@ -1,0 +1,20 @@
+# Emulator logging config (pointed at by ELM_LOG_CFG). Console-only: the stock
+# config also writes a rotating elm.log, which a non-root container can't create.
+version: 1
+disable_existing_loggers: False
+
+formatters:
+  compact:
+    format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+
+handlers:
+  console:
+    class: logging.StreamHandler
+    level: INFO
+    formatter: compact
+    stream: ext://sys.stdout
+
+root:
+  level: INFO
+  handlers:
+    - console

--- a/local-testing/grafana/provisioning/datasources/influxdb.yml
+++ b/local-testing/grafana/provisioning/datasources/influxdb.yml
@@ -38,6 +38,33 @@ datasources:
     secureJsonData:
       httpHeaderValue1: Token local-dev-token
 
+  # OBD/telemetry InfluxQL datasources (v1 DBRP db=stats_252) — back the
+  # telegraf, car252-pisugar-ups, and race-control OBD panels. UIDs match the
+  # datasource UIDs baked into the dashboard JSON (copied from prod).
+  - name: stats_252
+    uid: ddpgw53c4nojkd
+    type: influxdb
+    access: proxy
+    url: http://influxdb:8086
+    isDefault: false
+    jsonData:
+      dbName: stats_252
+      httpHeaderName1: Authorization
+    secureJsonData:
+      httpHeaderValue1: Token local-dev-token
+
+  - name: stats_252_pisugar
+    uid: f3134d95-85f2-4173-9d6b-5ce95b10bbd0
+    type: influxdb
+    access: proxy
+    url: http://influxdb:8086
+    isDefault: false
+    jsonData:
+      dbName: stats_252
+      httpHeaderName1: Authorization
+    secureJsonData:
+      httpHeaderValue1: Token local-dev-token
+
   # Flux datasources — back the dashboard template variables.
   - name: laps_flux
     uid: wotl-laps-flux

--- a/local-testing/influx-init/10-create-buckets.sh
+++ b/local-testing/influx-init/10-create-buckets.sh
@@ -6,10 +6,20 @@ set -euo pipefail
 
 # During first-init the entrypoint runs influxd on INFLUXD_INIT_PORT (9999),
 # not 8086 — 8086 only binds after init completes.
-for bucket in races race_sessions stats_252; do
+for bucket in races race_sessions; do
   influx bucket create \
     --name "$bucket" \
     --org "$DOCKER_INFLUXDB_INIT_ORG" \
     --host "http://localhost:${INFLUXD_INIT_PORT:-9999}" \
     --token "$DOCKER_INFLUXDB_INIT_ADMIN_TOKEN"
 done
+
+# stats_252 telemetry migrated from InfluxDB v1, so its bucket is NAMED
+# `stats_252/autogen` (v1 db/rp). telem + pisugar_monitor write to that exact
+# name via the v2 API, which matches on bucket name and ignores DBRP mappings —
+# so a bare `stats_252` bucket would 404 those writes.
+influx bucket create \
+  --name 'stats_252/autogen' \
+  --org "$DOCKER_INFLUXDB_INIT_ORG" \
+  --host "http://localhost:${INFLUXD_INIT_PORT:-9999}" \
+  --token "$DOCKER_INFLUXDB_INIT_ADMIN_TOKEN"

--- a/local-testing/influx-init/10-create-buckets.sh
+++ b/local-testing/influx-init/10-create-buckets.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 # During first-init the entrypoint runs influxd on INFLUXD_INIT_PORT (9999),
 # not 8086 — 8086 only binds after init completes.
-for bucket in races race_sessions; do
+for bucket in races race_sessions stats_252; do
   influx bucket create \
     --name "$bucket" \
     --org "$DOCKER_INFLUXDB_INIT_ORG" \

--- a/local-testing/influx-init/20-create-dbrp.sh
+++ b/local-testing/influx-init/20-create-dbrp.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # not 8086 — 8086 only binds after init completes.
 HOST="http://localhost:${INFLUXD_INIT_PORT:-9999}"
 
-for db in laps races; do
+for db in laps races stats_252; do
   bucket_id=$(influx bucket list \
     --name "$db" \
     --org "$DOCKER_INFLUXDB_INIT_ORG" \

--- a/local-testing/influx-init/20-create-dbrp.sh
+++ b/local-testing/influx-init/20-create-dbrp.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 # Runs once, inside the influxdb container, after 10-create-buckets.sh on first
 # init (empty volume). Creates v1 DBRP mappings so the InfluxQL Grafana
-# datasources (wotl-laps-ql / wotl-races-ql) can query the 2.x buckets via the
-# v1 API. The race_sessions bucket is queried only via Flux, so it needs no DBRP.
+# datasources (wotl-laps-ql / wotl-races-ql / stats_252) can query the 2.x
+# buckets via the v1 API. The race_sessions bucket is queried only via Flux,
+# so it needs no DBRP.
 set -euo pipefail
 
 # During first-init the entrypoint runs influxd on INFLUXD_INIT_PORT (9999),
 # not 8086 — 8086 only binds after init completes.
 HOST="http://localhost:${INFLUXD_INIT_PORT:-9999}"
 
-for db in laps races stats_252; do
+for db in laps races; do
   bucket_id=$(influx bucket list \
     --name "$db" \
     --org "$DOCKER_INFLUXDB_INIT_ORG" \
@@ -26,3 +27,21 @@ for db in laps races stats_252; do
     --host "$HOST" \
     --token "$DOCKER_INFLUXDB_INIT_ADMIN_TOKEN"
 done
+
+# Map v1 db=stats_252 rp=autogen to the `stats_252/autogen` bucket so the
+# InfluxQL `stats_252` Grafana datasources can read the emulated telemetry.
+stats_bucket_id=$(influx bucket list \
+  --name 'stats_252/autogen' \
+  --org "$DOCKER_INFLUXDB_INIT_ORG" \
+  --host "$HOST" \
+  --token "$DOCKER_INFLUXDB_INIT_ADMIN_TOKEN" \
+  --hide-headers | awk '{print $1}')
+
+influx v1 dbrp create \
+  --db stats_252 \
+  --rp autogen \
+  --bucket-id "$stats_bucket_id" \
+  --default \
+  --org "$DOCKER_INFLUXDB_INIT_ORG" \
+  --host "$HOST" \
+  --token "$DOCKER_INFLUXDB_INIT_ADMIN_TOKEN"

--- a/local-testing/install-emulator.sh
+++ b/local-testing/install-emulator.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Install the ELM327 emulator into the active uv venv for integration tests.
+#
+# Kept OUT of pyproject/uv.lock on purpose: the sdist imports pkg_resources at
+# build time (setuptools>=81 removed it) and pulls POSIX-only python-daemon,
+# which would pollute the universal lock for a tool used in one CI job only.
+set -euo pipefail
+uv pip install 'setuptools<81'
+uv pip install --no-build-isolation 'ELM327-emulator==3.0.5'

--- a/local-testing/install-emulator.sh
+++ b/local-testing/install-emulator.sh
@@ -6,4 +6,8 @@
 # which would pollute the universal lock for a tool used in one CI job only.
 set -euo pipefail
 uv pip install 'setuptools<81'
-uv pip install --no-build-isolation 'ELM327-emulator==3.0.5'
+# The emulator's setup.py appends `-$GITHUB_RUN_NUMBER` to its own version when
+# that env var is present (always set in GitHub Actions), producing e.g.
+# `3.0.5.post244`, which fails uv's `==3.0.5` metadata check. Unset it for the
+# build so the version stays exactly 3.0.5. No-op outside GitHub Actions.
+env -u GITHUB_RUN_NUMBER uv pip install --no-build-isolation 'ELM327-emulator==3.0.5'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,3 +52,9 @@ select = ["E", "F", "W", "D1", "I", "B", "UP", "RUF", "N", "C4", "SIM"]
 
 [dependency-groups]
 dev = ["pytest>=8", "ruff>=0.14,<1.0"]
+
+[tool.pytest.ini_options]
+addopts = "-m 'not integration'"
+markers = [
+    "integration: real OBD path against the ELM327 emulator (emulator must be installed; excluded from the default run)",
+]

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -281,7 +281,10 @@ def connect():
     kwargs = {'portstr': os.environ.get('OBD_PORT', '/dev/obd')}
     baud = os.environ.get('OBD_BAUDRATE')
     if baud:
-        kwargs['baudrate'] = int(baud)
+        try:
+            kwargs['baudrate'] = int(baud)
+        except ValueError:
+            raise ValueError(f"OBD_BAUDRATE must be an integer, got {baud!r}") from None
     return obd.Async(**kwargs)
 
 

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -272,8 +272,17 @@ def connect():
 
     Defaults to the ``/dev/obd`` udev symlink (passed into the container via a
     device mapping). ``OBD_PORT`` overrides it for host-based testing.
+
+    ``OBD_BAUDRATE`` optionally pins the baud rate. Real USB adapters leave it
+    unset so python-obd auto-detects; the emulator's ``socket://`` transport
+    needs it set (e.g. 38400) because python-obd only skips auto-baud for
+    ``/dev/pts`` pseudo-terminals, not TCP sockets.
     """
-    return obd.Async(portstr=os.environ.get('OBD_PORT', '/dev/obd'))
+    kwargs = {'portstr': os.environ.get('OBD_PORT', '/dev/obd')}
+    baud = os.environ.get('OBD_BAUDRATE')
+    if baud:
+        kwargs['baudrate'] = int(baud)
+    return obd.Async(**kwargs)
 
 
 def _configure_obd_logging():

--- a/tests/test_telem.py
+++ b/tests/test_telem.py
@@ -25,15 +25,34 @@ def _reset():
 class TestConnect:
     def test_defaults_to_obd_symlink(self, monkeypatch):
         monkeypatch.delenv("OBD_PORT", raising=False)
+        monkeypatch.delenv("OBD_BAUDRATE", raising=False)
         with patch.object(_mod.obd, "Async") as mock_async:
             _mod.connect()
         mock_async.assert_called_once_with(portstr="/dev/obd")
 
     def test_uses_obd_port_env_override(self, monkeypatch):
         monkeypatch.setenv("OBD_PORT", "/dev/ttyUSB0")
+        monkeypatch.delenv("OBD_BAUDRATE", raising=False)
         with patch.object(_mod.obd, "Async") as mock_async:
             _mod.connect()
         mock_async.assert_called_once_with(portstr="/dev/ttyUSB0")
+
+    def test_passes_baudrate_when_set(self, monkeypatch):
+        monkeypatch.setenv("OBD_PORT", "socket://elm327:35000")
+        monkeypatch.setenv("OBD_BAUDRATE", "38400")
+        with patch.object(_mod.obd, "Async") as mock_async:
+            _mod.connect()
+        mock_async.assert_called_once_with(
+            portstr="socket://elm327:35000", baudrate=38400
+        )
+
+    def test_omits_baudrate_when_unset(self, monkeypatch):
+        monkeypatch.setenv("OBD_PORT", "/dev/obd")
+        monkeypatch.delenv("OBD_BAUDRATE", raising=False)
+        with patch.object(_mod.obd, "Async") as mock_async:
+            _mod.connect()
+        _, kwargs = mock_async.call_args
+        assert "baudrate" not in kwargs
 
 
 class TestNewValue:

--- a/tests/test_telem_integration.py
+++ b/tests/test_telem_integration.py
@@ -5,6 +5,8 @@ emulator installed via local-testing/install-emulator.sh. The emulator is
 spawned as a subprocess and never imported, so this module imports cleanly even
 when the emulator is absent (the tests are simply deselected by default).
 """
+import os
+import select
 import socket
 import subprocess
 import sys
@@ -27,17 +29,28 @@ def _free_port():
 
 
 def _wait_for_ready(proc, needle, timeout):
-    """Block until the emulator prints its 'listening' line, or fail loudly."""
+    """Block until the emulator prints its 'listening' line, or fail loudly.
+
+    Reads the raw stdout fd via ``select`` so the deadline is enforced *during*
+    the wait — a plain ``readline()`` blocks until a newline arrives and would
+    ignore the timeout if the emulator stalled mid-line.
+    """
     deadline = time.monotonic() + timeout
+    fd = proc.stdout.fileno()
     captured = []
+    buf = ""
     while time.monotonic() < deadline:
-        line = proc.stdout.readline()
-        if not line:
+        ready, _, _ = select.select([fd], [], [], deadline - time.monotonic())
+        if not ready:
+            continue
+        chunk = os.read(fd, 4096).decode(errors="replace")
+        if not chunk:  # EOF
             if proc.poll() is not None:
                 raise RuntimeError("emulator exited early:\n" + "".join(captured))
             continue
-        captured.append(line)
-        if needle in line:
+        captured.append(chunk)
+        buf += chunk
+        if needle in buf:
             return
     raise RuntimeError(f"emulator not ready in {timeout}s:\n" + "".join(captured))
 

--- a/tests/test_telem_integration.py
+++ b/tests/test_telem_integration.py
@@ -5,8 +5,6 @@ emulator installed via local-testing/install-emulator.sh. The emulator is
 spawned as a subprocess and never imported, so this module imports cleanly even
 when the emulator is absent (the tests are simply deselected by default).
 """
-import os
-import select
 import socket
 import subprocess
 import sys
@@ -28,31 +26,26 @@ def _free_port():
     return port
 
 
-def _wait_for_ready(proc, needle, timeout):
-    """Block until the emulator prints its 'listening' line, or fail loudly.
+def _wait_for_ready(proc, host, port, timeout):
+    """Block until the emulator's TCP port accepts a connection, or fail loudly.
 
-    Reads the raw stdout fd via ``select`` so the deadline is enforced *during*
-    the wait — a plain ``readline()`` blocks until a newline arrives and would
-    ignore the timeout if the emulator stalled mid-line.
+    Probes the socket directly rather than parsing stdout: this confirms the
+    listener is actually accepting connections (the emulator prints its banner
+    from the cmd thread *before* the listener thread is necessarily ready) and
+    doesn't couple the test to a version-specific emulator log string.
     """
     deadline = time.monotonic() + timeout
-    fd = proc.stdout.fileno()
-    captured = []
-    buf = ""
+    last_err = None
     while time.monotonic() < deadline:
-        ready, _, _ = select.select([fd], [], [], deadline - time.monotonic())
-        if not ready:
-            continue
-        chunk = os.read(fd, 4096).decode(errors="replace")
-        if not chunk:  # EOF
-            if proc.poll() is not None:
-                raise RuntimeError("emulator exited early:\n" + "".join(captured))
-            continue
-        captured.append(chunk)
-        buf += chunk
-        if needle in buf:
-            return
-    raise RuntimeError(f"emulator not ready in {timeout}s:\n" + "".join(captured))
+        if proc.poll() is not None:
+            raise RuntimeError("emulator exited early:\n" + (proc.stdout.read() or ""))
+        try:
+            with socket.create_connection((host, port), timeout=1):
+                return
+        except OSError as exc:
+            last_err = exc
+            time.sleep(0.1)
+    raise RuntimeError(f"emulator not ready in {timeout}s (last error: {last_err})")
 
 
 @pytest.fixture(scope="module")
@@ -75,7 +68,7 @@ def emulator():
         bufsize=1,
     )
     try:
-        _wait_for_ready(proc, "running on TCP network port", timeout=30)
+        _wait_for_ready(proc, "127.0.0.1", port, timeout=30)
         yield Emu(url=f"socket://127.0.0.1:{port}", obd=real_obd)
     finally:
         proc.terminate()

--- a/tests/test_telem_integration.py
+++ b/tests/test_telem_integration.py
@@ -1,0 +1,115 @@
+"""Integration tests driving telem's real OBD path against the ELM327 emulator.
+
+Marked `integration` (excluded from the default pytest run). Requires the
+emulator installed via local-testing/install-emulator.sh. The emulator is
+spawned as a subprocess and never imported, so this module imports cleanly even
+when the emulator is absent (the tests are simply deselected by default).
+"""
+import socket
+import subprocess
+import sys
+import time
+from collections import namedtuple
+
+import pytest
+
+import lemongrass.telem as telem
+
+Emu = namedtuple("Emu", "url obd")
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _wait_for_ready(proc, needle, timeout):
+    """Block until the emulator prints its 'listening' line, or fail loudly."""
+    deadline = time.monotonic() + timeout
+    captured = []
+    while time.monotonic() < deadline:
+        line = proc.stdout.readline()
+        if not line:
+            if proc.poll() is not None:
+                raise RuntimeError("emulator exited early:\n" + "".join(captured))
+            continue
+        captured.append(line)
+        if needle in line:
+            return
+    raise RuntimeError(f"emulator not ready in {timeout}s:\n" + "".join(captured))
+
+
+@pytest.fixture(scope="module")
+def emulator():
+    # conftest.py installs a MagicMock for `obd`; swap in the real library and
+    # rebind it onto telem for the duration of this module.
+    saved = sys.modules.pop("obd", None)
+    import obd as real_obd
+
+    orig_telem_obd = telem.obd
+    telem.obd = real_obd
+
+    port = _free_port()
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "elm", "-s", "car", "-n", str(port)],
+        stdin=subprocess.PIPE,          # keep stdin open — cmd console exits on EOF
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    try:
+        _wait_for_ready(proc, "running on TCP network port", timeout=30)
+        yield Emu(url=f"socket://127.0.0.1:{port}", obd=real_obd)
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        telem.obd = orig_telem_obd
+        if saved is not None:
+            sys.modules["obd"] = saved
+        else:
+            sys.modules.pop("obd", None)
+
+
+@pytest.fixture
+def connection(emulator, monkeypatch):
+    monkeypatch.setenv("OBD_PORT", emulator.url)
+    monkeypatch.setenv("OBD_BAUDRATE", "38400")
+    conn = telem.connect()
+    yield conn
+    conn.close()
+
+
+@pytest.mark.integration
+def test_connect_reports_car_connected(emulator, connection):
+    assert connection.status() == emulator.obd.OBDStatus.CAR_CONNECTED
+    assert connection.protocol_name()  # non-empty once a protocol is negotiated
+
+
+@pytest.mark.integration
+def test_supported_commands_include_core_pids(emulator, connection):
+    names = {c.name for c in connection.supported_commands}
+    assert {"RPM", "SPEED"} <= names
+
+
+@pytest.mark.integration
+def test_new_value_queues_point_from_real_rpm(emulator, connection):
+    telem.pending_points.clear()
+    r = emulator.obd.OBD.query(connection, emulator.obd.commands.RPM, force=True)
+    assert not r.is_null()
+    telem.new_value(r)
+    assert len(telem.pending_points) == 1
+
+
+@pytest.mark.integration
+def test_query_fuel_type_once_matches_support(emulator, connection):
+    telem.pending_points.clear()
+    telem._query_fuel_type_once(connection)
+    supported = connection.supports(emulator.obd.commands.FUEL_TYPE)
+    assert len(telem.pending_points) == (1 if supported else 0)


### PR DESCRIPTION
## Summary

Gives the `telem` OBD service a **hardware-free path**: a virtual ELM327 (Ircama's `ELM327-emulator`) that the real `telem` process connects to over TCP. Wired into the local Docker stack for a "car in a box" demo and into a dedicated CI job for real-path integration tests.

- **`telem.connect()`** gains an optional `OBD_BAUDRATE` override (inert when unset, so real `/dev/obd` hardware keeps python-obd auto-detection). The emulator's `socket://` transport needs it set.
- **`integration` pytest marker** — emulator-backed tests, deselected from the default (mock-only) run.
- **Emulator install script + integration tests** driving telem's real OBD path against a spawned emulator subprocess. The emulator is installed imperatively and kept **out of `uv.lock`** (POSIX-only deps + `pkg_resources` build needs).
- **`elm327` emulator Docker image** + **`elm327`/`telem` compose services** that come up with the default `local-testing` stack (`docker compose … up --build -d` now starts InfluxDB + Grafana + the emulated car). The emulator runs non-root and logs to stdout; `telem` is gated on an `elm327` socket healthcheck (`service_healthy`), and the emulator TCP port is single-sourced from `local-testing/.env` (`OBD_EMULATOR_PORT`).
- **Local InfluxDB seed** for the `stats_252/autogen` telemetry bucket + DBRP, and **Grafana InfluxQL datasources** so the OBD dashboards (telegraf, race-control OBD panels) render emulated data.
- **CI `integration` job** installing the emulator and running `-m integration`, with `persist-credentials: false` and `timeout-minutes: 15` on the job.
- **Docs** for the emulator stack and integration tests in `CONTRIBUTING.md`.

## Verification

- Unit suite: **524 passed**, 4 integration deselected; `ruff check .` clean.
- Integration tests: **4 passed** against a spawned emulator (`uv sync` → `install-emulator.sh` → `uv run --no-sync pytest -m integration tests/`).
- End-to-end on a fresh volume: a plain `up --build -d` starts all four services, telem streams to `stats_252/autogen` (no write failures), `SHOW MEASUREMENTS` on `db=stats_252` returns 35 measurements, and both provisioned Grafana datasource UIDs resolve.
- CI green: `integration` job, test matrix (3.10–3.14), syntax, lock check, and the multi-arch Docker image build all pass.

## Notable during implementation

Three issues surfaced while verifying the "car in a box" stack and are fixed here:

1. **`.dockerignore` broke `docker build .`** (`775f8cc`, pre-existing on `main`) — it excluded `README.md`/`LICENSE` that `Dockerfile:4` COPYs, so on BuildKit the build failed with `COPY … not found`. Re-included both (root-anchored). This also repairs a latent break in the **release image build**, not just local testing.
2. **`stats_252` write path** (`0b9542a`) — a DBRP does **not** make telem's InfluxDB **v2** write to `bucket='stats_252/autogen'` resolve against a bare `stats_252` bucket; a v2 write matches on the literal **bucket name** and ignores DBRPs. The local seed now creates a bucket **named** `stats_252/autogen` (matching prod's v1-migrated bucket and both `telem.py` + `pisugar_monitor.py` write targets). **No app source changed.**
3. **Emulator version pin under CI** (`0ed83bd`) — ELM327-emulator's `setup.py` appends `-$GITHUB_RUN_NUMBER` to its own version when that env var is set (always in GitHub Actions), producing `3.0.5.post<run>` and failing uv's `==3.0.5` metadata check. `install-emulator.sh` now builds with `env -u GITHUB_RUN_NUMBER` so the version stays exactly `3.0.5`.

## Follow-up (non-blocking)

- The workflow `on.pull_request.paths` trigger doesn't include `local-testing/**`, so a PR touching only emulator infra (Dockerfile/compose/install script) won't trigger either job. Worth adding `local-testing/**` (and the workflow file itself) in a later change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for local OBD/telemetry emulation, making it easier to run the full telemetry flow on a developer machine.
  * Added a separate integration test run in CI for real-device-path coverage.

* **Bug Fixes**
  * Improved telemetry connection handling so port and baud rate settings are read more reliably from the environment.
  * Prevented Docker builds from failing when required project files are excluded.

* **Documentation**
  * Expanded local testing and contribution guidance for emulated telemetry and dashboard behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
