### PR TITLE
feat(laps): answer backfill --skip-if-complete from Influx without RaceMonitor fetches

### DIFF
--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -198,6 +198,18 @@ def main():
         dry_run=args.dry_run,
     )
 
+    # Fast path: for the historical backfill (--skip-if-complete), decide whether
+    # to skip entirely from Influx before making any RaceMonitor call. Gated on
+    # skip_if_complete (set only by race-backfill), so interactive and monitor
+    # runs never enter here; stored_end_in_past keeps any possibly-live race on
+    # the normal is_live path.
+    if opts.network_mode and opts.skip_if_complete and not opts.dry_run \
+            and _influx_only_skip(race_id):
+        logging.info(
+            "SKIP: race %s already complete and current "
+            "(from Influx, no RaceMonitor fetch)", race_id)
+        return 0
+
     try:
         with RaceMonitorClient(api_token=tokens) as client:
             race_details = client.race.details(race_id)
@@ -1162,6 +1174,23 @@ def race_complete_in_influx(ctx, stored):
         return False
     std_total, std_current = existing_standings_counts_fieldwide(ctx)
     return std_total > 0 and std_current == std_total
+
+
+def _influx_only_skip(race_id):
+    """True when race_id is complete, current, and ended per Influx alone.
+
+    Opens a short-lived read-only Influx connection and answers the backfill skip
+    decision without any RaceMonitor call. Any race that is not definitively
+    ended (see stored_end_in_past) returns False so it falls through to the normal
+    flow's is_live check.
+    """
+    with _influx.connect() as influx_client:
+        ctx = RaceContext(race_id, None, None, None, 0,
+                          query_api=influx_client.query_api())
+        stored = stored_race_completeness(ctx)
+        return (stored is not None
+                and stored_end_in_past(stored)
+                and race_complete_in_influx(ctx, stored))
 
 
 def _build_class_index(session_details):

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -1133,6 +1133,16 @@ def stored_race_completeness(ctx):
     return None
 
 
+def stored_end_in_past(stored):
+    """True only when the race's stored end time is known (nonzero) and in the past.
+
+    The live-race guard for the Influx-only skip: any race whose stored end is 0
+    (unknown) or in the future is treated as possibly-live and must fall through
+    to the real is_live check rather than being skipped from Influx alone.
+    """
+    return bool(stored.end_time_epoc) and stored.end_time_epoc < time.time()
+
+
 def _build_class_index(session_details):
     """Precompute per-session class-position data shared by every competitor.
 

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -66,12 +66,14 @@ _SETTLED_BUFFER_S = 4 * 86400  # 4 days
 class StoredRace:
     """Race-completeness fields read back from a stored race point.
 
