### PR TITLE
test: use real pandas instead of mocking it

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ from unittest.mock import MagicMock
 
 for _mod in [
     'obd',
-    'pandas',
     'race_monitor',
 ]:
     sys.modules.setdefault(_mod, MagicMock())

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -2824,7 +2824,7 @@ class TestPrintRankingsNonNumericPosition:
 
 
 class TestPrintRankingsSortOrder:
-    """Behavioral tests using real pandas (conftest mocks pandas; patch it back)."""
+    """Behavioral tests exercising the real pandas table-building path."""
 
     def _competitor(self, position='1', number='42', name='Jane', category='1', laps='5'):
         return {
@@ -2836,20 +2836,11 @@ class TestPrintRankingsSortOrder:
         return {'1': {'ID': '1', 'Name': 'Gold'}}
 
     def test_numeric_position_sorts_before_non_numeric(self, capsys):
-        import sys
-        # conftest mocks pandas in sys.modules; pop it to import the real one
-        pandas_mock = sys.modules.pop('pandas', None)
-        try:
-            import pandas as real_pandas
-        finally:
-            if pandas_mock is not None:
-                sys.modules['pandas'] = pandas_mock
         competitors = [
             self._competitor(position='6$G', number='99'),
             self._competitor(position='1', number='42'),
         ]
-        with patch.object(_mod, 'pandas', real_pandas):
-            _mod.print_rankings(competitors, False, None, self._categories())
+        _mod.print_rankings(competitors, False, None, self._categories())
         out = capsys.readouterr().out
         assert out.index('42') < out.index('99')
 


### PR DESCRIPTION
## Why

`tests/conftest.py` blanket-mocks `obd`, `race_monitor`, **and** `pandas` with `MagicMock`. Mocking `obd` (serial/OBD hardware) and `race_monitor` (network) is defensible, but **pandas is pure, deterministic, I/O-free computation** — mocking it only hid the real DataFrame logic from every `print_rankings` / `json_normalize` test. It also forced `TestPrintRankingsSortOrder` into a fragile pop-and-restore-from-`sys.modules` dance just to test sort order against real pandas.

## What

- Drop `pandas` from the conftest mock list — use real pandas everywhere.
- Simplify `TestPrintRankingsSortOrder` to call `print_rankings` directly (no more mock juggling).

## Effect

- Display-table tests now exercise the real pandas code path (genuine coverage instead of rubber-stamping a mock).
- Removes brittle `sys.modules` manipulation.
- **Unblocks pandas 3.0.** The old dance left a `MagicMock` in `sys.modules['pandas']`; pandas 3.0 consults `sys.modules['pandas']` while building a `DataFrame` from a list of dicts, producing an empty-column frame and a `KeyError: 'Pos.'`. With real pandas resident throughout, the full suite passes on both **2.3.3** and **3.0.3** (`524 passed`).

Groundwork for the eventual pandas 3.0 bump (Renovate #176); no production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)