### PR TITLE
feat(telem): durable disk spool for InfluxDB writes during outages

### DIFF
--- a/local-testing/docker-compose.yml
+++ b/local-testing/docker-compose.yml
@@ -64,6 +64,12 @@ services:
       INFLUX_URL: http://influxdb:8086
       INFLUX_ORG: lemongrass
       INFLUX_TELEMETRY_TOKEN: local-dev-token
+    volumes:
+      # Persist /data (the spool lives at /data/telem-spool) so buffered points
+      # survive a telem restart — lets the outage->restart->recovery path be
+      # exercised locally: stop influxdb, let points spool, restart telem, then
+      # start influxdb and watch the spool drain.
+      - telem-data:/data
     depends_on:
       influxdb:
         condition: service_healthy
@@ -73,3 +79,4 @@ services:
 volumes:
   influxdb-data:
   grafana-data:
+  telem-data:

--- a/src/lemongrass/_influx.py
+++ b/src/lemongrass/_influx.py
@@ -24,31 +24,47 @@ BUCKET_SESSIONS = 'race_sessions'
 # NOT honor Retry-After: a downed Cloudflare tunnel returns 530 with
 # Retry-After: 120, which would otherwise hang the CLI for minutes. allowed_methods
 # is None so POST writes are retried too — the points written are idempotent.
-INFLUX_RETRIES = Retry(
-    total=3,
-    backoff_factor=1,
-    backoff_max=10,
-    status_forcelist=[429, 502, 503, 504, 530],
-    respect_retry_after_header=False,
-    allowed_methods=None,
-)
+def build_retries(total):
+    """Build the shared transient-error retry policy with a given attempt budget.
+
+    Batch commands use the 3-retry default; the telemetry hot loop trims this
+    (it has a durable spool as its real retry path) but keeps the same
+    forcelist/back-off semantics, so the policy lives in one place.
+    """
+    return Retry(
+        total=total,
+        backoff_factor=1,
+        backoff_max=10,
+        status_forcelist=[429, 502, 503, 504, 530],
+        respect_retry_after_header=False,
+        allowed_methods=None,
+    )
 
 
-def connect():
+INFLUX_RETRIES = build_retries(3)
+
+
+def connect(timeout=None, retries=INFLUX_RETRIES):
     """Return an InfluxDBClient wired with the shared URL/org/retries.
 
     Reads the token from INFLUX_TELEMETRY_TOKEN; logs an error and exits with
     status 1 if it is unset. The InfluxDBClient import is deferred so importing
     this module (which every command does) stays cheap.
+
+    `timeout` (ms) and `retries` let the telemetry hot loop fail fast to its
+    spool; when timeout is None the influxdb-client library default (10s) applies
+    so batch callers are unaffected.
     """
     token = os.environ.get('INFLUX_TELEMETRY_TOKEN')
     if not token:
         logging.error("INFLUX_TELEMETRY_TOKEN environment variable not set")
         sys.exit(1)
     from influxdb_client import InfluxDBClient
-    return InfluxDBClient(
-        url=INFLUX_URL, token=token, org=INFLUX_ORG, retries=INFLUX_RETRIES
-    )
+    kwargs = {'url': INFLUX_URL, 'token': token, 'org': INFLUX_ORG,
+              'retries': retries}
+    if timeout is not None:
+        kwargs['timeout'] = timeout
+    return InfluxDBClient(**kwargs)
 
 
 # Lap timestamps are session-anchored and Flux `stop` is exclusive, so laps can

--- a/src/lemongrass/_spool.py
+++ b/src/lemongrass/_spool.py
@@ -11,6 +11,8 @@ import logging
 import os
 from pathlib import Path
 
+from influxdb_client.rest import ApiException
+
 logger = logging.getLogger('telem')
 
 DEFAULT_SPOOL_DIR = '/data/telem-spool'
@@ -97,3 +99,58 @@ class Spool:
                 self.max_bytes,
                 dropped,
             )
+
+    def replay_oldest(self, write_api, bucket):
+        """Replay the oldest spool file through write_api; delete it on success.
+
+        Returns True if the spool is empty or one file was drained (or a corrupt
+        file was quarantined — progress either way). Returns False if the write
+        failed for a retryable/connectivity reason (Influx still down): the file
+        is kept for the next attempt.
+        """
+        if not self.enabled:
+            return True
+        files = self._files()
+        if not files:
+            return True
+        path = files[0]
+        try:
+            text = path.read_text()
+        except OSError as e:
+            logger.error("Cannot read spool file %s: %s", path, e)
+            return False
+        try:
+            write_api.write(bucket=bucket, record=text)
+        except ApiException as e:
+            if e.status and 400 <= e.status < 500 and e.status != 429:
+                return self._handle_corrupt(write_api, bucket, path, text)
+            return False  # 5xx / 429: retryable, keep the file
+        except Exception:
+            return False  # connectivity failure, keep the file
+        path.unlink(missing_ok=True)
+        logger.info("Replayed spool file %s", path.name)
+        return True
+
+    def _handle_corrupt(self, write_api, bucket, path, text):
+        """Salvage a 4xx-rejected file by dropping its (possibly torn) last line;
+        quarantine to <name>.bad if it still will not write."""
+        lines = text.splitlines()
+        if len(lines) > 1:
+            salvaged = '\n'.join(lines[:-1]) + '\n'
+            try:
+                write_api.write(bucket=bucket, record=salvaged)
+                path.unlink(missing_ok=True)
+                logger.warning(
+                    "Dropped 1 unwritable line from spool file %s", path.name
+                )
+                return True
+            except Exception:
+                pass
+        quarantine = path.with_suffix('.bad')
+        path.rename(quarantine)
+        logger.error(
+            "Quarantined unwritable spool file %s -> %s",
+            path.name,
+            quarantine.name,
+        )
+        return True

--- a/src/lemongrass/_spool.py
+++ b/src/lemongrass/_spool.py
@@ -18,7 +18,8 @@ logger = logging.getLogger('telem')
 DEFAULT_SPOOL_DIR = '/data/telem-spool'
 DEFAULT_MAX_BYTES = 1024 ** 3        # 1 GiB
 ROTATE_BYTES = 8 * 1024 * 1024       # 8 MiB per file
-_SUFFIX = '.lp'
+_SUFFIX = '.lp'                      # live, replayable spool files
+_BAD_SUFFIX = '.bad'                 # quarantined files (unwritable / unreadable)
 
 
 class Spool:
@@ -90,7 +91,14 @@ class Spool:
         return True
 
     def _enforce_cap(self):
-        files = self._files()
+        # Count both live (.lp) and quarantined (.bad) files toward the cap: a
+        # recurring stream of poison/unreadable files must not accumulate .bad
+        # files past TELEM_SPOOL_MAX_BYTES on a constrained device. Both suffixes
+        # are zero-padded-sequence names, so a plain name sort is oldest-first.
+        files = sorted(
+            [*self.dir.glob(f'*{_SUFFIX}'), *self.dir.glob(f'*{_BAD_SUFFIX}')],
+            key=lambda p: p.name,
+        )
         total = sum(f.stat().st_size for f in files)
         dropped = 0
         while total > self.max_bytes and len(files) > 1:
@@ -126,7 +134,7 @@ class Spool:
             text = path.read_text()
         except OSError as e:
             logger.error("Cannot read spool file %s: %s; quarantining", path, e)
-            quarantine = path.with_suffix('.bad')
+            quarantine = path.with_suffix(_BAD_SUFFIX)
             try:
                 path.rename(quarantine)
             except OSError as e2:
