### PR TITLE
test: de-mock obd and race_monitor to un-mask hidden issues

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,26 +1,4 @@
-import sys
-from unittest.mock import MagicMock
-
-for _mod in [
-    'obd',
-    'race_monitor',
-]:
-    sys.modules.setdefault(_mod, MagicMock())
-
-# The real get_streaming_command is needed for _describe_bad_value tests, and the
-# real exception classes are needed so cli.py can `except RaceMonitorError` (a
-# MagicMock attribute is not a valid exception type). Temporarily remove the mock,
-# import the real module, copy the needed symbols onto the mock, restore.
-_race_monitor_mock = sys.modules.pop('race_monitor')
-try:
-    import race_monitor as _real_race_monitor
-
-    _race_monitor_mock.get_streaming_command = _real_race_monitor.get_streaming_command
-    _race_monitor_mock.RaceMonitorError = _real_race_monitor.RaceMonitorError
-    _race_monitor_mock.RaceMonitorHTTPError = _real_race_monitor.RaceMonitorHTTPError
-    del _real_race_monitor
-except ImportError:
-    sys.modules['race_monitor'] = _race_monitor_mock
-    raise
-finally:
-    sys.modules['race_monitor'] = _race_monitor_mock
+# obd and race_monitor are real, installed dependencies that import with no
+# hardware or network side effects (only OBD/Async construction and
+# RaceMonitorClient calls touch the outside world). Tests mock those I/O seams
+# individually, so no suite-wide module mock is needed here.

--- a/tests/test_telem.py
+++ b/tests/test_telem.py
@@ -1,6 +1,4 @@
-import importlib
 import logging
-import sys
 from unittest.mock import MagicMock, patch
 
 import lemongrass.telem as _mod
@@ -549,17 +547,10 @@ class TestRouteCommand:
     def test_no_real_dtc_command_is_watched(self):
         # Guard against the real library inventory, not just names we expect:
         # no mode-2 freeze-frame twin and no mode-03/07 DTC command may route
-        # to a callback. conftest mocks obd suite-wide, so temporarily import
-        # the real module (same pop/restore idiom conftest uses for race_monitor).
-        mock_obd = sys.modules.pop("obd")
-        try:
-            real_obd = importlib.import_module("obd")
-        finally:
-            sys.modules["obd"] = mock_obd
-
+        # to a callback.
         dtc_commands = {"GET_DTC", "GET_CURRENT_DTC", "CLEAR_DTC", "FREEZE_DTC"}
         checked = 0
-        for mode in real_obd.commands.modes:
+        for mode in _mod.obd.commands.modes:
             for command in mode:
                 if command is None:
                     continue

--- a/tests/test_telem.py
+++ b/tests/test_telem.py
@@ -167,15 +167,15 @@ class TestNewFuelStatus:
 class TestConfigureObdLogging:
     def test_no_debug_by_default(self, monkeypatch):
         monkeypatch.delenv("OBD_DEBUG", raising=False)
-        _mod.obd.logger.setLevel.reset_mock()
-        _mod._configure_obd_logging()
-        _mod.obd.logger.setLevel.assert_not_called()
+        with patch.object(_mod.obd.logger, "setLevel") as mock_set_level:
+            _mod._configure_obd_logging()
+        mock_set_level.assert_not_called()
 
     def test_debug_enabled_via_env(self, monkeypatch):
         monkeypatch.setenv("OBD_DEBUG", "1")
-        _mod.obd.logger.setLevel.reset_mock()
-        _mod._configure_obd_logging()
-        _mod.obd.logger.setLevel.assert_called_once_with(_mod.obd.logging.DEBUG)
+        with patch.object(_mod.obd.logger, "setLevel") as mock_set_level:
+            _mod._configure_obd_logging()
+        mock_set_level.assert_called_once_with(logging.DEBUG)
 
 
 class TestNewAirStatus:

--- a/tests/test_telem_integration.py
+++ b/tests/test_telem_integration.py
@@ -52,8 +52,6 @@ def _wait_for_ready(proc, host, port, timeout):
 def emulator():
     # obd is the real library by default now, so no module swap is needed here;
     # telem.obd already points at it.
