### PR TITLE
chore: only changes to the published artifact cut releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,11 +6,7 @@
     { "type": "fix", "section": "Bug Fixes" },
     { "type": "perf", "section": "Performance Improvements" },
     { "type": "revert", "section": "Reverts" },
-    { "type": "deps", "section": "Dependencies" },
-    { "type": "chore", "section": "Miscellaneous" },
-    { "type": "refactor", "section": "Miscellaneous" },
-    { "type": "ci", "section": "Miscellaneous" },
-    { "type": "build", "section": "Miscellaneous" }
+    { "type": "deps", "section": "Dependencies" }
   ],
   "packages": {
     ".": {}

--- a/renovate.json
+++ b/renovate.json
@@ -5,10 +5,22 @@
     ":semanticCommits",
     "docker:pinDigests"
   ],
-  "semanticCommitType": "deps",
+  "semanticCommitType": "chore",
   "semanticCommitScope": null,
   "minimumReleaseAge": "7 days",
   "packageRules": [
+    {
+      "description": "Runtime dependencies ship in the published wheel, so their bumps should cut a release. Everything else Renovate touches (dev groups, GitHub Actions, the uv build stage) defaults to a non-releasable 'chore'.",
+      "matchManagers": ["pep621"],
+      "matchDepTypes": ["project.dependencies"],
+      "semanticCommitType": "deps"
+    },
+    {
+      "description": "The runtime base image ships in the published container, which is built only on release tags — so a base-image bump must cut a release to reach the published image. The uv builder stage is build-only and stays a non-releasable 'chore'.",
+      "matchManagers": ["dockerfile"],
+      "matchPackageNames": ["python"],
+      "semanticCommitType": "deps"
+    },
     {
       "description": "astral-sh/uv releases faster than the 7-day stability gate, so the newest tag is always <7 days old and the base-image FROM update never matures out of 'pending' — freezing us several releases behind. Relax the soak for this one trusted, digest-pinned first-party image only; the 7-day default still protects every other dependency.",
       "matchDatasources": ["docker"],


### PR DESCRIPTION
Goal: a release should only be cut for changes that actually reach a **published artifact** (the PyPI wheel and the release-tagged container). Two sources were cutting spurious releases for infra-only changes.

## 1. release-please: drop infra commit types

`ci`, `chore`, `refactor`, and `build` were listed as visible `changelog-sections`, which makes release-please treat them as releasable — so a CI-only commit opened a patch release PR (#186 for #185). Removed them, reverting to release-please's Python defaults where those types are hidden and non-releasable. `feat`/`fix`/`perf`/`revert`/`deps` still cut releases.

## 2. renovate: differentiate dependency bumps

Renovate already emits `deps:` (set in #175), and **`deps` stays releasable** — but not every dependency reaches a published artifact. Now the default Renovate type is a non-releasable `chore:`, and only these are elevated to `deps:`:

- **runtime `project.dependencies`** — ship in the published wheel
- **the runtime container base image (`python`)** — ships in the container, which is built **only on release tags**, so a base-image CVE patch must cut a release to reach the published image

Dev-group deps, GitHub Actions, and the **uv build stage** (build-only) stay `chore:` and no longer open release PRs.

Companion: WOT-Lemons/race-monitor-py#49 (same, minus the Docker rule — no container there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)