@@ -150,23 +158,35 @@ class Spool:
 
     def _handle_corrupt(self, write_api, bucket, path, text):
         """Salvage a 4xx-rejected file by dropping its (possibly torn) last line;
-        quarantine to <name>.bad if it still will not write."""
+        quarantine to <name>.bad if it still will not write.
+
+        A *retryable* failure of the salvage write (5xx / 429 / unknown status /
+        connectivity) keeps the file and returns False, so its good lines are not
+        thrown away over a transient hiccup between the two writes; only a genuine
+        4xx rejection (or an unsalvageable single-line file) is quarantined.
+        """
         lines = text.splitlines()
         if len(lines) > 1:
             salvaged = '\n'.join(lines[:-1]) + '\n'
             try:
                 write_api.write(bucket=bucket, record=salvaged)
+            except ApiException as e:
+                if not (e.status and 400 <= e.status < 500 and e.status != 429):
+                    return False  # retryable — keep the file, try again later
+                # genuine 4xx on the salvaged data too — fall through to quarantine
+            except Exception:
+                return False  # connectivity failure — keep the file
+            else:
                 try:
                     path.unlink(missing_ok=True)
                 except OSError as e:
-                    logger.warning("Could not remove salvaged spool file %s: %s", path.name, e)
+                    logger.warning(
+                        "Could not remove salvaged spool file %s: %s", path.name, e)
                 logger.warning(
                     "Dropped 1 unwritable line from spool file %s", path.name
                 )
                 return True
-            except Exception:
-                pass
-        quarantine = path.with_suffix('.bad')
+        quarantine = path.with_suffix(_BAD_SUFFIX)
         try:
             path.rename(quarantine)
         except OSError as e:

--- a/src/lemongrass/_spool.py
+++ b/src/lemongrass/_spool.py
@@ -59,12 +59,35 @@ class Spool:
             return []
         return sorted(self.dir.glob(f'*{_SUFFIX}'))
 
+    def _next_seq(self):
+        # Derive the next sequence from BOTH live (.lp) and quarantined (.bad)
+        # files: once every .lp drains, a lingering .bad must not let the
+        # counter reset to 1 and collide with (rename would clobber) or
+        # mis-order against the quarantined file.
+        seqs = [
+            int(p.stem)
+            for p in (*self.dir.glob(f'*{_SUFFIX}'), *self.dir.glob(f'*{_BAD_SUFFIX}'))
+        ]
+        return (max(seqs) + 1) if seqs else 1
+
     def _append_path(self):
         files = self._files()
         if files and files[-1].stat().st_size < self.rotate_bytes:
             return files[-1]
-        next_seq = (int(files[-1].stem) + 1) if files else 1
-        return self.dir / f'{next_seq:012d}{_SUFFIX}'
+        return self.dir / f'{self._next_seq():012d}{_SUFFIX}'
+
+    def _fsync_dir(self):
+        """fsync the spool directory so a newly-created file's directory entry
+        is durable across a hard fault (the per-file data fsync alone does not
+        persist the parent-dir metadata that makes the new file discoverable)."""
+        try:
+            dir_fd = os.open(self.dir, os.O_RDONLY)
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)
+        except OSError as e:
+            logger.warning("Could not fsync spool dir %s: %s", self.dir, e)
 
     def append(self, points):
         """Serialize points to line protocol and fsync-append to the newest file.
@@ -79,11 +102,14 @@ class Spool:
             return True
         blob = ''.join(p.to_line_protocol() + '\n' for p in points).encode()
         path = self._append_path()
+        is_new = not path.exists()
         try:
             with open(path, 'ab') as f:
                 f.write(blob)
                 f.flush()
                 os.fsync(f.fileno())
+            if is_new:
+                self._fsync_dir()
         except OSError as e:
             logger.error("Spool append to %s failed: %s", path, e)
             return False

--- a/src/lemongrass/_spool.py
+++ b/src/lemongrass/_spool.py
@@ -1,0 +1,99 @@
+"""Durable on-disk spool for telemetry points during an InfluxDB outage.
+
+telem.py's hot tier is an in-memory queue flushed to InfluxDB every 0.5s. When a
+flush fails (Influx unreachable) the unwritten batch is serialized to InfluxDB
+line protocol and appended here, on disk, so it survives the watchdog restart a
+coincident OBD dropout triggers. On recovery the oldest file is replayed through
+the same write_api and deleted. Replay is idempotent: every point carries an
+explicit nanosecond timestamp and Influx upserts by measurement+tags+time.
+"""
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger('telem')
+
+DEFAULT_SPOOL_DIR = '/data/telem-spool'
+DEFAULT_MAX_BYTES = 1024 ** 3        # 1 GiB
+ROTATE_BYTES = 8 * 1024 * 1024       # 8 MiB per file
+_SUFFIX = '.lp'
+
+
+class Spool:
+    """A directory of rotating line-protocol files buffering points on disk."""
+
+    def __init__(
+        self, directory, max_bytes=DEFAULT_MAX_BYTES, rotate_bytes=ROTATE_BYTES
+    ):
+        self.dir = Path(directory)
+        self.max_bytes = max_bytes
+        self.rotate_bytes = rotate_bytes
+        self.enabled = self._ensure_dir()
+
+    @classmethod
+    def from_env(cls):
+        return cls(
+            os.environ.get('TELEM_SPOOL_DIR', DEFAULT_SPOOL_DIR),
+            max_bytes=int(
+                os.environ.get('TELEM_SPOOL_MAX_BYTES', DEFAULT_MAX_BYTES)
+            ),
+        )
+
+    def _ensure_dir(self):
+        try:
+            self.dir.mkdir(parents=True, exist_ok=True)
+            return True
+        except OSError as e:
+            logger.error(
+                "Spool dir %s unusable (%s); telemetry durability disabled",
+                self.dir,
+                e,
+            )
+            return False
+
+    def _files(self):
+        if not self.enabled:
+            return []
+        return sorted(self.dir.glob(f'*{_SUFFIX}'))
+
+    def _append_path(self):
+        files = self._files()
+        if files and files[-1].stat().st_size < self.rotate_bytes:
+            return files[-1]
+        next_seq = (int(files[-1].stem) + 1) if files else 1
+        return self.dir / f'{next_seq:012d}{_SUFFIX}'
+
+    def append(self, points):
+        """Serialize points to line protocol and fsync-append to the newest file."""
+        if not self.enabled or not points:
+            return
+        blob = ''.join(p.to_line_protocol() + '\n' for p in points).encode()
+        path = self._append_path()
+        try:
+            with open(path, 'ab') as f:
+                f.write(blob)
+                f.flush()
+                os.fsync(f.fileno())
+        except OSError as e:
+            logger.error("Spool append to %s failed: %s", path, e)
+            return
+        self._enforce_cap()
+
+    def _enforce_cap(self):
+        files = self._files()
+        total = sum(f.stat().st_size for f in files)
+        dropped = 0
+        while total > self.max_bytes and len(files) > 1:
+            victim = files.pop(0)
+            total -= victim.stat().st_size
+            try:
+                victim.unlink()
+                dropped += 1
+            except OSError:
+                pass
+        if dropped:
+            logger.warning(
+                "Spool exceeded %d bytes; dropped %d oldest file(s)",
+                self.max_bytes,
+                dropped,
+            )

--- a/src/lemongrass/_spool.py
+++ b/src/lemongrass/_spool.py
@@ -66,9 +66,16 @@ class Spool:
         return self.dir / f'{next_seq:012d}{_SUFFIX}'
 
     def append(self, points):
-        """Serialize points to line protocol and fsync-append to the newest file."""
-        if not self.enabled or not points:
-            return
+        """Serialize points to line protocol and fsync-append to the newest file.
+
+        Returns True when the points were durably written to disk (or there
+        was nothing to do), False when they could not be durably stored --
+        callers must fall back to an in-memory backlog in that case.
+        """
+        if not self.enabled:
+            return False
+        if not points:
+            return True
         blob = ''.join(p.to_line_protocol() + '\n' for p in points).encode()
         path = self._append_path()
         try:
@@ -78,8 +85,9 @@ class Spool:
                 os.fsync(f.fileno())
         except OSError as e:
             logger.error("Spool append to %s failed: %s", path, e)
-            return
+            return False
         self._enforce_cap()
+        return True
 
     def _enforce_cap(self):
         files = self._files()
@@ -91,8 +99,8 @@ class Spool:
             try:
                 victim.unlink()
                 dropped += 1