-    schema_version and expected_lap_count are None when the point predates the
-    fields they name — callers must guard against None before comparing them.
+    Any field is None when absent from the point (schema_version and
+    expected_lap_count predate the fields they name; end_time_epoc is missing
+    only from a malformed point) — callers must guard against None before
+    comparing them.
     """
     schema_version: int | None
     expected_lap_count: int | None
-    end_time_epoc: int
+    end_time_epoc: int | None
 
 
 def _describe_bad_value(value: object, field: str) -> str:

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -19,7 +19,7 @@ import os
 import sys
 import threading
 import time
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
@@ -53,6 +53,8 @@ SCHEMA_VERSION = 4
 
 _WRITE_BATCH_SIZE = 5000
 _LIVE_CHECK_INTERVAL = 5
+
+StoredRace = namedtuple('StoredRace', ['schema_version', 'expected_lap_count', 'end_time_epoc'])
 
 
 def _describe_bad_value(value: object, field: str) -> str:
@@ -1103,6 +1105,32 @@ def existing_standings_counts_fieldwide(ctx):
     total = _count('r._field == "position"')
     current = _count(f'r._field == "schema_version" and r._value == {SCHEMA_VERSION}')
     return total, current
+
+
+def stored_race_completeness(ctx):
+    """Read the stored race metadata point for ctx.race_id from the races bucket.
+
+    Returns a StoredRace, or None when no race point exists. schema_version and
+    expected_lap_count are None when the point predates the fields they name —
+    callers must guard against None before comparing them numerically.
+    """
+    tables = ctx.query_api.query(
+        f'from(bucket: "{_influx.BUCKET_RACES}")\n'
+        f'  |> range(start: {EPOCH_START})\n'
+        f'  |> filter(fn: (r) => r._measurement == "race"\n'
+        f'      and r.race_id == "{ctx.race_id}")\n'
+        f'  |> last()\n'
+        f'  |> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")'
+    )
+    for table in tables:
+        for record in table.records:
+            vals = record.values
+            return StoredRace(
+                schema_version=vals.get('schema_version'),
+                expected_lap_count=vals.get('expected_lap_count'),
+                end_time_epoc=vals.get('end_time_epoc'),
+            )
+    return None
 
 
 def _build_class_index(session_details):

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -19,7 +19,7 @@ import os
 import sys
 import threading
 import time
-from collections import defaultdict, namedtuple
+from collections import defaultdict
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
@@ -54,7 +54,24 @@ SCHEMA_VERSION = 4
 _WRITE_BATCH_SIZE = 5000
 _LIVE_CHECK_INTERVAL = 5
 
-StoredRace = namedtuple('StoredRace', ['schema_version', 'expected_lap_count', 'end_time_epoc'])
+# How far in the past a race's stored end time must be before the Influx-only skip
+# will trust it as fully over. Sessions can share one race_id across a multi-day
+# event, so a stored end that is only recently past may still have a later session
+# going live; only skip once the whole event is settled well behind us. Anything
+# more recent falls through to the authoritative is_live RaceMonitor check.
+_SETTLED_BUFFER_S = 4 * 86400  # 4 days
+
+
+@dataclass(frozen=True)
+class StoredRace:
+    """Race-completeness fields read back from a stored race point.
+
+    schema_version and expected_lap_count are None when the point predates the
+    fields they name — callers must guard against None before comparing them.
+    """
+    schema_version: int | None
+    expected_lap_count: int | None
+    end_time_epoc: int
 
 
 def _describe_bad_value(value: object, field: str) -> str:
@@ -201,8 +218,11 @@ def main():
     # Fast path: for the historical backfill (--skip-if-complete), decide whether
     # to skip entirely from Influx before making any RaceMonitor call. Gated on
     # skip_if_complete (set only by race-backfill), so interactive and monitor
-    # runs never enter here; stored_end_in_past keeps any possibly-live race on
-    # the normal is_live path.
+    # runs never enter here; stored_end_settled keeps any possibly-live race on
+    # the normal is_live path. To force a re-backfill past this skip (e.g. a race
+    # whose lap count was revised after it was stored), use
+    # `race-backfill --upgrade-stored [--force]`, which re-runs laps without
+    # --skip-if-complete and so never enters this branch.
     if opts.network_mode and opts.skip_if_complete and not opts.dry_run \
             and _influx_only_skip(race_id):
         logging.info(
@@ -1145,14 +1165,17 @@ def stored_race_completeness(ctx):
     return None
 
 
-def stored_end_in_past(stored):
-    """True only when the race's stored end time is known (nonzero) and in the past.
+def stored_end_settled(stored):
+    """True only when the race's stored end time is known and settled in the past.
 
-    The live-race guard for the Influx-only skip: any race whose stored end is 0
-    (unknown) or in the future is treated as possibly-live and must fall through
-    to the real is_live check rather than being skipped from Influx alone.
+    The live-race guard for the Influx-only skip. Sessions can share one race_id
+    across a multi-day event, so a race whose stored end is 0 (unknown), in the
+    future, or only recently past (within _SETTLED_BUFFER_S) may still have a
+    later session going live. Only a race whose end is settled well behind us is
+    safe to skip from Influx alone; anything more recent must fall through to the
+    real is_live check rather than being skipped from Influx alone.
     """
-    return bool(stored.end_time_epoc) and stored.end_time_epoc < time.time()
+    return bool(stored.end_time_epoc) and stored.end_time_epoc < time.time() - _SETTLED_BUFFER_S
 
 
 def race_complete_in_influx(ctx, stored):
