### PR TITLE
chore(renovate): relax stability gate for uv base image

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,14 @@
   "semanticCommitType": "deps",
   "semanticCommitScope": null,
   "minimumReleaseAge": "7 days",
+  "packageRules": [
+    {
+      "description": "astral-sh/uv releases faster than the 7-day stability gate, so the newest tag is always <7 days old and the base-image FROM update never matures out of 'pending' — freezing us several releases behind. Relax the soak for this one trusted, digest-pinned first-party image only; the 7-day default still protects every other dependency.",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["ghcr.io/astral-sh/uv"],
+      "minimumReleaseAge": "1 day"
+    }
+  ],
   "pep621": {
     "enabled": true
   }


### PR DESCRIPTION
## Why

The `ghcr.io/astral-sh/uv` base image in `Dockerfile:1` and `local-testing/elm327/Dockerfile:4` has been frozen at `0.11.21` while newer releases (currently `0.11.26`) pile up. Renovate *does* detect the update — it's listed on Dependency Dashboard #86 — but it's stuck under **"Pending Status Checks."**

`minimumReleaseAge: "7 days"` gates on the age of the *target* version, and Renovate always targets the newest in-range release. `astral-sh/uv` ships ~every 2.8 days, so the newest tag is *always* younger than 7 days → the update never matures into a PR. Net effect is we sit several releases behind, which is worse for security than the soak protects against.

## What

Add a `packageRule` scoped to **only** the `ghcr.io/astral-sh/uv` docker image (`matchDatasources: ["docker"]` + `matchPackageNames`), dropping its stability window to `1 day` (below uv's release cadence so it can actually mature).

The 7-day default still guards every other dependency — PyPI deps, GitHub Actions, the `python:3.14-slim-trixie` base image, and any future image — so the supply-chain soak stays intact where the long-tail risk actually lives. `docker:pinDigests` continues to pin each update to an immutable `sha256`.

## Not in scope

The `astral-sh/uv` version pinned in `.github/workflows/*.yml` is a different datasource (github-tags) and isn't as starved; left untouched until it's actually a problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)