### PR TITLE
chore(docker): run lemongrass container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,14 @@ FROM python:3.14-slim-trixie@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d
 WORKDIR /app
 COPY --from=builder /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
+# Drop to a non-root user. The venv stays root-owned (execute-only for this
+# user), so the app can't modify itself. /data is the one writable dir: the
+# legacy `lemongrass laps -o` CSV lands there — mount a writable dir at /data
+# to persist it. All other commands are network-only and write nothing.
+RUN useradd --uid 10001 --no-create-home lemongrass \
+    && mkdir /data \
+    && chown lemongrass:lemongrass /data
+WORKDIR /data
+USER lemongrass
 # No ENTRYPOINT/CMD — the runtime command is supplied by docker-compose (external repo).
 # Use `lemongrass <command>` — e.g. `lemongrass laps`, `lemongrass telem`, `lemongrass race-backfill`.

--- a/README.md
+++ b/README.md
@@ -183,10 +183,14 @@ lemongrass laps RACE_ID              # full field
 > **Persisting CSV output:** `lemongrass laps -o` writes a `.csv` to the container's
 > working directory (`/data`). The container runs as a non-root user, so that write
 > stays inside the container and is lost on exit unless you mount a writable directory
-> at `/data`:
+> at `/data`. Bind mounts keep their host ownership, so pass `--user` to run as your
+> host user — the CSV then lands in `./out` owned by you:
 >
 > ```shell
-> docker run --rm -it --env-file .env -v "$(pwd)/out:/data" \
+> mkdir -p out
+> docker run --rm -it --env-file .env \
+>   --user "$(id -u):$(id -g)" \
+>   -v "$(pwd)/out:/data" \
 >   ghcr.io/wot-lemons/lemongrass:latest \
 >   lemongrass laps RACE_ID CAR_NUMBER -o
 > ```

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ lemongrass races <subcommand> [args]
 ```
 
 | Subcommand | Description |
-|------------|-------------|
+| ------------ | ------------- |
 | `list` | Show all stored races with lap counts and schema status |
 | `prune RACE_ID...` | Delete all data for one or more races from InfluxDB |
 | `backfill` | Run historical backfill for all tracked races (delegates to `lemongrass race-backfill`; use `--help` for all options) |
@@ -317,7 +317,7 @@ lemongrass races diagnose 144185 252
 The `backfill` subcommand delegates to `lemongrass race-backfill` and supports these flags:
 
 | Flag | Description |
-|------|-------------|
+| ------ | ------------- |
 | `--dry-run` | Print what would be backfilled without writing anything |
 | `--force` | Re-backfill every race, even those already complete and current |
 | `--upgrade-stored` | Re-process laps already in InfluxDB whose `schema_version` is older than current — faster than `--force` because it skips re-fetching from RaceMonitor |
@@ -342,7 +342,7 @@ InfluxDB stack instead of prod, see [CONTRIBUTING.md](CONTRIBUTING.md).
 As of v2.0.0, the individual entry points (`laps`, `telem`, `race-backfill`, `pisugar-monitor`, `race-diagnose`) were replaced by a single `lemongrass` command. If you have the old package installed, update and prefix commands with `lemongrass`:
 
 | Before | After |
-|--------|-------|
+| -------- | ------- |
 | `laps RACE_ID CAR_NUMBER` | `lemongrass laps RACE_ID CAR_NUMBER` |
 | `telem` | `lemongrass telem` |
 | `race-backfill` | `lemongrass race-backfill` or `lemongrass races backfill` |

--- a/README.md
+++ b/README.md
@@ -180,6 +180,17 @@ lemongrass laps RACE_ID CAR_NUMBER   # single car
 lemongrass laps RACE_ID              # full field
 ```
 
+> **Persisting CSV output:** `lemongrass laps -o` writes a `.csv` to the container's
+> working directory (`/data`). The container runs as a non-root user, so that write
+> stays inside the container and is lost on exit unless you mount a writable directory
+> at `/data`:
+>
+> ```shell
+> docker run --rm -it --env-file .env -v "$(pwd)/out:/data" \
+>   ghcr.io/wot-lemons/lemongrass:latest \
+>   lemongrass laps RACE_ID CAR_NUMBER -o
+> ```
+
 Real example:
 
 ```shell


### PR DESCRIPTION
## What

Runs the main `lemongrass` application image (root `Dockerfile`) as a dedicated non-root user `lemongrass` (uid `10001`), mirroring the hardening already applied to the elm327 emulator container in #171.

## Why

The workload is network-bound and needs no privileged capabilities, yet the image still ran as root. This drops it to a fixed high-UID non-root user — `10001` matches the elm327 `elm` user convention and avoids colliding with a host user under bind mounts.

## Changes

Confined to the runtime (second) stage of `Dockerfile`; the `builder` stage is untouched:

- Add `lemongrass` user: `useradd --uid 10001 --no-create-home lemongrass`.
- Keep the venv/`/app` root-owned (execute-only to the runtime user), so the app can't modify itself.
- Add a dedicated writable `/data` dir (`chown` to the user) and set `WORKDIR /data` — the mount point for the legacy `laps -o` CSV output. Ephemeral by default; persists only if a writable dir is bind-mounted there.
- `USER lemongrass` before the end.

No application code changes; `local-testing/docker-compose.yml` unchanged. Read-only-root-filesystem hardening is deliberately left to the runtime compose (external repo).

## Docs

- README: document that `laps -o` CSV output lands in `/data` and needs a bind mount to persist. Because bind mounts keep host ownership (and ignore the image's `chown` of `/data` to uid 10001), the example runs as the host user via `--user "$(id -u):$(id -g)"` so `./out` is writable — otherwise it would `PermissionError` on native Linux.
- README: pad table delimiter rows to satisfy markdownlint MD060.

## Verification

- `docker build` succeeds; `docker run ... id` → `uid=10001(lemongrass)`.
- `lemongrass --help` runs on PATH; cwd `/data` is writable; `/app` is read-only (permission denied) to the user.
- Full local stack (`docker compose -f local-testing/docker-compose.yml up`) comes up healthy — `telem` polls the emulator and flushes to InfluxDB with no permission errors.
- `uv run pytest`: 524 passed, 4 deselected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)