@@ -1181,7 +1204,7 @@ def _influx_only_skip(race_id):
 
     Opens a short-lived read-only Influx connection and answers the backfill skip
     decision without any RaceMonitor call. Any race that is not definitively
-    ended (see stored_end_in_past) returns False so it falls through to the normal
+    ended (see stored_end_settled) returns False so it falls through to the normal
     flow's is_live check.
     """
     with _influx.connect() as influx_client:
@@ -1189,7 +1212,7 @@ def _influx_only_skip(race_id):
                           query_api=influx_client.query_api())
         stored = stored_race_completeness(ctx)
         return (stored is not None
-                and stored_end_in_past(stored)
+                and stored_end_settled(stored)
                 and race_complete_in_influx(ctx, stored))
 
 

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -524,7 +524,7 @@ def old_race(ctx, opts):
                     race_ts_ms = (
                         ctx.start_epoc * 1000 if ctx.start_epoc != 0 else int(time.time() * 1000)
                     )
-                    if not push_influx_race(ctx, race_ts_ms):
+                    if not push_influx_race(ctx, race_ts_ms, expected, len(pending_writes)):
                         logging.error(
                             "Race metadata write failed for race %s — failing the "
                             "run so the next backfill retries", ctx.race_id)
@@ -559,7 +559,7 @@ def old_race(ctx, opts):
             logging.warning("Skipping race stamp so next run will re-backfill")
             return 1
 
-        if not push_influx_race(ctx, race_ts_ms):
+        if not push_influx_race(ctx, race_ts_ms, expected, len(pending_writes)):
             logging.error(
                 "Race metadata write failed for race %s — failing the run so the "
                 "next backfill retries", ctx.race_id)
@@ -934,7 +934,7 @@ def push_influx(ctx, laps, monitor_mode, competitor_name=None, car_info=None,
     return True
 
 
-def push_influx_race(ctx, timestamp_ms):
+def push_influx_race(ctx, timestamp_ms, expected_lap_count, session_count):
     """Write one race metadata point to the races bucket, replacing any prior point.
 
     Returns True on success. Returns False when metadata is missing or the
@@ -960,6 +960,9 @@ def push_influx_race(ctx, timestamp_ms):
             .tag("track_name", meta.track_name)
             .tag("series_name", meta.series_name)
             .field("end_time_epoc", meta.end_time_epoc)
+            .field("schema_version", SCHEMA_VERSION)
+            .field("expected_lap_count", expected_lap_count)
+            .field("session_count", session_count)
             .time(timestamp_ms, WritePrecision.MS)
         )
         ctx.write_api.write(bucket=_influx.BUCKET_RACES, record=point)

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -1143,6 +1143,27 @@ def stored_end_in_past(stored):
     return bool(stored.end_time_epoc) and stored.end_time_epoc < time.time()
 
 
+def race_complete_in_influx(ctx, stored):
+    """True when the stored race point proves this race is complete and current.
+
+    Mirrors old_race's skip predicate but sources the expected lap total from the
+    stored race point (Influx) instead of a RaceMonitor fetch. `stored` is passed
+    in already-fetched so main() does not query the race point twice. The
+    is-not-None guard is required: a pre-existing point has expected_lap_count
+    None, and None > 0 raises TypeError in Python 3.
+    """
+    if stored is None or stored.schema_version != SCHEMA_VERSION:
+        return False
+    if stored.expected_lap_count is None or stored.expected_lap_count <= 0:
+        return False
+    expected = stored.expected_lap_count
+    total, current = existing_lap_counts_fieldwide(ctx)
+    if not (total == current == expected):
+        return False
+    std_total, std_current = existing_standings_counts_fieldwide(ctx)
+    return std_total > 0 and std_current == std_total
+
+
 def _build_class_index(session_details):
     """Precompute per-session class-position data shared by every competitor.
 

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -934,7 +934,7 @@ def push_influx(ctx, laps, monitor_mode, competitor_name=None, car_info=None,
     return True
 
 
-def push_influx_race(ctx, timestamp_ms, expected_lap_count, session_count):
+def push_influx_race(ctx, timestamp_ms, expected_lap_count=None, session_count=None):
     """Write one race metadata point to the races bucket, replacing any prior point.
 
     Returns True on success. Returns False when metadata is missing or the