-            except OSError:
-                pass
+            except OSError as e:
+                logger.warning("Could not evict spool file %s: %s", victim.name, e)
         if dropped:
             logger.warning(
                 "Spool exceeded %d bytes; dropped %d oldest file(s)",
@@ -117,14 +125,20 @@ class Spool:
         try:
             text = path.read_text()
         except OSError as e:
-            logger.error("Cannot read spool file %s: %s", path, e)
-            return False
+            logger.error("Cannot read spool file %s: %s; quarantining", path, e)
+            quarantine = path.with_suffix('.bad')
+            try:
+                path.rename(quarantine)
+            except OSError as e2:
+                logger.warning(
+                    "Could not quarantine unreadable spool file %s: %s", path.name, e2)
+            return True
         try:
             write_api.write(bucket=bucket, record=text)
         except ApiException as e:
             if e.status and 400 <= e.status < 500 and e.status != 429:
                 return self._handle_corrupt(write_api, bucket, path, text)
-            return False  # 5xx / 429: retryable, keep the file
+            return False  # 5xx / 429 / unknown status: retryable, keep the file
         except Exception:
             return False  # connectivity failure, keep the file
         try:

--- a/src/lemongrass/_spool.py
+++ b/src/lemongrass/_spool.py
@@ -127,7 +127,10 @@ class Spool:
             return False  # 5xx / 429: retryable, keep the file
         except Exception:
             return False  # connectivity failure, keep the file
-        path.unlink(missing_ok=True)
+        try:
+            path.unlink(missing_ok=True)
+        except OSError as e:
+            logger.warning("Could not remove replayed spool file %s: %s", path.name, e)
         logger.info("Replayed spool file %s", path.name)
         return True
 
@@ -139,7 +142,10 @@ class Spool:
             salvaged = '\n'.join(lines[:-1]) + '\n'
             try:
                 write_api.write(bucket=bucket, record=salvaged)
-                path.unlink(missing_ok=True)
+                try:
+                    path.unlink(missing_ok=True)
+                except OSError as e:
+                    logger.warning("Could not remove salvaged spool file %s: %s", path.name, e)
                 logger.warning(
                     "Dropped 1 unwritable line from spool file %s", path.name
                 )
@@ -147,7 +153,15 @@ class Spool:
             except Exception:
                 pass
         quarantine = path.with_suffix('.bad')
-        path.rename(quarantine)
+        try:
+            path.rename(quarantine)
+        except OSError as e:
+            logger.warning(
+                "Could not quarantine spool file %s -> %s: %s",
+                path.name,
+                quarantine.name,
+                e,
+            )
         logger.error(
             "Quarantined unwritable spool file %s -> %s",
             path.name,

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -349,9 +349,21 @@ def flush_points(write_api, batch_size=FLUSH_BATCH_SIZE):
         return False
 
 
+def _pump(write_api):
+    """One service cycle: flush fresh points, then replay one spooled file.
+
+    Replay runs only when the live flush succeeded — while Influx is down the
+    flush already failed (and spilled), so we skip a second blocking write.
+    """
+    if flush_points(write_api) and _spool is not None:
+        _spool.replay_oldest(write_api, WRITE_BUCKET)
+
+
 def main():
     """Main loop of OBD-II scraping"""
-    global _connection, _last_append_monotonic
+    global _connection, _last_append_monotonic, _spool
+
+    _spool = Spool.from_env()
 
     with _influx.connect() as influx_client:
         write_api = influx_client.write_api(write_options=SYNCHRONOUS)
@@ -386,11 +398,11 @@ def main():
 
         while True:
             sleep(0.5)
-            flush_points(write_api)
+            _pump(write_api)
             if not _connection_healthy(connection):
                 # Exit nonzero so the container/systemd restart policy re-runs
-                # the well-tested startup connect sequence; the flush at the top
-                # of this iteration already covers pending points.
+                # the well-tested startup connect sequence; _pump at the top of
+                # this iteration already flushed or spilled pending points.
                 logger.error("Exiting for supervisor restart")
                 sys.exit(1)
 

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -18,6 +18,21 @@ from lemongrass._spool import Spool
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger('telem')
 
+
+def _quiet_retry_logging():
+    """Silence urllib3's per-retry WARNING chatter.
+
+    urllib3 logs a WARNING on every retry attempt. During an Influx outage the
+    pump retries on each 0.5s cycle, which would bury flush_points' own
+    edge-triggered onset/recovery lines under a wall of identical retry
+    warnings. Our logging already reports outage state, so drop urllib3's
+    connection-retry logger to ERROR (genuine errors still surface).
+    """
+    logging.getLogger('urllib3.connectionpool').setLevel(logging.ERROR)
+
+
+_quiet_retry_logging()
+
 EXCLUDED_PATTERNS = ["MIDS", "PIDS", "O2_SENSORS", "ELM", "OBD"]
 SKIP_NAMES = {"FREEZE_DTC", "GET_DTC", "GET_CURRENT_DTC", "CLEAR_DTC", "FUEL_TYPE"}
 MAX_DTC_FETCH_FAILURES = 3
@@ -60,6 +75,10 @@ pending_lock = threading.Lock()
 
 _connection = None  # set by main(); lets new_status trigger on-demand DTC lookups
 _spool: Spool | None = None  # set by main()
+# Outage state, edge-triggered so a sustained outage logs once (WARN) at onset
+# and once (INFO) on recovery instead of one line per 0.5s pump cycle. Only
+# touched from the main pump thread (flush_points), so no lock is needed.
+_spooling = False
 # Both only ever written from the Async callback thread; no lock needed.
 _last_dtc_count = 0
 _dtc_fetch_failures = 0
@@ -339,6 +358,7 @@ def flush_points(write_api, batch_size=FLUSH_BATCH_SIZE):
     in-memory backlog, bounded by MAX_PENDING_POINTS, so a misconfigured spool
     dir doesn't silently drop telemetry.
     """
+    global _spooling
     with pending_lock:
         if not pending_points:
             return True
@@ -350,10 +370,23 @@ def flush_points(write_api, batch_size=FLUSH_BATCH_SIZE):
             write_api.write(bucket=WRITE_BUCKET, record=batch[i:i + batch_size])
             written += len(batch[i:i + batch_size])
         logger.info("Flushed %d points to InfluxDB", written)
+        if _spooling:
+            logger.info(
+                "InfluxDB reachable again; flushed %d points, draining spool",
+                written)
+            _spooling = False
         return True
     except Exception as e:
         unwritten = batch[written:]
-        logger.error('Failed to write %d points to InfluxDB: %s', len(unwritten), e)
+        if not _spooling:
+            logger.warning(
+                "InfluxDB write failed (%s); buffering telemetry to on-disk spool",
+                e)
+            _spooling = True
+        else:
+            logger.debug(
+                "InfluxDB still unreachable; spooling %d more points",
+                len(unwritten))
         spilled = _spool.append(unwritten) if _spool is not None else False
         if not spilled:
             # Spool unavailable (unusable dir or disk error) — fall back to the

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -13,6 +13,7 @@ from influxdb_client import Point
 from influxdb_client.client.write_api import SYNCHRONOUS
 
 from lemongrass import _influx
+from lemongrass._spool import Spool
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger('telem')
@@ -26,6 +27,10 @@ MAX_DTC_FETCH_FAILURES = 3
 MAX_PENDING_POINTS = 50_000
 FLUSH_BATCH_SIZE = 5_000
 STATUS_COMMANDS = {"STATUS", "STATUS_DRIVE_CYCLE"}
+
+# Write bucket for both the live flush and spool replay; the v2 write path
+# ignores DBRP so the target bucket must carry this literal name.
+WRITE_BUCKET = 'stats_252/autogen'
 
 FUEL_STATUS_MAP = {
     "Open loop due to insufficient engine temperature": 0,
@@ -46,6 +51,7 @@ pending_points = []
 pending_lock = threading.Lock()
 
 _connection = None  # set by main(); lets new_status trigger on-demand DTC lookups
+_spool: Spool | None = None  # set by main()
 # Both only ever written from the Async callback thread; no lock needed.
 _last_dtc_count = 0
 _dtc_fetch_failures = 0
@@ -316,35 +322,31 @@ def _connection_healthy(connection):
 
 
 def flush_points(write_api, batch_size=FLUSH_BATCH_SIZE):
-    """Write all pending points to InfluxDB in batches of batch_size.
+    """Write pending points to InfluxDB in batches; spill unwritten on failure.
 
-    On a failed write the unwritten remainder is re-queued, capped at
-    MAX_PENDING_POINTS with the oldest dropped, so an extended outage cannot
-    grow the backlog without bound — and recovery after the outage goes out in
-    bounded requests instead of one giant write.
+    Returns True when everything pending was written (or nothing was pending),
+    False when a write failed. On failure the unwritten remainder is serialized
+    to the on-disk spool (durable across the watchdog restart) instead of being
+    re-queued in RAM, so an outage cannot grow the in-memory backlog.
     """
     with pending_lock:
         if not pending_points:
-            return
+            return True
         batch = pending_points.copy()
         pending_points.clear()
     written = 0
     try:
         for i in range(0, len(batch), batch_size):
-            write_api.write(bucket='stats_252/autogen', record=batch[i:i + batch_size])
+            write_api.write(bucket=WRITE_BUCKET, record=batch[i:i + batch_size])
             written += len(batch[i:i + batch_size])
         logger.info("Flushed %d points to InfluxDB", written)
+        return True
     except Exception as e:
         unwritten = batch[written:]
         logger.error('Failed to write %d points to InfluxDB: %s', len(unwritten), e)
-        with pending_lock:
-            pending_points[:0] = unwritten
-            overflow = len(pending_points) - MAX_PENDING_POINTS
-            if overflow > 0:
-                del pending_points[:overflow]
-                logger.warning(
-                    "Backlog exceeded %d points; dropped %d oldest",
-                    MAX_PENDING_POINTS, overflow)
+        if _spool is not None:
+            _spool.append(unwritten)
+        return False
 
 
 def main():

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -32,6 +32,14 @@ STATUS_COMMANDS = {"STATUS", "STATUS_DRIVE_CYCLE"}
 # ignores DBRP so the target bucket must carry this literal name.
 WRITE_BUCKET = 'stats_252/autogen'
 
+# Influx client tuning for the 0.5s pump loop. A short per-request timeout and a
+# single retry keep a downed/hung Influx from blocking the hot path — the durable
+# spool (replayed each cycle) is the real retry path, so we fail fast to it
+# rather than the library-default 10s x 3 attempts. Batch commands keep the
+# default (longer timeout, 3 retries) via the unparameterized _influx.connect().
+WRITE_TIMEOUT_MS = 3000
+WRITE_RETRIES = _influx.build_retries(1)
+
 FUEL_STATUS_MAP = {
     "Open loop due to insufficient engine temperature": 0,
     "Closed loop, using oxygen sensor feedback to determine fuel mix": 1,
@@ -378,7 +386,7 @@ def main():
 
     _spool = Spool.from_env()
 
-    with _influx.connect() as influx_client:
+    with _influx.connect(timeout=WRITE_TIMEOUT_MS, retries=WRITE_RETRIES) as influx_client:
         write_api = influx_client.write_api(write_options=SYNCHRONOUS)
 
         _configure_obd_logging()

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -74,8 +74,8 @@ def _queue_point(point):
         pending_points.append(point)
         overflow = len(pending_points) - MAX_PENDING_POINTS
         if overflow > 0:
-            # Producers can outpace a hung or delayed flush; cap here too so
-            # callbacks can't grow memory unbounded before flush_points requeues.
+            # Producers can outpace a hung or blocked flush; cap here too so
+            # callbacks can't grow memory unbounded while a flush is stuck.
             del pending_points[:overflow]
             _dropped_since_warn += overflow
             now = monotonic()
@@ -326,8 +326,10 @@ def flush_points(write_api, batch_size=FLUSH_BATCH_SIZE):
 
     Returns True when everything pending was written (or nothing was pending),
     False when a write failed. On failure the unwritten remainder is serialized
-    to the on-disk spool (durable across the watchdog restart) instead of being
-    re-queued in RAM, so an outage cannot grow the in-memory backlog.
+    to the on-disk spool (durable across the watchdog restart); if the spool
+    can't durably accept it (disabled or a disk error), it falls back to the
+    in-memory backlog, bounded by MAX_PENDING_POINTS, so a misconfigured spool
+    dir doesn't silently drop telemetry.
     """
     with pending_lock:
         if not pending_points:
@@ -344,8 +346,19 @@ def flush_points(write_api, batch_size=FLUSH_BATCH_SIZE):
     except Exception as e:
         unwritten = batch[written:]
         logger.error('Failed to write %d points to InfluxDB: %s', len(unwritten), e)
-        if _spool is not None:
-            _spool.append(unwritten)
+        spilled = _spool.append(unwritten) if _spool is not None else False
+        if not spilled:
+            # Spool unavailable (unusable dir or disk error) — fall back to the
+            # in-memory backlog so a misconfigured /data doesn't silently drop
+            # telemetry. Bounded by MAX_PENDING_POINTS, dropping oldest.
+            with pending_lock:
+                pending_points[:0] = unwritten
+                overflow = len(pending_points) - MAX_PENDING_POINTS
+                if overflow > 0:
+                    del pending_points[:overflow]
+                    logger.warning(
+                        "Backlog exceeded %d points; dropped %d oldest",
+                        MAX_PENDING_POINTS, overflow)
         return False
 
 

--- a/tests/test_influx.py
+++ b/tests/test_influx.py
@@ -62,6 +62,40 @@ def test_connect_builds_client_with_shared_settings(monkeypatch):
     )
 
 
+def test_connect_omits_timeout_by_default(monkeypatch):
+    """Batch callers keep the library default timeout; connect() must not pass a
+    timeout kwarg unless one is explicitly requested."""
+    monkeypatch.setenv('INFLUX_TELEMETRY_TOKEN', 'secret-token')
+    with mock.patch('influxdb_client.InfluxDBClient') as client_cls:
+        influx_mod.connect()
+    assert 'timeout' not in client_cls.call_args.kwargs
+
+
+def test_connect_forwards_timeout_and_retries(monkeypatch):
+    monkeypatch.setenv('INFLUX_TELEMETRY_TOKEN', 'secret-token')
+    retries = influx_mod.build_retries(1)
+    with mock.patch('influxdb_client.InfluxDBClient') as client_cls:
+        influx_mod.connect(timeout=3000, retries=retries)
+    client_cls.assert_called_once_with(
+        url=influx_mod.INFLUX_URL,
+        token='secret-token',
+        org=influx_mod.INFLUX_ORG,
+        retries=retries,
+        timeout=3000,
+    )
+
+
+def test_build_retries_shares_transient_policy_with_fewer_attempts():
+    trimmed = influx_mod.build_retries(1)
+    assert isinstance(trimmed, Retry)
+    assert trimmed.total == 1
+    # Same transient-error semantics as the shared default, only fewer attempts.
+    assert trimmed.status_forcelist == influx_mod.INFLUX_RETRIES.status_forcelist
+    assert trimmed.respect_retry_after_header is False
+    assert trimmed.allowed_methods is None
+    assert trimmed.backoff_max == 10
+
+
 class TestInvalidFluxIds:
     def test_clean_ids_pass(self):
         from lemongrass import _influx

--- a/tests/test_spool.py
+++ b/tests/test_spool.py
@@ -69,6 +69,17 @@ class TestAppend:
         assert remaining == ["000000000003.lp"]
         assert any("dropped" in r.message.lower() for r in caplog.records)
 
+    def test_enforce_cap_counts_and_evicts_bad_files(self, tmp_path):
+        # Quarantined .bad files must count toward the cap and be evicted
+        # oldest-first alongside .lp, so poison can't grow the spool past it.
+        s = Spool(tmp_path / "spool", max_bytes=1, rotate_bytes=1)
+        s.append([_pt("RPM", 1)])                       # 000000000001.lp
+        bad = s.dir / "000000000000.bad"                # older-ordering quarantine
+        bad.write_text("old poison\n")
+        s.append([_pt("RPM", 2)])                       # 000000000002.lp -> enforce
+        assert not bad.exists()                         # .bad counted + evicted
+        assert (s.dir / "000000000002.lp").exists()     # newest .lp preserved
+
 
 class TestDegradation:
     def test_unusable_dir_disables_without_crashing(self, tmp_path):
@@ -136,6 +147,45 @@ class TestReplay:
         write_api = MagicMock()
         write_api.write.side_effect = ApiException(status=400, reason="bad")
         assert s.replay_oldest(write_api, BUCKET) is True  # progress: file removed from queue
+        assert list((tmp_path / "spool").glob("*.lp")) == []
+        assert len(list((tmp_path / "spool").glob("*.bad"))) == 1
+
+    def test_salvage_retryable_5xx_keeps_file_not_quarantined(self, tmp_path):
+        # Full-file write 400s (corrupt); the salvage retry hits a transient 5xx.
+        # The good lines must be kept for a later retry, NOT quarantined.
+        s = Spool(tmp_path / "spool")
+        s.append([_pt("RPM", 1), _pt("RPM", 2)])
+        write_api = MagicMock()
+        write_api.write.side_effect = [
+            ApiException(status=400, reason="bad"),
+            ApiException(status=503, reason="unavailable"),
+        ]
+        assert s.replay_oldest(write_api, BUCKET) is False
+        assert len(list((tmp_path / "spool").glob("*.lp"))) == 1
+        assert list((tmp_path / "spool").glob("*.bad")) == []
+
+    def test_salvage_connectivity_failure_keeps_file(self, tmp_path):
+        s = Spool(tmp_path / "spool")
+        s.append([_pt("RPM", 1), _pt("RPM", 2)])
+        write_api = MagicMock()
+        write_api.write.side_effect = [
+            ApiException(status=400, reason="bad"),
+            ConnectionError("influx down"),
+        ]
+        assert s.replay_oldest(write_api, BUCKET) is False
+        assert len(list((tmp_path / "spool").glob("*.lp"))) == 1
+        assert list((tmp_path / "spool").glob("*.bad")) == []
+
+    def test_salvage_second_4xx_quarantines(self, tmp_path):
+        # A genuine 4xx on the salvaged data too means it really is corrupt.
+        s = Spool(tmp_path / "spool")
+        s.append([_pt("RPM", 1), _pt("RPM", 2)])
+        write_api = MagicMock()
+        write_api.write.side_effect = [
+            ApiException(status=400, reason="bad"),
+            ApiException(status=400, reason="still bad"),
+        ]
+        assert s.replay_oldest(write_api, BUCKET) is True
         assert list((tmp_path / "spool").glob("*.lp")) == []
         assert len(list((tmp_path / "spool").glob("*.bad"))) == 1
 

--- a/tests/test_spool.py
+++ b/tests/test_spool.py
@@ -1,6 +1,8 @@
 import logging
+from unittest.mock import MagicMock
 
 from influxdb_client import Point
+from influxdb_client.rest import ApiException
 
 from lemongrass._spool import DEFAULT_MAX_BYTES, DEFAULT_SPOOL_DIR, Spool
 
@@ -74,3 +76,63 @@ class TestDegradation:
         s = Spool(blocker / "spool")
         assert s.enabled is False
         s.append([_pt("RPM", 1)])  # must not raise
+
+
+BUCKET = "stats_252/autogen"
+
+
+class TestReplay:
+    def test_empty_spool_returns_true(self, tmp_path):
+        s = Spool(tmp_path / "spool")
+        assert s.replay_oldest(MagicMock(), BUCKET) is True
+
+    def test_replays_and_deletes_oldest_first(self, tmp_path):
+        s = Spool(tmp_path / "spool", rotate_bytes=1)
+        s.append([_pt("RPM", 1)])   # -> 000000000001.lp
+        s.append([_pt("RPM", 2)])   # -> 000000000002.lp
+        write_api = MagicMock()
+        assert s.replay_oldest(write_api, BUCKET) is True
+        sent = write_api.write.call_args.kwargs["record"]
+        assert "RPM value=1i" in sent
+        remaining = sorted(p.name for p in (tmp_path / "spool").glob("*.lp"))
+        assert remaining == ["000000000002.lp"]
+
+    def test_connectivity_failure_keeps_file(self, tmp_path):
+        s = Spool(tmp_path / "spool")
+        s.append([_pt("RPM", 1)])
+        write_api = MagicMock()
+        write_api.write.side_effect = ConnectionError("influx down")
+        assert s.replay_oldest(write_api, BUCKET) is False
+        assert len(list((tmp_path / "spool").glob("*.lp"))) == 1
+
+    def test_5xx_keeps_file(self, tmp_path):
+        s = Spool(tmp_path / "spool")
+        s.append([_pt("RPM", 1)])
+        write_api = MagicMock()
+        write_api.write.side_effect = ApiException(status=503, reason="unavailable")
+        assert s.replay_oldest(write_api, BUCKET) is False
+        assert len(list((tmp_path / "spool").glob("*.lp"))) == 1
+
+    def test_torn_last_line_is_salvaged(self, tmp_path):
+        s = Spool(tmp_path / "spool")
+        s.append([_pt("RPM", 1), _pt("RPM", 2)])
+        # simulate a crash-torn final line appended after the good ones
+        f = next((tmp_path / "spool").glob("*.lp"))
+        with open(f, "a") as fh:
+            fh.write("RPM value=BROKEN")  # no newline, invalid
+        write_api = MagicMock()
+        # full-file write 400s; salvaged (last line dropped) write succeeds
+        write_api.write.side_effect = [ApiException(status=400, reason="bad"), None]
+        assert s.replay_oldest(write_api, BUCKET) is True
+        salvaged = write_api.write.call_args_list[1].kwargs["record"]
+        assert "RPM value=1i" in salvaged and "BROKEN" not in salvaged
+        assert list((tmp_path / "spool").glob("*.lp")) == []
+
+    def test_unsalvageable_file_is_quarantined(self, tmp_path):
+        s = Spool(tmp_path / "spool")
+        s.append([_pt("RPM", 1)])
+        write_api = MagicMock()
+        write_api.write.side_effect = ApiException(status=400, reason="bad")
+        assert s.replay_oldest(write_api, BUCKET) is True  # progress: file removed from queue
+        assert list((tmp_path / "spool").glob("*.lp")) == []
+        assert len(list((tmp_path / "spool").glob("*.bad"))) == 1

--- a/tests/test_spool.py
+++ b/tests/test_spool.py
@@ -152,3 +152,30 @@ class TestReplay:
         assert result is True
         # Warning should be logged about the unlink failure
         assert any("Could not remove replayed spool file" in r.message for r in caplog.records)
+
+
+class TestRoundTrip:
+    def test_outage_then_recovery_delivers_exact_points(self, tmp_path):
+        spool = Spool(tmp_path / "spool")
+
+        # --- outage: three batches fail to write and are spilled ---
+        spool.append([_pt("RPM", 1000), _pt("SPEED", 10)])
+        spool.append([_pt("RPM", 2000)])
+        spool.append([_pt("RPM", 3000)])
+        assert len(list((tmp_path / "spool").glob("*.lp"))) >= 1
+
+        # --- recovery: write_api works; drain until empty ---
+        write_api = MagicMock()
+        for _ in range(10):
+            if spool.replay_oldest(write_api, BUCKET) and not list(
+                (tmp_path / "spool").glob("*.lp")
+            ):
+                break
+
+        assert list((tmp_path / "spool").glob("*.lp")) == []  # fully drained
+        delivered = "".join(
+            c.kwargs["record"] for c in write_api.write.call_args_list
+        )
+        for token in ("RPM value=1000i", "SPEED value=10i",
+                      "RPM value=2000i", "RPM value=3000i"):
+            assert token in delivered

--- a/tests/test_spool.py
+++ b/tests/test_spool.py
@@ -80,6 +80,47 @@ class TestAppend:
         assert not bad.exists()                         # .bad counted + evicted
         assert (s.dir / "000000000002.lp").exists()     # newest .lp preserved
 
+    def test_append_preserves_explicit_ns_timestamp(self, tmp_path):
+        # Replay idempotency depends on each spooled point carrying its capture
+        # time in the line protocol (Influx upserts by measurement+tags+time).
+        # Guard that append serializes an explicit ns timestamp rather than
+        # dropping it, which would let Influx assign a replay-time timestamp.
+        from influxdb_client import WritePrecision
+        s = Spool(tmp_path / "spool")
+        ts = 1_700_000_000_000_000_000  # fixed ns
+        s.append([Point("RPM").field("value", 1).time(ts, WritePrecision.NS)])
+        text = next((tmp_path / "spool").glob("*.lp")).read_text()
+        assert text.strip().endswith(str(ts))
+
+    def test_new_file_seq_does_not_reset_below_lingering_bad(self, tmp_path):
+        # After every .lp drains, a lingering .bad must not let the sequence
+        # reset to 1 and collide with / mis-order against the quarantined file.
+        s = Spool(tmp_path / "spool", rotate_bytes=1)
+        s.append([_pt("RPM", 1)])                        # 000000000001.lp
+        # simulate: that file was quarantined high, then all live .lp drained
+        (s.dir / "000000000001.lp").rename(s.dir / "000000000005.bad")
+        s.append([_pt("RPM", 2)])                        # must be seq > 5
+        names = sorted(p.name for p in s.dir.glob("*.lp"))
+        assert names == ["000000000006.lp"]
+
+    def test_new_file_triggers_dir_fsync(self, tmp_path, monkeypatch):
+        # A newly-created (rotated) spool file needs its directory entry fsync'd
+        # so the file survives a hard fault before dir metadata is flushed.
+        s = Spool(tmp_path / "spool", rotate_bytes=1)  # every append rotates
+        calls = []
+        monkeypatch.setattr(s, "_fsync_dir", lambda: calls.append(1), raising=False)
+        s.append([_pt("RPM", 1)])                        # new file -> dir fsync
+        s.append([_pt("RPM", 2)])                        # new file -> dir fsync
+        assert len(calls) == 2
+
+    def test_append_to_existing_file_skips_dir_fsync(self, tmp_path, monkeypatch):
+        s = Spool(tmp_path / "spool", rotate_bytes=10_000)  # reuse one file
+        calls = []
+        monkeypatch.setattr(s, "_fsync_dir", lambda: calls.append(1), raising=False)
+        s.append([_pt("RPM", 1)])                        # new file -> 1 dir fsync
+        s.append([_pt("RPM", 2)])                        # reuse -> no dir fsync
+        assert len(calls) == 1
+
 
 class TestDegradation:
     def test_unusable_dir_disables_without_crashing(self, tmp_path):

--- a/tests/test_spool.py
+++ b/tests/test_spool.py
@@ -16,6 +16,7 @@ class TestConfig:
     def test_from_env_defaults(self, monkeypatch):
         monkeypatch.delenv("TELEM_SPOOL_DIR", raising=False)
         monkeypatch.delenv("TELEM_SPOOL_MAX_BYTES", raising=False)
+        monkeypatch.setattr(Spool, "_ensure_dir", lambda self: True)
         s = Spool.from_env()
         assert str(s.dir) == DEFAULT_SPOOL_DIR
         assert s.max_bytes == DEFAULT_MAX_BYTES
@@ -137,6 +138,22 @@ class TestReplay:
         assert s.replay_oldest(write_api, BUCKET) is True  # progress: file removed from queue
         assert list((tmp_path / "spool").glob("*.lp")) == []
         assert len(list((tmp_path / "spool").glob("*.bad"))) == 1
+
+    def test_unreadable_oldest_file_is_quarantined(self, tmp_path, monkeypatch, caplog):
+        s = Spool(tmp_path / "spool")
+        s.append([_pt("RPM", 1)])
+        write_api = MagicMock()
+
+        def failing_read_text(self, *args, **kwargs):
+            raise OSError("I/O error")
+
+        monkeypatch.setattr(Path, "read_text", failing_read_text)
+        with caplog.at_level(logging.ERROR):
+            result = s.replay_oldest(write_api, BUCKET)
+        assert result is True
+        assert list((tmp_path / "spool").glob("*.lp")) == []
+        assert len(list((tmp_path / "spool").glob("*.bad"))) == 1
+        write_api.write.assert_not_called()
 
     def test_unlink_oserror_does_not_propagate(self, tmp_path, monkeypatch, caplog):
         s = Spool(tmp_path / "spool")

--- a/tests/test_spool.py
+++ b/tests/test_spool.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 from unittest.mock import MagicMock
 
 from influxdb_client import Point
@@ -136,3 +137,18 @@ class TestReplay:
         assert s.replay_oldest(write_api, BUCKET) is True  # progress: file removed from queue
         assert list((tmp_path / "spool").glob("*.lp")) == []
         assert len(list((tmp_path / "spool").glob("*.bad"))) == 1
+
+    def test_unlink_oserror_does_not_propagate(self, tmp_path, monkeypatch, caplog):
+        s = Spool(tmp_path / "spool")
+        s.append([_pt("RPM", 1)])
+        write_api = MagicMock()
+        # Make unlink raise OSError to simulate permission or disk error
+        def failing_unlink(self, missing_ok=False):
+            raise OSError("Permission denied")
+        monkeypatch.setattr(Path, "unlink", failing_unlink)
+        with caplog.at_level(logging.WARNING):
+            result = s.replay_oldest(write_api, BUCKET)
+        # Should return True (data written successfully, cleanup error is non-fatal)
+        assert result is True
+        # Warning should be logged about the unlink failure
+        assert any("Could not remove replayed spool file" in r.message for r in caplog.records)

--- a/tests/test_spool.py
+++ b/tests/test_spool.py
@@ -1,0 +1,76 @@
+import logging
+
+from influxdb_client import Point
+
+from lemongrass._spool import DEFAULT_MAX_BYTES, DEFAULT_SPOOL_DIR, Spool
+
+
+def _pt(measurement, value):
+    return Point(measurement).field("value", value)
+
+
+class TestConfig:
+    def test_from_env_defaults(self, monkeypatch):
+        monkeypatch.delenv("TELEM_SPOOL_DIR", raising=False)
+        monkeypatch.delenv("TELEM_SPOOL_MAX_BYTES", raising=False)
+        s = Spool.from_env()
+        assert str(s.dir) == DEFAULT_SPOOL_DIR
+        assert s.max_bytes == DEFAULT_MAX_BYTES
+
+    def test_from_env_overrides(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("TELEM_SPOOL_DIR", str(tmp_path / "spool"))
+        monkeypatch.setenv("TELEM_SPOOL_MAX_BYTES", "12345")
+        s = Spool.from_env()
+        assert str(s.dir) == str(tmp_path / "spool")
+        assert s.max_bytes == 12345
+
+
+class TestAppend:
+    def test_append_writes_line_protocol(self, tmp_path):
+        s = Spool(tmp_path / "spool")
+        s.append([_pt("RPM", 3500), _pt("SPEED", 60)])
+        files = list((tmp_path / "spool").glob("*.lp"))
+        assert len(files) == 1
+        text = files[0].read_text()
+        assert "RPM value=3500i" in text
+        assert "SPEED value=60i" in text
+        assert text.endswith("\n")
+
+    def test_append_ignores_empty(self, tmp_path):
+        s = Spool(tmp_path / "spool")
+        s.append([])
+        assert list((tmp_path / "spool").glob("*.lp")) == []
+
+    def test_append_reuses_file_until_rotate_size(self, tmp_path):
+        s = Spool(tmp_path / "spool", rotate_bytes=10_000)
+        s.append([_pt("RPM", 1)])
+        s.append([_pt("RPM", 2)])
+        assert len(list((tmp_path / "spool").glob("*.lp"))) == 1
+
+    def test_append_rotates_past_rotate_size(self, tmp_path):
+        s = Spool(tmp_path / "spool", rotate_bytes=1)  # every append rotates
+        s.append([_pt("RPM", 1)])
+        s.append([_pt("RPM", 2)])
+        names = sorted(p.name for p in (tmp_path / "spool").glob("*.lp"))
+        assert names == ["000000000001.lp", "000000000002.lp"]
+
+    def test_enforce_cap_drops_oldest_keeps_newest(self, tmp_path, caplog):
+        s = Spool(tmp_path / "spool", max_bytes=1, rotate_bytes=1)
+        with caplog.at_level(logging.WARNING):
+            s.append([_pt("RPM", 1)])
+            s.append([_pt("RPM", 2)])
+            s.append([_pt("RPM", 3)])
+        # cap is tiny, so only the newest (currently-appended) file survives
+        remaining = sorted(p.name for p in (tmp_path / "spool").glob("*.lp"))
+        assert remaining == ["000000000003.lp"]
+        assert any("dropped" in r.message.lower() for r in caplog.records)
+
+
+class TestDegradation:
+    def test_unusable_dir_disables_without_crashing(self, tmp_path):
+        # a *file* where the dir should be makes mkdir fail
+        blocker = tmp_path / "blocker"
+        blocker.write_text("x")
+        s = Spool(blocker / "spool")
+        assert s.enabled is False
+        s.append([_pt("RPM", 1)])  # must not raise

--- a/tests/test_telem.py
+++ b/tests/test_telem.py
@@ -1,7 +1,10 @@
 import logging
 from unittest.mock import MagicMock, patch
 
+from influxdb_client import Point
+
 import lemongrass.telem as _mod
+from lemongrass._spool import Spool
 
 
 class _Cmd:
@@ -471,21 +474,33 @@ class TestFlushPoints:
         assert write_api.write.call_count == 3
         assert len(_mod.pending_points) == 0
 
-    def test_failed_write_spills_batch_and_clears_ram(self):
-        _mod.pending_points.append("p1")
+    def test_failed_write_spills_batch_to_disk_and_clears_ram(self, tmp_path):
+        # Real Spool on tmp_path: assert the batch actually lands on disk, not
+        # merely that append() was called on a mock.
+        _mod._spool = Spool(tmp_path / "spool")
+        _mod.pending_points.append(Point("RPM").field("value", 3500))
         write_api = MagicMock()
         write_api.write.side_effect = Exception("network error")
         assert _mod.flush_points(write_api) is False
         assert _mod.pending_points == []
-        _mod._spool.append.assert_called_once_with(["p1"])
+        spooled = list((tmp_path / "spool").glob("*.lp"))
+        assert len(spooled) == 1
+        assert "RPM value=3500i" in spooled[0].read_text()
 
-    def test_spills_only_unwritten_on_midbatch_failure(self):
-        _mod.pending_points.extend(["p1", "p2", "p3", "p4", "p5"])
+    def test_spills_only_unwritten_on_midbatch_failure(self, tmp_path):
+        _mod._spool = Spool(tmp_path / "spool")
+        _mod.pending_points.extend(
+            Point("RPM").field("value", i) for i in range(1, 6)
+        )
         write_api = MagicMock()
         write_api.write.side_effect = [None, Exception("boom")]
         assert _mod.flush_points(write_api, batch_size=2) is False
         assert _mod.pending_points == []
-        _mod._spool.append.assert_called_once_with(["p3", "p4", "p5"])
+        # First batch (values 1,2) reached Influx; only the unwritten remainder
+        # (3,4,5) is spilled to disk.
+        text = next((tmp_path / "spool").glob("*.lp")).read_text()
+        assert "value=3i" in text and "value=4i" in text and "value=5i" in text
+        assert "value=1i" not in text and "value=2i" not in text
 
     def test_failed_write_with_no_spool_does_not_crash(self):
         _mod._spool = None
@@ -494,11 +509,13 @@ class TestFlushPoints:
         write_api.write.side_effect = Exception("boom")
         assert _mod.flush_points(write_api) is False
 
-    def test_failed_write_falls_back_to_ram_when_spool_cannot_accept(self):
-        """If the spool is unusable (disabled dir, disk error), the unwritten
-        batch must be re-queued in RAM rather than silently dropped."""
-        _mod._spool = MagicMock()
-        _mod._spool.append.return_value = False
+    def test_failed_write_falls_back_to_ram_when_spool_unusable(self, tmp_path):
+        """A genuinely disabled spool (unusable dir) must not silently drop
+        telemetry — the unwritten batch is re-queued in the bounded backlog."""
+        blocker = tmp_path / "blocker"
+        blocker.write_text("x")  # a file where the dir should be -> mkdir fails
+        _mod._spool = Spool(blocker / "spool")
+        assert _mod._spool.enabled is False
         _mod.pending_points.extend(["p1", "p2"])
         write_api = MagicMock()
         write_api.write.side_effect = Exception("network error")
@@ -533,9 +550,6 @@ class TestPump:
         """When Influx is down, the flush inside a pump cycle must leave the
         backlog spilled to disk (durable across the watchdog sys.exit), never in
         RAM. This is the load-bearing ordering the watchdog relies on."""
-        from influxdb_client import Point
-
-        from lemongrass._spool import Spool
         _mod._spool = Spool(tmp_path / "spool")
         _mod.pending_points.append(Point("RPM").field("value", 3500))
         write_api = MagicMock()

--- a/tests/test_telem.py
+++ b/tests/test_telem.py
@@ -494,6 +494,17 @@ class TestFlushPoints:
         write_api.write.side_effect = Exception("boom")
         assert _mod.flush_points(write_api) is False
 
+    def test_failed_write_falls_back_to_ram_when_spool_cannot_accept(self):
+        """If the spool is unusable (disabled dir, disk error), the unwritten
+        batch must be re-queued in RAM rather than silently dropped."""
+        _mod._spool = MagicMock()
+        _mod._spool.append.return_value = False
+        _mod.pending_points.extend(["p1", "p2"])
+        write_api = MagicMock()
+        write_api.write.side_effect = Exception("network error")
+        assert _mod.flush_points(write_api) is False
+        assert _mod.pending_points == ["p1", "p2"]
+
 
 class TestPump:
     def setup_method(self):

--- a/tests/test_telem.py
+++ b/tests/test_telem.py
@@ -451,32 +451,17 @@ class TestNewStatusDtcTrigger:
 class TestFlushPoints:
     def setup_method(self):
         _reset()
+        _mod._spool = MagicMock()
 
-    def test_writes_and_clears_pending_points(self):
-        _mod.pending_points.append("p1")
-        write_api = MagicMock()
-        _mod.flush_points(write_api)
-        write_api.write.assert_called_once()
-        assert len(_mod.pending_points) == 0
-
-    def test_does_nothing_when_empty(self):
-        write_api = MagicMock()
-        _mod.flush_points(write_api)
-        write_api.write.assert_not_called()
-
-    def test_restores_points_on_write_failure(self):
-        _mod.pending_points.append("p1")
-        write_api = MagicMock()
-        write_api.write.side_effect = Exception("network error")
-        _mod.flush_points(write_api)
-        assert len(_mod.pending_points) == 1
-
-    def test_writes_all_pending_points(self):
+    def test_returns_true_and_writes_all_pending(self):
         _mod.pending_points.extend(["p1", "p2", "p3"])
         write_api = MagicMock()
-        _mod.flush_points(write_api)
+        assert _mod.flush_points(write_api) is True
         write_api.write.assert_called_once()
         assert len(_mod.pending_points) == 0
+
+    def test_returns_true_when_nothing_pending(self):
+        assert _mod.flush_points(MagicMock()) is True
 
     def test_flushes_in_batches(self):
         _mod.pending_points.extend(f"p{i}" for i in range(5))
@@ -485,21 +470,28 @@ class TestFlushPoints:
         assert write_api.write.call_count == 3
         assert len(_mod.pending_points) == 0
 
-    def test_requeues_only_unwritten_on_midbatch_failure(self):
+    def test_failed_write_spills_batch_and_clears_ram(self):
+        _mod.pending_points.append("p1")
+        write_api = MagicMock()
+        write_api.write.side_effect = Exception("network error")
+        assert _mod.flush_points(write_api) is False
+        assert _mod.pending_points == []
+        _mod._spool.append.assert_called_once_with(["p1"])
+
+    def test_spills_only_unwritten_on_midbatch_failure(self):
         _mod.pending_points.extend(["p1", "p2", "p3", "p4", "p5"])
         write_api = MagicMock()
         write_api.write.side_effect = [None, Exception("boom")]
-        _mod.flush_points(write_api, batch_size=2)
-        assert _mod.pending_points == ["p3", "p4", "p5"]
+        assert _mod.flush_points(write_api, batch_size=2) is False
+        assert _mod.pending_points == []
+        _mod._spool.append.assert_called_once_with(["p3", "p4", "p5"])
 
-    def test_backlog_capped_dropping_oldest(self):
-        """A multi-hour outage must not grow the backlog until the Pi OOMs."""
+    def test_failed_write_with_no_spool_does_not_crash(self):
+        _mod._spool = None
+        _mod.pending_points.append("p1")
         write_api = MagicMock()
         write_api.write.side_effect = Exception("boom")
-        with patch.object(_mod, "MAX_PENDING_POINTS", 3):
-            _mod.pending_points.extend(["p1", "p2", "p3", "p4"])
-            _mod.flush_points(write_api)
-        assert _mod.pending_points == ["p2", "p3", "p4"]
+        assert _mod.flush_points(write_api) is False
 
 
 class TestRouteCommand:

--- a/tests/test_telem.py
+++ b/tests/test_telem.py
@@ -18,6 +18,7 @@ def _reset():
     _mod._last_dtc_count = 0
     _mod._dtc_fetch_failures = 0
     _mod._connection = None
+    _mod._spool = None
 
 
 class TestConnect:
@@ -492,6 +493,45 @@ class TestFlushPoints:
         write_api = MagicMock()
         write_api.write.side_effect = Exception("boom")
         assert _mod.flush_points(write_api) is False
+
+
+class TestPump:
+    def setup_method(self):
+        _reset()
+
+    def test_replays_spool_when_flush_succeeds(self):
+        _mod._spool = MagicMock()
+        write_api = MagicMock()
+        with patch.object(_mod, "flush_points", return_value=True):
+            _mod._pump(write_api)
+        _mod._spool.replay_oldest.assert_called_once_with(write_api, _mod.WRITE_BUCKET)
+
+    def test_skips_replay_when_flush_fails(self):
+        _mod._spool = MagicMock()
+        write_api = MagicMock()
+        with patch.object(_mod, "flush_points", return_value=False):
+            _mod._pump(write_api)
+        _mod._spool.replay_oldest.assert_not_called()
+
+    def test_no_spool_does_not_crash(self):
+        _mod._spool = None
+        with patch.object(_mod, "flush_points", return_value=True):
+            _mod._pump(MagicMock())  # must not raise
+
+    def test_crash_invariant_backlog_is_on_disk_not_ram(self, tmp_path):
+        """When Influx is down, the flush inside a pump cycle must leave the
+        backlog spilled to disk (durable across the watchdog sys.exit), never in
+        RAM. This is the load-bearing ordering the watchdog relies on."""
+        from influxdb_client import Point
+
+        from lemongrass._spool import Spool
+        _mod._spool = Spool(tmp_path / "spool")
+        _mod.pending_points.append(Point("RPM").field("value", 3500))
+        write_api = MagicMock()
+        write_api.write.side_effect = ConnectionError("influx down")
+        _mod._pump(write_api)
+        assert _mod.pending_points == []                       # nothing left in RAM
+        assert len(list((tmp_path / "spool").glob("*.lp"))) == 1  # durable on disk
 
 
 class TestRouteCommand:

--- a/tests/test_telem.py
+++ b/tests/test_telem.py
@@ -23,6 +23,7 @@ def _reset():
     _mod._dtc_fetch_failures = 0
     _mod._connection = None
     _mod._spool = None
+    _mod._spooling = False
 
 
 class TestConnect:
@@ -524,6 +525,20 @@ class TestFlushPoints:
         assert _mod.pending_points == ["p1", "p2"]
 
 
+class TestLoggingConfig:
+    def test_quiets_urllib3_retry_warnings(self):
+        """urllib3 logs a WARNING per retry attempt; during an outage the pump
+        retries every 0.5s, which would bury our edge-triggered outage lines."""
+        target = logging.getLogger("urllib3.connectionpool")
+        original = target.level
+        try:
+            target.setLevel(logging.NOTSET)
+            _mod._quiet_retry_logging()
+            assert target.level == logging.ERROR
+        finally:
+            target.setLevel(original)
+
+
 class TestInfluxConnectTuning:
     def setup_method(self):
         _reset()
@@ -539,6 +554,64 @@ class TestInfluxConnectTuning:
                 _mod.main()
         influx_connect.assert_called_once_with(
             timeout=_mod.WRITE_TIMEOUT_MS, retries=_mod.WRITE_RETRIES)
+
+
+class TestSpoolStateLogging:
+    """Outage logging is edge-triggered: one WARN when we start spooling, one
+    INFO when Influx recovers, and no per-cycle spam in between."""
+
+    def setup_method(self):
+        _reset()
+        _mod._spool = MagicMock()  # append() truthy -> stays on the spool path
+
+    def _fail(self, write_api):
+        _mod.pending_points.append(Point("RPM").field("value", 1))
+        write_api.write.side_effect = Exception("influx down")
+        _mod.flush_points(write_api)
+
+    def _succeed(self, write_api):
+        _mod.pending_points.append(Point("RPM").field("value", 2))
+        write_api.write.side_effect = None
+        _mod.flush_points(write_api)
+
+    def test_first_spool_failure_logs_warning_and_sets_flag(self, caplog):
+        write_api = MagicMock()
+        with caplog.at_level(logging.DEBUG, logger="telem"):
+            self._fail(write_api)
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert any("buffering telemetry to on-disk spool" in r.message
+                   for r in warnings)
+        assert _mod._spooling is True
+
+    def test_repeated_failures_warn_once_then_debug(self, caplog):
+        write_api = MagicMock()
+        with caplog.at_level(logging.DEBUG, logger="telem"):
+            self._fail(write_api)
+            self._fail(write_api)
+        warnings = [r for r in caplog.records
+                    if r.levelname == "WARNING"
+                    and "buffering telemetry" in r.message]
+        assert len(warnings) == 1
+        assert any(r.levelname == "DEBUG" and "still unreachable" in r.message
+                   for r in caplog.records)
+
+    def test_recovery_logs_info_and_clears_flag(self, caplog):
+        write_api = MagicMock()
+        self._fail(write_api)
+        with caplog.at_level(logging.DEBUG, logger="telem"):
+            self._succeed(write_api)
+        assert any(r.levelname == "INFO" and "reachable again" in r.message
+                   for r in caplog.records)
+        assert _mod._spooling is False
+
+    def test_empty_flush_does_not_clear_spooling(self, caplog):
+        write_api = MagicMock()
+        self._fail(write_api)
+        assert _mod._spooling is True
+        with caplog.at_level(logging.DEBUG, logger="telem"):
+            _mod.flush_points(write_api)  # nothing pending -> early True
+        assert _mod._spooling is True  # empty flush is not proof of recovery
+        assert not any("reachable again" in r.message for r in caplog.records)
 
 
 class TestPump:

--- a/tests/test_telem.py
+++ b/tests/test_telem.py
@@ -1,6 +1,7 @@
 import logging
 from unittest.mock import MagicMock, patch
 
+import pytest
 from influxdb_client import Point
 
 import lemongrass.telem as _mod
@@ -521,6 +522,23 @@ class TestFlushPoints:
         write_api.write.side_effect = Exception("network error")
         assert _mod.flush_points(write_api) is False
         assert _mod.pending_points == ["p1", "p2"]
+
+
+class TestInfluxConnectTuning:
+    def setup_method(self):
+        _reset()
+
+    def test_main_connects_with_short_timeout_and_trimmed_retries(self):
+        """The hot loop must build its Influx client with a short timeout and a
+        trimmed retry budget so a downed Influx fails fast to the spool."""
+        with patch.object(_mod._influx, "connect") as influx_connect, \
+                patch.object(_mod.Spool, "from_env"), \
+                patch.object(_mod, "_configure_obd_logging"), \
+                patch.object(_mod, "connect", side_effect=RuntimeError("stop")):
+            with pytest.raises(RuntimeError, match="stop"):
+                _mod.main()
+        influx_connect.assert_called_once_with(
+            timeout=_mod.WRITE_TIMEOUT_MS, retries=_mod.WRITE_RETRIES)
 
 
 class TestPump:


### PR DESCRIPTION
## What & why

Telemetry (`lemongrass telem`) streams OBD-II points to InfluxDB. When Influx is unreachable, unwritten points were re-queued **in RAM only** (capped at 50k, dropping oldest), and the OBD watchdog `sys.exit(1)`s on a lost/stale link for a supervisor restart — wiping that backlog. An Influx outage coinciding with a connection blip silently lost telemetry, which (unlike race/lap data recoverable from race-monitor) has no upstream source of truth.

This adds a durable **two-tier buffer** plus fail-fast outage handling on the write path.

## How it works

### Durable spool

- **Normal operation (Influx up):** points flush every 0.5s, **zero disk writes**.
- **During an outage:** a failed flush serializes the unwritten batch to InfluxDB line protocol and appends it (`fsync`'d, and the directory entry `fsync`'d on rotation) to a rotating file under `TELEM_SPOOL_DIR` (default `/data/telem-spool`); RAM is cleared. Replay is idempotent (ns timestamps + Influx upsert).
- **On recovery:** the oldest spool file is replayed via the same `write_api` and deleted — one file per loop iteration, only when the live flush succeeded (never a second blocking write while Influx is down). Startup drains any files left by a prior run.
- **Crash-lossless:** `_pump` (flush-or-spill) runs at the top of the loop *before* the `_connection_healthy` exit, so the watchdog restart never discards the durable tier.
- **Bounded:** total spool — live (`.lp`) and quarantined (`.bad`) files together — is capped by `TELEM_SPOOL_MAX_BYTES` (default 1 GiB); oldest dropped past the cap, newest never evicted.
- **Robust:** poison/torn files (HTTP 4xx or unreadable) are salvaged (drop the torn last line) or quarantined to `.bad` so they can't wedge recovery; transient failures mid-salvage keep the file for a later retry. If the spool dir is unusable, writes fall back to the bounded in-memory backlog and degrade — never crash.

### Fail-fast write path

- The telem Influx client uses a **3s request timeout and a single retry** (`_influx.connect(timeout, retries)` + `build_retries()`) instead of the influxdb-client default of 10s × 3. A downed or hung Influx spills to the spool within seconds rather than blocking the 0.5s pump; the spool replayed each cycle is the real retry path. Batch commands (`races`, `race-backfill`, `laps`) keep the library defaults via the unparameterized `connect()`.

### Edge-triggered outage logging

- Outage state is tracked in a `_spooling` flag: one `WARNING` when spooling begins, one `INFO` on recovery, and `DEBUG` for the intervening cycles — instead of an ERROR on every 0.5s flush. Recovery is declared only on a real successful write, so an empty flush during a coincident OBD dropout does not falsely clear the flag.
- urllib3's per-retry `connectionpool` WARNING is dropped to ERROR in the telem process (lazy CLI dispatch keeps this scoped to `telem`; batch commands are unaffected), so an outage no longer re-floods the logs independent of our own logging.

The OBD watchdog crash-to-restart is intentionally **unchanged** (it's for the car-link, a separate failure); the spool just makes that restart lossless.

## Config

| Env var | Default | Meaning |
|---|---|---|
| `TELEM_SPOOL_DIR` | `/data/telem-spool` | Spool directory (must be writable) |
| `TELEM_SPOOL_MAX_BYTES` | `1073741824` (1 GiB) | Total spool cap; oldest dropped past it |

The client timeout (3s) and retry budget (1) are constants in `telem.py`, not env-configurable.

## Local testing

`local-testing/docker-compose.yml` mounts a `telem-data` volume at `/data` so the spool survives a `telem` restart, letting the local stack drive the full outage→restart→recovery path: stop `influxdb`, watch points spool to disk, restart `telem`, start `influxdb`, watch the spool drain.

## Testing

- `tests/test_spool.py` — config, append/rotation/cap (incl. `.bad` eviction), replay ordering, poison/torn-line salvage and retryable-vs-rejection routing, unreadable-file quarantine, disabled-dir degradation, full outage→recovery round-trip.
- `tests/test_telem.py` — spill-on-failure, bool return, RAM fallback when the spool is unusable, `_pump` gating, the crash-lossless invariant (against a real `Spool` on disk), tuned-client wiring, and the edge-triggered logging state machine.
- `tests/test_influx.py` — `connect()` timeout/retries passthrough and `build_retries()` shape.
- Full suite: **562 passed, 4 deselected** (emulator integration), ruff clean.

## Deployment note

For the spool to survive a container restart in production, the deployment must mount a **persistent volume at `/data`** (production compose lives in an external repo; `local-testing` already mounts it). No InfluxDB/bucket changes — replay targets the existing `stats_252/autogen` bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable local buffering for telemetry when the server is unavailable.
  * Telemetry data can now be retried automatically after connectivity is restored.

* **Bug Fixes**
  * Improved handling of failed writes so pending data is preserved instead of being lost.
  * Added recovery for partially written data and unreadable spool files.
  * Reduced the chance of dropping telemetry during outages by keeping data on disk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