-    import obd as real_obd
-
     port = _free_port()
     proc = subprocess.Popen(
         [sys.executable, "-m", "elm", "-s", "car", "-n", str(port)],
@@ -65,7 +63,7 @@ def emulator():
     )
     try:
         _wait_for_ready(proc, "127.0.0.1", port, timeout=30)
-        yield Emu(url=f"socket://127.0.0.1:{port}", obd=real_obd)
+        yield Emu(url=f"socket://127.0.0.1:{port}", obd=telem.obd)
     finally:
         proc.terminate()
         try:

--- a/tests/test_telem_integration.py
+++ b/tests/test_telem_integration.py
@@ -50,13 +50,9 @@ def _wait_for_ready(proc, host, port, timeout):
 
 @pytest.fixture(scope="module")
 def emulator():
-    # conftest.py installs a MagicMock for `obd`; swap in the real library and
-    # rebind it onto telem for the duration of this module.
-    saved = sys.modules.pop("obd", None)
+    # obd is the real library by default now, so no module swap is needed here;
+    # telem.obd already points at it.
     import obd as real_obd
-
-    orig_telem_obd = telem.obd
-    telem.obd = real_obd
 
     port = _free_port()
     proc = subprocess.Popen(
@@ -76,11 +72,6 @@ def emulator():
             proc.wait(timeout=5)
         except subprocess.TimeoutExpired:
             proc.kill()
-        telem.obd = orig_telem_obd
-        if saved is not None:
-            sys.modules["obd"] = saved
-        else:
-            sys.modules.pop("obd", None)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Why

Follow-up to #177 (real pandas instead of a mock). That PR called out that `obd`
and `race_monitor` — unlike pandas — "touch hardware and the network," but both
are actually real, installed dependencies that import in ~0.13s with **zero**
hardware/network side effects. The outside world is only touched on
`obd.OBD`/`obd.Async` construction and on `RaceMonitorClient` calls. The
suite-wide `MagicMock()` in `conftest.py` therefore masked more than it needed to:

- `obd.commands.FUEL_TYPE`/`GET_DTC` were themselves mocks, so
  `assert_called_once_with(conn, _mod.obd.commands.FUEL_TYPE, force=True)`
  compared a mock to the same mock — a typo'd/renamed command would still pass.
- `TestConfigureObdLogging` asserted `setLevel.assert_called_once_with(obd.logging.DEBUG)`
  with both sides MagicMock attributes (circular).
- `race_monitor` exceptions were hand-copied onto the mock so `cli.py`'s
  `except RaceMonitorError` had a real class to catch.

It also forced **three** fragile pop-mock / import-real / restore dances
(`conftest.py`, `test_no_real_dtc_command_is_watched`, the integration
`emulator` fixture).

## What

Drop `obd` and `race_monitor` from the conftest mock list, let the real
libraries load, and mock only their true I/O seams (`obd.OBD`/`obd.Async`,
`RaceMonitorClient` instances — the latter already mocked per-test in
laps/races/cli). The de-mocked assertions now compare real command objects and a
real exception hierarchy, and all three dances are gone.

- `conftest.py`: remove the mock block + race_monitor symbol-copy dance.
- `test_telem.py`: rewrite `TestConfigureObdLogging` to patch the real
  `obd.logger.setLevel`; drop the dance in `test_no_real_dtc_command_is_watched`
  (iterate real `obd.commands.modes`); remove now-unused `sys`/`importlib`.
- `test_telem_integration.py`: drop the obd module swap in the `emulator`
  fixture; it uses `telem.obd` directly (the real library) instead.

No production/`src` changes.

## Verification

- `uv run pytest` → 524 passed, 4 deselected
- `uv run pytest tests/test_telem_integration.py -m integration` → 4 passed
- `uv run ruff check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified test setup to rely on the real installed libraries directly.
  * Improved coverage around OBD command handling and logging behavior checks.
  * Streamlined integration test cleanup and fixture behavior.

* **Chores**
  * Removed broad module-level mocking from the test configuration in favor of targeted test isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->