@@ -960,11 +960,12 @@ def push_influx_race(ctx, timestamp_ms, expected_lap_count, session_count):
             .tag("track_name", meta.track_name)
             .tag("series_name", meta.series_name)
             .field("end_time_epoc", meta.end_time_epoc)
-            .field("schema_version", SCHEMA_VERSION)
-            .field("expected_lap_count", expected_lap_count)
-            .field("session_count", session_count)
             .time(timestamp_ms, WritePrecision.MS)
         )
+        if expected_lap_count is not None:
+            point.field("schema_version", SCHEMA_VERSION)
+            point.field("expected_lap_count", expected_lap_count)
+            point.field("session_count", session_count)
         ctx.write_api.write(bucket=_influx.BUCKET_RACES, record=point)
         return True
     except Exception as e:

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -3831,3 +3831,52 @@ class TestStoredEndInPast:
     def test_past_epoch_is_past(self):
         with patch.object(_mod.time, 'time', return_value=1000):
             assert _mod.stored_end_in_past(self._stored(500)) is True
+
+
+class TestRaceCompleteInInflux:
+    def _ctx(self):
+        ctx = _mod.RaceContext('999', None, MagicMock(), MagicMock(), 0)
+        ctx.query_api = MagicMock()
+        return ctx
+
+    def _stored(self, schema=None, expected=None):
+        schema = _mod.SCHEMA_VERSION if schema is None else schema
+        return _mod.StoredRace(
+            schema_version=schema, expected_lap_count=expected, end_time_epoc=123)
+
+    def test_none_stored_is_false(self):
+        assert _mod.race_complete_in_influx(self._ctx(), None) is False
+
+    def test_stale_schema_is_false(self):
+        stored = self._stored(schema=_mod.SCHEMA_VERSION - 1, expected=10)
+        assert _mod.race_complete_in_influx(self._ctx(), stored) is False
+
+    def test_missing_expected_is_false(self):
+        stored = self._stored(expected=None)
+        assert _mod.race_complete_in_influx(self._ctx(), stored) is False
+
+    def test_zero_expected_is_false(self):
+        stored = self._stored(expected=0)
+        assert _mod.race_complete_in_influx(self._ctx(), stored) is False
+
+    def test_laps_below_expected_is_false(self):
+        stored = self._stored(expected=10)
+        with patch.object(_mod, 'existing_lap_counts_fieldwide', return_value=(9, 9)):
+            assert _mod.race_complete_in_influx(self._ctx(), stored) is False
+
+    def test_laps_stale_schema_is_false(self):
+        stored = self._stored(expected=10)
+        with patch.object(_mod, 'existing_lap_counts_fieldwide', return_value=(10, 9)):
+            assert _mod.race_complete_in_influx(self._ctx(), stored) is False
+
+    def test_standings_missing_is_false(self):
+        stored = self._stored(expected=10)
+        with patch.object(_mod, 'existing_lap_counts_fieldwide', return_value=(10, 10)):
+            with patch.object(_mod, 'existing_standings_counts_fieldwide', return_value=(0, 0)):
+                assert _mod.race_complete_in_influx(self._ctx(), stored) is False
+
+    def test_all_good_is_true(self):
+        stored = self._stored(expected=10)
+        with patch.object(_mod, 'existing_lap_counts_fieldwide', return_value=(10, 10)):
+            with patch.object(_mod, 'existing_standings_counts_fieldwide', return_value=(5, 5)):
+                assert _mod.race_complete_in_influx(self._ctx(), stored) is True

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -3812,3 +3812,22 @@ class TestStoredRaceCompleteness:
         assert result.schema_version is None
         assert result.expected_lap_count is None
         assert result.end_time_epoc == 123
