### PR TITLE
ci(release-please): add Miscellaneous and Dependencies changelog sections

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,20 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "python",
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "perf", "section": "Performance Improvements" },
+    { "type": "revert", "section": "Reverts" },
+    { "type": "deps", "section": "Dependencies" },
+    { "type": "chore", "section": "Miscellaneous" },
+    { "type": "refactor", "section": "Miscellaneous" },
+    { "type": "ci", "section": "Miscellaneous" },
+    { "type": "build", "section": "Miscellaneous" },
+    { "type": "docs", "section": "Documentation", "hidden": true },
+    { "type": "style", "section": "Styles", "hidden": true },
+    { "type": "test", "section": "Tests", "hidden": true }
+  ],
   "packages": {
     ".": {}
   }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,10 +10,7 @@
     { "type": "chore", "section": "Miscellaneous" },
     { "type": "refactor", "section": "Miscellaneous" },
     { "type": "ci", "section": "Miscellaneous" },
-    { "type": "build", "section": "Miscellaneous" },
-    { "type": "docs", "section": "Documentation", "hidden": true },
-    { "type": "style", "section": "Styles", "hidden": true },
-    { "type": "test", "section": "Tests", "hidden": true }
+    { "type": "build", "section": "Miscellaneous" }
   ],
   "packages": {
     ".": {}

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,8 @@
     ":semanticCommits",
     "docker:pinDigests"
   ],
+  "semanticCommitType": "deps",
+  "semanticCommitScope": null,
   "minimumReleaseAge": "7 days",
   "pep621": {
     "enabled": true


### PR DESCRIPTION
## What

Configure release-please to surface previously-hidden operational changes and to group dependency updates in their own section.

- **`release-please-config.json`** — add `changelog-sections`:
  - `chore`, `refactor`, `ci`, `build` → **Miscellaneous** (previously hidden by default, so changes like the non-root container hardening never appeared in release notes).
  - `deps` → **Dependencies**.
  - `feat` / `fix` / `perf` / `revert` keep their standard sections.
  - Everything else (`docs`, `style`, `test`, …) stays hidden — unlisted types are hidden by default, so no explicit entries are needed.
- **`renovate.json`** — set `semanticCommitType: "deps"` and `semanticCommitScope: null` so renovate emits `deps: update ...` instead of `chore(deps): ...`, routing dependency bumps to **Dependencies** rather than **Miscellaneous**.

## Why

`chore`-typed commits (e.g. `chore(docker): run lemongrass container as non-root user`, #174) were hidden from the changelog under release-please's defaults. This makes real operational changes visible while keeping renovate's dependency churn in its own section.

## Note on the pending 3.1.0 release

The 4 `chore(deps)` commits already merged since v3.0.2 predate the renovate change, so they are type `chore` and will appear under **Miscellaneous** in 3.1.0 this one time. Future dependency bumps (typed `deps`) route to **Dependencies**. Once merged, release-please recomputes the 3.1.0 notes and also pulls in the `chore(docker)` non-root change automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)