+
+
+class TestStoredEndInPast:
+    def _stored(self, end_epoc):
+        return _mod.StoredRace(schema_version=4, expected_lap_count=1, end_time_epoc=end_epoc)
+
+    def test_zero_epoch_is_not_past(self):
+        assert _mod.stored_end_in_past(self._stored(0)) is False
+
+    def test_none_epoch_is_not_past(self):
+        assert _mod.stored_end_in_past(self._stored(None)) is False
+
+    def test_future_epoch_is_not_past(self):
+        with patch.object(_mod.time, 'time', return_value=1000):
+            assert _mod.stored_end_in_past(self._stored(5000)) is False
+
+    def test_past_epoch_is_past(self):
+        with patch.object(_mod.time, 'time', return_value=1000):
+            assert _mod.stored_end_in_past(self._stored(500)) is True

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -3771,3 +3771,44 @@ class TestClassIndex:
                 with patch.object(_mod, 'print_rankings'):
                     _mod.old_race(ctx, opts)
         assert mock_index.call_count == 1  # once per session, not per competitor
+
+
+class TestStoredRaceCompleteness:
+    def _ctx(self, record_values):
+        """record_values: dict for the pivoted race row, or None for 'no race point'."""
+        api = MagicMock()
+
+        def fake_query(_flux):
+            if record_values is None:
+                return []
+            table = MagicMock()
+            rec = MagicMock()
+            rec.values = record_values
+            table.records = [rec]
+            return [table]
+
+        api.query.side_effect = fake_query
+        ctx = _mod.RaceContext('999', None, MagicMock(), MagicMock(), 0)
+        ctx.query_api = api
+        return ctx
+
+    def test_returns_none_when_no_race_point(self):
+        ctx = self._ctx(None)
+        assert _mod.stored_race_completeness(ctx) is None
+
+    def test_reads_all_fields(self):
+        ctx = self._ctx({
+            'schema_version': _mod.SCHEMA_VERSION,
+            'expected_lap_count': 42,
+            'end_time_epoc': 123,
+        })
+        result = _mod.stored_race_completeness(ctx)
+        assert result == _mod.StoredRace(
+            schema_version=_mod.SCHEMA_VERSION, expected_lap_count=42, end_time_epoc=123)
+
+    def test_missing_new_fields_come_back_none(self):
+        ctx = self._ctx({'end_time_epoc': 123})
+        result = _mod.stored_race_completeness(ctx)
+        assert result.schema_version is None
+        assert result.expected_lap_count is None
+        assert result.end_time_epoc == 123

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -3836,6 +3836,11 @@ class TestStoredEndSettled:
         with patch.object(_mod.time, 'time', return_value=self._NOW):
             assert _mod.stored_end_settled(self._stored(self._NOW - 3600)) is False
 
+    def test_end_exactly_at_buffer_is_not_settled(self):
+        with patch.object(_mod.time, 'time', return_value=self._NOW):
+            end = self._NOW - _mod._SETTLED_BUFFER_S
+            assert _mod.stored_end_settled(self._stored(end)) is False
+
     def test_end_just_inside_buffer_is_not_settled(self):
         with patch.object(_mod.time, 'time', return_value=self._NOW):
             end = self._NOW - _mod._SETTLED_BUFFER_S + 1

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -3880,3 +3880,71 @@ class TestRaceCompleteInInflux:
         with patch.object(_mod, 'existing_lap_counts_fieldwide', return_value=(10, 10)):
             with patch.object(_mod, 'existing_standings_counts_fieldwide', return_value=(5, 5)):
                 assert _mod.race_complete_in_influx(self._ctx(), stored) is True
+
+
+class TestInfluxOnlySkip:
+    def _conn_ctx(self):
+        """Patch _influx.connect to yield a client whose query_api() is a MagicMock."""
+        cm = patch.object(_mod._influx, 'connect')
+        mock_conn = cm.start()
+        mock_conn.return_value.__enter__.return_value.query_api.return_value = MagicMock()
+        return cm
+
+    def test_true_when_complete_and_ended(self):
+        cm = self._conn_ctx()
+        try:
+            complete = _mod.StoredRace(_mod.SCHEMA_VERSION, 10, 1000)
+            with patch.object(_mod, 'stored_race_completeness', return_value=complete):
+                with patch.object(_mod, 'stored_end_in_past', return_value=True):
+                    with patch.object(_mod, 'race_complete_in_influx', return_value=True):
+                        assert _mod._influx_only_skip('999') is True
+        finally:
+            cm.stop()
+
+    def test_false_when_no_stored_race(self):
+        cm = self._conn_ctx()
+        try:
+            with patch.object(_mod, 'stored_race_completeness', return_value=None):
+                assert _mod._influx_only_skip('999') is False
+        finally:
+            cm.stop()
+
+    def test_false_when_not_ended(self):
+        cm = self._conn_ctx()
+        try:
+            complete = _mod.StoredRace(_mod.SCHEMA_VERSION, 10, 0)
+            with patch.object(_mod, 'stored_race_completeness', return_value=complete):
+                with patch.object(_mod, 'stored_end_in_past', return_value=False):
+                    assert _mod._influx_only_skip('999') is False
+        finally:
+            cm.stop()
+
+
+class TestMainFastPath:
+    _ARGV: ClassVar[list] = ['lemongrass-laps', '-n', '--skip-if-complete', '999']
+    _ENV: ClassVar[dict] = {'RACEMONITOR_TOKENS': 'T', 'INFLUX_TELEMETRY_TOKEN': 'I'}
+
+    def test_skips_without_racemonitor_when_complete(self):
+        with patch.object(_mod.sys, 'argv', self._ARGV):
+            with patch.dict(os.environ, self._ENV, clear=True):
+                with patch.object(_mod, '_influx_only_skip', return_value=True):
+                    with patch.object(_mod, 'RaceMonitorClient') as mock_rm:
+                        result = _mod.main()
+        assert result == 0
+        mock_rm.assert_not_called()
+
+    def test_falls_through_to_racemonitor_when_not_complete(self):
+        client = MagicMock()
+        client.race.details.return_value = {'Successful': False}
+        client.race.is_live.return_value = {'Successful': True, 'IsLive': False}
+        with patch.object(_mod.sys, 'argv', self._ARGV):
+            with patch.dict(os.environ, self._ENV, clear=True):
+                with patch.object(_mod, '_influx_only_skip', return_value=False):
+                    with patch.object(_mod, 'RaceMonitorClient') as mock_rm:
+                        mock_rm.return_value.__enter__.return_value = client
+                        with patch.object(_mod._influx, 'connect') as mock_connect:
+                            mock_connect.return_value.__enter__.return_value = MagicMock()
+                            with patch.object(_mod, '_run_race', return_value=0):
+                                result = _mod.main()
+        assert result == 0
+        mock_rm.assert_called_once()

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -2336,6 +2336,24 @@ class TestPushInfluxRace:
         assert _mod.push_influx_race(ctx, 1000) is False
 
 
+class TestPushInfluxRaceFields:
+    def _ctx(self):
+        meta = _mod.RaceMetadata(
+            race_name='R', track_name='T', series_name='S', end_time_epoc=123)
+        return _mod.RaceContext('999', None, MagicMock(), MagicMock(), 0,
+                                metadata=meta, delete_api=MagicMock())
+
+    def test_writes_expected_session_and_schema_fields(self):
+        ctx = self._ctx()
+        ok = _mod.push_influx_race(ctx, 1000, expected_lap_count=42, session_count=3)
+        assert ok is True
+        point = ctx.write_api.write.call_args.kwargs['record']
+        lp = point.to_line_protocol()
+        assert 'expected_lap_count=42i' in lp
+        assert 'session_count=3i' in lp
+        assert f'schema_version={_mod.SCHEMA_VERSION}i' in lp
+
+
 class TestOldRaceMetadataFailure:
     def _session_details(self):
         return {

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -2353,6 +2353,16 @@ class TestPushInfluxRaceFields:
         assert 'session_count=3i' in lp
         assert f'schema_version={_mod.SCHEMA_VERSION}i' in lp
 
+    def test_omits_new_fields_when_expected_not_supplied(self):
+        ctx = self._ctx()
+        ok = _mod.push_influx_race(ctx, 1000)
+        assert ok is True
+        lp = ctx.write_api.write.call_args.kwargs['record'].to_line_protocol()
+        assert 'end_time_epoc=' in lp
+        assert 'expected_lap_count' not in lp
+        assert 'session_count' not in lp
+        assert 'schema_version' not in lp
+
 
 class TestOldRaceMetadataFailure:
     def _session_details(self):

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -3814,23 +3814,37 @@ class TestStoredRaceCompleteness:
         assert result.end_time_epoc == 123
 
 
-class TestStoredEndInPast:
+class TestStoredEndSettled:
+    _NOW: ClassVar[int] = 1_000_000_000
+
     def _stored(self, end_epoc):
         return _mod.StoredRace(schema_version=4, expected_lap_count=1, end_time_epoc=end_epoc)
 
-    def test_zero_epoch_is_not_past(self):
-        assert _mod.stored_end_in_past(self._stored(0)) is False
+    def test_zero_epoch_is_not_settled(self):
+        assert _mod.stored_end_settled(self._stored(0)) is False
 
-    def test_none_epoch_is_not_past(self):
-        assert _mod.stored_end_in_past(self._stored(None)) is False
+    def test_none_epoch_is_not_settled(self):
+        assert _mod.stored_end_settled(self._stored(None)) is False
 
-    def test_future_epoch_is_not_past(self):
-        with patch.object(_mod.time, 'time', return_value=1000):
-            assert _mod.stored_end_in_past(self._stored(5000)) is False
+    def test_future_epoch_is_not_settled(self):
+        with patch.object(_mod.time, 'time', return_value=self._NOW):
+            assert _mod.stored_end_settled(self._stored(self._NOW + 5000)) is False
 
-    def test_past_epoch_is_past(self):
-        with patch.object(_mod.time, 'time', return_value=1000):
-            assert _mod.stored_end_in_past(self._stored(500)) is True
+    def test_recent_past_within_buffer_is_not_settled(self):
+        # Ended an hour ago — a later session under the same race_id could still be
+        # live, so this must fall through to the authoritative is_live check.
+        with patch.object(_mod.time, 'time', return_value=self._NOW):
+            assert _mod.stored_end_settled(self._stored(self._NOW - 3600)) is False
+
+    def test_end_just_inside_buffer_is_not_settled(self):
+        with patch.object(_mod.time, 'time', return_value=self._NOW):
+            end = self._NOW - _mod._SETTLED_BUFFER_S + 1
+            assert _mod.stored_end_settled(self._stored(end)) is False
+
+    def test_end_beyond_buffer_is_settled(self):
+        with patch.object(_mod.time, 'time', return_value=self._NOW):
+            end = self._NOW - _mod._SETTLED_BUFFER_S - 1
+            assert _mod.stored_end_settled(self._stored(end)) is True
 
 
 class TestRaceCompleteInInflux:
@@ -3903,7 +3917,7 @@ class TestInfluxOnlySkip:
         try:
             complete = _mod.StoredRace(_mod.SCHEMA_VERSION, 10, 1000)
             with patch.object(_mod, 'stored_race_completeness', return_value=complete):
-                with patch.object(_mod, 'stored_end_in_past', return_value=True):
+                with patch.object(_mod, 'stored_end_settled', return_value=True):
                     with patch.object(_mod, 'race_complete_in_influx', return_value=True):
                         assert _mod._influx_only_skip('999') is True
         finally:
@@ -3922,7 +3936,7 @@ class TestInfluxOnlySkip:
         try:
             complete = _mod.StoredRace(_mod.SCHEMA_VERSION, 10, 0)
             with patch.object(_mod, 'stored_race_completeness', return_value=complete):
-                with patch.object(_mod, 'stored_end_in_past', return_value=False):
+                with patch.object(_mod, 'stored_end_settled', return_value=False):
                     assert _mod._influx_only_skip('999') is False
         finally:
             cm.stop()

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -3875,6 +3875,14 @@ class TestRaceCompleteInInflux:
             with patch.object(_mod, 'existing_standings_counts_fieldwide', return_value=(0, 0)):
                 assert _mod.race_complete_in_influx(self._ctx(), stored) is False
 
+    def test_standings_present_but_stale_is_false(self):
+        # Standings exist (std_total > 0) but some predate the current schema
+        # (std_current < std_total) — a prior run whose standings phase went stale.
+        stored = self._stored(expected=10)
+        with patch.object(_mod, 'existing_lap_counts_fieldwide', return_value=(10, 10)):
+            with patch.object(_mod, 'existing_standings_counts_fieldwide', return_value=(5, 3)):
+                assert _mod.race_complete_in_influx(self._ctx(), stored) is False
+
     def test_all_good_is_true(self):
         stored = self._stored(expected=10)
         with patch.object(_mod, 'existing_lap_counts_fieldwide', return_value=(10, 10)):


### PR DESCRIPTION
Closes #169.

Answers the `race-backfill --skip-if-complete` skip decision entirely from InfluxDB, **before any RaceMonitor call** — a skipped race makes zero API requests (previously it fetched `race.details` + metadata + `is_live` + every session via `old_race` under the ~6 req/min limit).

## Changes

- **`push_influx_race`** — stores `schema_version`, `expected_lap_count`, and `session_count` on the `race` metadata point. New params are optional; live/monitor callers pass nothing and the fields are omitted.
- **`StoredRace`** — frozen dataclass holding the three completeness fields read back from a race point; every field is `int | None` (absent fields read back as `None`).
- **`stored_race_completeness(ctx)`** — reads the latest race point into a `StoredRace`, or `None` when no point exists.
- **`race_complete_in_influx(ctx, stored)`** — mirrors `old_race`'s skip predicate (laps + standings complete and at current schema) but sources the expected lap total from the stored point instead of a fresh fetch.
- **`stored_end_settled(stored)`** — live-race guard: True only when `end_time_epoc` is known and more than `_SETTLED_BUFFER_S` (4 days) in the past. Sessions can share one `race_id` across a multi-day event, so an unknown (`0`), future, or within-buffer end may still have a later session live and falls through to `is_live`.
- **`_influx_only_skip(race_id)`** — opens a short-lived read-only Influx connection and combines the above.
- **`laps.main()`** — runs `_influx_only_skip` ahead of the `RaceMonitorClient` block; on a hit logs `SKIP` and returns 0 (read as success by `run_backfill`).

## Migration

No `SCHEMA_VERSION` bump (race-point fields, not a lap-shape change). Race points written before this change lack `expected_lap_count`, so `race_complete_in_influx` returns `False` and they fall through to the full-fetch path, which writes the field. One backfill pass migrates everything; subsequent passes are fast.

## Live-race safety

Two independent layers, both ahead of `main()`'s `is_live` dispatch:

1. **Gate** — the fast path requires `--skip-if-complete`, set only by `run_backfill` (never interactive/monitor runs).
2. **Guards** — live/monitor-written race points carry `expected_lap_count=None` → predicate returns `False`; and `stored_end_settled` requires the end settled >4 days back, so no in-progress multi-session event is skipped.

To force a re-backfill past the skip (e.g. a stored lap count revised after backfill), `race-backfill --upgrade-stored [--force]` re-runs `laps` without `--skip-if-complete`, so it never enters the fast path.

## Testing

550 passed / 4 deselected, ruff clean. New coverage: race-point field write/omit; `stored_race_completeness`; `stored_end_settled` (zero, None, future, within-buffer, exact boundary, just-inside, beyond); all `race_complete_in_influx` branches (`None`-guard, stale schema, laps below expected, standings missing, standings present-but-stale); `_influx_only_skip`; and `main()` skip-vs-fall-through (asserting `RaceMonitorClient` is never constructed on a skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a faster historical backfill path that can skip work when stored race data is already complete and current.
  * Race metadata now records additional completeness details for future checks.

* **Bug Fixes**
  * Improved handling of settled race end times and completeness checks to reduce unnecessary reprocessing.
  * Backfill runs now preserve enough metadata to make later skip decisions more reliable.

* **Tests**
  * Expanded coverage for race metadata writing, completeness detection, skip logic, and the CLI fast path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->