### PR TITLE
feat(telem): per-car VIN identity and dedicated pisugar bucket

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,8 +26,9 @@ When prod is unavailable, run the full pipeline against a local InfluxDB.
 
    `--build` builds the `elm327` and `telem` images on first start (and after
    changes). First start creates org `lemongrass`, a pinned operator token
-   (`local-dev-token`), and the `laps`, `races`, `race_sessions`, and
-   `stats_252/autogen` buckets. These are non-secret, local-only values.
+   (`local-dev-token`), and the `laps`, `races`, `race_sessions`, `telem`,
+   `pisugar`, and legacy `stats_252/autogen` buckets. These are non-secret,
+   local-only values.
 
 2. Point the CLI at the local stack by sourcing the committed app env:
 
@@ -79,9 +80,11 @@ the `elm327` service and telem connects to it over TCP (`socket://elm327:35000`)
 start as part of the default stack (step 1), so telem streams emulated OBD data with no
 extra flags.
 
-telem writes emulated data to the `stats_252/autogen` bucket (seeded by the InfluxDB init
-scripts), so the **telegraf** dashboard and the OBD panels in **race-control** show live
-data. That bucket and its DBRP are created only on a **fresh** InfluxDB volume, so if you
+telem writes emulated OBD data to the `telem` bucket (tagged with the car VIN);
+PiSugar host metrics go to the `pisugar` bucket (tagged with `host`). Both are
+created by the InfluxDB init scripts. The legacy `stats_252/autogen` bucket is
+still created so the one-time migration in `local-testing/migrations/` can be
+exercised locally. That bucket and its DBRP are created only on a **fresh** InfluxDB volume, so if you
 had a stack running before these were added, recreate the volume:
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,10 +82,9 @@ extra flags.
 
 telem writes emulated OBD data to the `telem` bucket (tagged with the car VIN);
 PiSugar host metrics go to the `pisugar` bucket (tagged with `host`). Both are
-created by the InfluxDB init scripts. The legacy `stats_252/autogen` bucket is
-still created so the one-time migration in `local-testing/migrations/` can be
-exercised locally. The `stats_252/autogen` bucket and its DBRP are created only on a **fresh** InfluxDB volume, so if you
-had a stack running before these were added, recreate the volume:
+created by the InfluxDB init scripts. The `telem` and `pisugar` buckets and
+their DBRPs are created only on a **fresh** InfluxDB volume, so if you had a
+stack running before they were added, recreate the volume:
 
 ```bash
 docker compose -f local-testing/docker-compose.yml down -v

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ telem writes emulated OBD data to the `telem` bucket (tagged with the car VIN);
 PiSugar host metrics go to the `pisugar` bucket (tagged with `host`). Both are
 created by the InfluxDB init scripts. The legacy `stats_252/autogen` bucket is
 still created so the one-time migration in `local-testing/migrations/` can be
-exercised locally. That bucket and its DBRP are created only on a **fresh** InfluxDB volume, so if you
+exercised locally. The `stats_252/autogen` bucket and its DBRP are created only on a **fresh** InfluxDB volume, so if you
 had a stack running before these were added, recreate the volume:
 
 ```bash

--- a/local-testing/grafana/provisioning/dashboards/json/car252-pisugar-ups.json
+++ b/local-testing/grafana/provisioning/dashboards/json/car252-pisugar-ups.json
@@ -36,7 +36,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+        "uid": "wotl-pisugar-ql"
       },
       "description": "",
       "fieldConfig": {
@@ -101,7 +101,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+            "uid": "wotl-pisugar-ql"
           },
           "groupBy": [
             {
@@ -136,7 +136,13 @@
               }
             ]
           ],
-          "tags": []
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            }
+          ]
         }
       ],
       "title": "PiSugar Power Status",
@@ -159,7 +165,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+        "uid": "wotl-pisugar-ql"
       },
       "description": "PiSugar Temperature",
       "fieldConfig": {
@@ -214,7 +220,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+            "uid": "wotl-pisugar-ql"
           },
           "groupBy": [
             {
@@ -249,7 +255,13 @@
               }
             ]
           ],
-          "tags": []
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            }
+          ]
         }
       ],
       "title": "PiSugar Temperature",
@@ -258,7 +270,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+        "uid": "wotl-pisugar-ql"
       },
       "description": "PiSugar Battery Voltage",
       "fieldConfig": {
@@ -318,7 +330,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+            "uid": "wotl-pisugar-ql"
           },
           "groupBy": [
             {
@@ -353,7 +365,13 @@
               }
             ]
           ],
-          "tags": []
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            }
+          ]
         }
       ],
       "title": "PiSugar Battery Voltage",
@@ -363,7 +381,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+        "uid": "wotl-pisugar-ql"
       },
       "description": "PiSugar Battery Level",
       "fieldConfig": {
@@ -419,7 +437,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+            "uid": "wotl-pisugar-ql"
           },
           "groupBy": [
             {
@@ -454,7 +472,13 @@
               }
             ]
           ],
-          "tags": []
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            }
+          ]
         }
       ],
       "title": "PiSugar Battery Level",
@@ -467,7 +491,21 @@
   "schemaVersion": 40,
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "name": "host",
+        "label": "Host",
+        "type": "query",
+        "datasource": {
+          "type": "influxdb",
+          "uid": "wotl-pisugar-ql"
+        },
+        "query": "SHOW TAG VALUES FROM \"pisugar-battery-level\" WITH KEY = \"host\"",
+        "refresh": 1,
+        "includeAll": true,
+        "multi": false
+      }
+    ]
   },
   "time": {
     "from": "now-15m",
@@ -475,7 +513,7 @@
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "car252 PiSugar UPS",
+  "title": "PiSugar UPS",
   "uid": "aek7ov53gt62od",
   "version": 10,
   "weekStart": ""

--- a/local-testing/grafana/provisioning/dashboards/json/race-control.json
+++ b/local-testing/grafana/provisioning/dashboards/json/race-control.json
@@ -3530,15 +3530,15 @@
         "name": "vin",
         "label": "Car",
         "type": "custom",
-        "query": "bytearray(b'WP0ZZZ99ZTS39') : Test Car",
+        "query": "WP0ZZZ99ZTS39 : Test Car",
         "current": {
           "text": "Test Car",
-          "value": "bytearray(b'WP0ZZZ99ZTS39')"
+          "value": "WP0ZZZ99ZTS39"
         },
         "options": [
           {
             "text": "Test Car",
-            "value": "bytearray(b'WP0ZZZ99ZTS39')",
+            "value": "WP0ZZZ99ZTS39",
             "selected": true
           }
         ],

--- a/local-testing/grafana/provisioning/dashboards/json/race-control.json
+++ b/local-testing/grafana/provisioning/dashboards/json/race-control.json
@@ -3530,15 +3530,15 @@
         "name": "vin",
         "label": "Car",
         "type": "custom",
-        "query": "unknown : Test Car",
+        "query": "bytearray(b'WP0ZZZ99ZTS39') : Test Car",
         "current": {
           "text": "Test Car",
-          "value": "unknown"
+          "value": "bytearray(b'WP0ZZZ99ZTS39')"
         },
         "options": [
           {
             "text": "Test Car",
-            "value": "unknown",
+            "value": "bytearray(b'WP0ZZZ99ZTS39')",
             "selected": true
           }
         ],

--- a/local-testing/grafana/provisioning/dashboards/json/race-control.json
+++ b/local-testing/grafana/provisioning/dashboards/json/race-control.json
@@ -1045,7 +1045,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+        "uid": "wotl-pisugar-ql"
       },
       "description": "",
       "fieldConfig": {
@@ -1110,7 +1110,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+            "uid": "wotl-pisugar-ql"
           },
           "groupBy": [
             {
@@ -3530,7 +3530,7 @@
         "name": "vin",
         "label": "Car",
         "type": "custom",
-        "query": "WP0ZZZ99ZTS39 : Test Car",
+        "query": "Test Car : WP0ZZZ99ZTS39",
         "current": {
           "text": "Test Car",
           "value": "WP0ZZZ99ZTS39"

--- a/local-testing/grafana/provisioning/dashboards/json/race-control.json
+++ b/local-testing/grafana/provisioning/dashboards/json/race-control.json
@@ -929,7 +929,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+        "uid": "wotl-telem-ql"
       },
       "fieldConfig": {
         "defaults": {
@@ -995,7 +995,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+            "uid": "wotl-telem-ql"
           },
           "groupBy": [
             {
@@ -1030,7 +1030,13 @@
               }
             ]
           ],
-          "tags": []
+          "tags": [
+            {
+              "key": "vin",
+              "operator": "=~",
+              "value": "/^$vin$/"
+            }
+          ]
         }
       ],
       "title": "Engine Coolant Temperature",
@@ -1149,7 +1155,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+        "uid": "wotl-telem-ql"
       },
       "fieldConfig": {
         "defaults": {
@@ -1215,7 +1221,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+            "uid": "wotl-telem-ql"
           },
           "groupBy": [
             {
@@ -1250,7 +1256,13 @@
               }
             ]
           ],
-          "tags": []
+          "tags": [
+            {
+              "key": "vin",
+              "operator": "=~",
+              "value": "/^$vin$/"
+            }
+          ]
         }
       ],
       "title": "OBD-II Voltage",
@@ -1380,7 +1392,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+        "uid": "wotl-telem-ql"
       },
       "fieldConfig": {
         "defaults": {
@@ -1473,7 +1485,7 @@
           "alias": "Degrees Celcius",
           "datasource": {
             "type": "influxdb",
-            "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+            "uid": "wotl-telem-ql"
           },
           "groupBy": [
             {
@@ -1508,7 +1520,13 @@
               }
             ]
           ],
-          "tags": []
+          "tags": [
+            {
+              "key": "vin",
+              "operator": "=~",
+              "value": "/^$vin$/"
+            }
+          ]
         }
       ],
       "title": "Engine Coolant Temperature",
@@ -1517,7 +1535,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+        "uid": "wotl-telem-ql"
       },
       "fieldConfig": {
         "defaults": {
@@ -1604,7 +1622,7 @@
           "alias": "Throttle Position %",
           "datasource": {
             "type": "influxdb",
-            "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+            "uid": "wotl-telem-ql"
           },
           "groupBy": [
             {
@@ -1639,13 +1657,19 @@
               }
             ]
           ],
-          "tags": []
+          "tags": [
+            {
+              "key": "vin",
+              "operator": "=~",
+              "value": "/^$vin$/"
+            }
+          ]
         },
         {
           "alias": "Vehicle Seed (MPH)",
           "datasource": {
             "type": "influxdb",
-            "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+            "uid": "wotl-telem-ql"
           },
           "groupBy": [
             {
@@ -1686,7 +1710,13 @@
               }
             ]
           ],
-          "tags": []
+          "tags": [
+            {
+              "key": "vin",
+              "operator": "=~",
+              "value": "/^$vin$/"
+            }
+          ]
         }
       ],
       "title": "Throttle Position vs. Vehicle speed",
@@ -1695,7 +1725,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+        "uid": "wotl-telem-ql"
       },
       "fieldConfig": {
         "defaults": {
@@ -1755,7 +1785,7 @@
           "alias": "RPM",
           "datasource": {
             "type": "influxdb",
-            "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+            "uid": "wotl-telem-ql"
           },
           "groupBy": [
             {
@@ -1790,7 +1820,13 @@
               }
             ]
           ],
-          "tags": []
+          "tags": [
+            {
+              "key": "vin",
+              "operator": "=~",
+              "value": "/^$vin$/"
+            }
+          ]
         }
       ],
       "title": "Engine RPM",
@@ -1799,7 +1835,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+        "uid": "wotl-telem-ql"
       },
       "fieldConfig": {
         "defaults": {
@@ -1890,7 +1926,7 @@
           "alias": "degrees",
           "datasource": {
             "type": "influxdb",
-            "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+            "uid": "wotl-telem-ql"
           },
           "groupBy": [
             {
@@ -1925,7 +1961,13 @@
               }
             ]
           ],
-          "tags": []
+          "tags": [
+            {
+              "key": "vin",
+              "operator": "=~",
+              "value": "/^$vin$/"
+            }
+          ]
         }
       ],
       "title": "Timing Advance",
@@ -1934,7 +1976,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+        "uid": "wotl-telem-ql"
       },
       "fieldConfig": {
         "defaults": {
@@ -2031,7 +2073,7 @@
           "alias": "Long term fuel trim",
           "datasource": {
             "type": "influxdb",
-            "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+            "uid": "wotl-telem-ql"
           },
           "groupBy": [
             {
@@ -2066,13 +2108,19 @@
               }
             ]
           ],
-          "tags": []
+          "tags": [
+            {
+              "key": "vin",
+              "operator": "=~",
+              "value": "/^$vin$/"
+            }
+          ]
         },
         {
           "alias": "Short term fuel trim",
           "datasource": {
             "type": "influxdb",
-            "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+            "uid": "wotl-telem-ql"
           },
           "groupBy": [
             {
@@ -2107,7 +2155,13 @@
               }
             ]
           ],
-          "tags": []
+          "tags": [
+            {
+              "key": "vin",
+              "operator": "=~",
+              "value": "/^$vin$/"
+            }
+          ]
         }
       ],
       "title": "Fuel Trims",
@@ -2116,7 +2170,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+        "uid": "wotl-telem-ql"
       },
       "fieldConfig": {
         "defaults": {
@@ -2183,7 +2237,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+            "uid": "wotl-telem-ql"
           },
           "groupBy": [
             {
@@ -2224,7 +2278,13 @@
               }
             ]
           ],
-          "tags": []
+          "tags": [
+            {
+              "key": "vin",
+              "operator": "=~",
+              "value": "/^$vin$/"
+            }
+          ]
         }
       ],
       "title": "Vehicle Speed",
@@ -2233,7 +2293,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+        "uid": "wotl-telem-ql"
       },
       "fieldConfig": {
         "defaults": {
@@ -2289,7 +2349,7 @@
           "alias": "Throttle Position",
           "datasource": {
             "type": "influxdb",
-            "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+            "uid": "wotl-telem-ql"
           },
           "groupBy": [
             {
@@ -2324,7 +2384,13 @@
               }
             ]
           ],
-          "tags": []
+          "tags": [
+            {
+              "key": "vin",
+              "operator": "=~",
+              "value": "/^$vin$/"
+            }
+          ]
         }
       ],
       "title": "Throttle Position",
@@ -2333,7 +2399,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+        "uid": "wotl-telem-ql"
       },
       "fieldConfig": {
         "defaults": {
@@ -2414,7 +2480,7 @@
           "alias": "Fuel System Status",
           "datasource": {
             "type": "influxdb",
-            "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+            "uid": "wotl-telem-ql"
           },
           "groupBy": [
             {
@@ -2449,7 +2515,13 @@
               }
             ]
           ],
-          "tags": []
+          "tags": [
+            {
+              "key": "vin",
+              "operator": "=~",
+              "value": "/^$vin$/"
+            }
+          ]
         }
       ],
       "title": "Fuel System Status",
@@ -2458,7 +2530,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+        "uid": "wotl-telem-ql"
       },
       "description": "In gps",
       "fieldConfig": {
@@ -2548,7 +2620,7 @@
           "alias": "GPS",
           "datasource": {
             "type": "influxdb",
-            "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+            "uid": "wotl-telem-ql"
           },
           "groupBy": [
             {
@@ -2583,7 +2655,13 @@
               }
             ]
           ],
-          "tags": []
+          "tags": [
+            {
+              "key": "vin",
+              "operator": "=~",
+              "value": "/^$vin$/"
+            }
+          ]
         }
       ],
       "title": "Mass Air Flow Rate",
@@ -2592,7 +2670,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+        "uid": "wotl-telem-ql"
       },
       "fieldConfig": {
         "defaults": {
@@ -2681,7 +2759,7 @@
           "alias": "Kilopascal",
           "datasource": {
             "type": "influxdb",
-            "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+            "uid": "wotl-telem-ql"
           },
           "groupBy": [
             {
@@ -2716,7 +2794,13 @@
               }
             ]
           ],
-          "tags": []
+          "tags": [
+            {
+              "key": "vin",
+              "operator": "=~",
+              "value": "/^$vin$/"
+            }
+          ]
         }
       ],
       "title": "Fuel Pressure",
@@ -2725,7 +2809,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+        "uid": "wotl-telem-ql"
       },
       "fieldConfig": {
         "defaults": {
@@ -2814,7 +2898,7 @@
           "alias": "Volts",
           "datasource": {
             "type": "influxdb",
-            "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+            "uid": "wotl-telem-ql"
           },
           "groupBy": [
             {
@@ -2843,7 +2927,13 @@
               }
             ]
           ],
-          "tags": []
+          "tags": [
+            {
+              "key": "vin",
+              "operator": "=~",
+              "value": "/^$vin$/"
+            }
+          ]
         }
       ],
       "title": "O2 Sensor Voltage",
@@ -2852,7 +2942,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+        "uid": "wotl-telem-ql"
       },
       "fieldConfig": {
         "defaults": {
@@ -2943,7 +3033,7 @@
           "alias": "MPH",
           "datasource": {
             "type": "influxdb",
-            "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+            "uid": "wotl-telem-ql"
           },
           "groupBy": [
             {
@@ -2984,7 +3074,13 @@
               }
             ]
           ],
-          "tags": []
+          "tags": [
+            {
+              "key": "vin",
+              "operator": "=~",
+              "value": "/^$vin$/"
+            }
+          ]
         }
       ],
       "title": "Vehicle Speed",
@@ -2993,7 +3089,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+        "uid": "wotl-telem-ql"
       },
       "fieldConfig": {
         "defaults": {
@@ -3093,7 +3189,7 @@
           "alias": "Revolutions Per Minute",
           "datasource": {
             "type": "influxdb",
-            "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+            "uid": "wotl-telem-ql"
           },
           "groupBy": [
             {
@@ -3130,7 +3226,13 @@
               }
             ]
           ],
-          "tags": []
+          "tags": [
+            {
+              "key": "vin",
+              "operator": "=~",
+              "value": "/^$vin$/"
+            }
+          ]
         }
       ],
       "title": "Engine RPM",
@@ -3139,7 +3241,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+        "uid": "wotl-telem-ql"
       },
       "fieldConfig": {
         "defaults": {
@@ -3228,7 +3330,7 @@
           "alias": "Degrees Celcius",
           "datasource": {
             "type": "influxdb",
-            "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+            "uid": "wotl-telem-ql"
           },
           "groupBy": [
             {
@@ -3263,7 +3365,13 @@
               }
             ]
           ],
-          "tags": []
+          "tags": [
+            {
+              "key": "vin",
+              "operator": "=~",
+              "value": "/^$vin$/"
+            }
+          ]
         }
       ],
       "title": "Intake Air Temperature",
@@ -3272,7 +3380,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+        "uid": "wotl-telem-ql"
       },
       "description": "Fuel system status is reported as 1 of 5 modes.\n0 - Open loop due to insufficient engine temperature\n1 - Closed loop, using oxygen sensor feedback to determine fuel mix\n2 - Open loop due to engine load OR fuel cut due to deceleration\n3 - Open loop due to system failure\n4 - Closed loop, using at least one oxygen sensor but there is a fault in the feedback system",
       "fieldConfig": {
@@ -3364,7 +3472,7 @@
           "alias": "Mode",
           "datasource": {
             "type": "influxdb",
-            "uid": "f3134d95-85f2-4173-9d6b-5ce95b10bbd0"
+            "uid": "wotl-telem-ql"
           },
           "groupBy": [
             {
@@ -3399,7 +3507,13 @@
               }
             ]
           ],
-          "tags": []
+          "tags": [
+            {
+              "key": "vin",
+              "operator": "=~",
+              "value": "/^$vin$/"
+            }
+          ]
         }
       ],
       "title": "Fuel System Status",
@@ -3412,6 +3526,25 @@
   "tags": [],
   "templating": {
     "list": [
+      {
+        "name": "vin",
+        "label": "Car",
+        "type": "custom",
+        "query": "unknown : Test Car",
+        "current": {
+          "text": "Test Car",
+          "value": "unknown"
+        },
+        "options": [
+          {
+            "text": "Test Car",
+            "value": "unknown",
+            "selected": true
+          }
+        ],
+        "includeAll": false,
+        "multi": false
+      },
       {
         "name": "raceid",
         "label": "Race",

--- a/local-testing/grafana/provisioning/datasources/influxdb.yml
+++ b/local-testing/grafana/provisioning/datasources/influxdb.yml
@@ -65,6 +65,32 @@ datasources:
     secureJsonData:
       httpHeaderValue1: Token local-dev-token
 
+  # Car OBD telemetry (vin-tagged) — backs the race-control OBD panels.
+  - name: telem
+    uid: wotl-telem-ql
+    type: influxdb
+    access: proxy
+    url: http://influxdb:8086
+    isDefault: false
+    jsonData:
+      dbName: telem
+      httpHeaderName1: Authorization
+    secureJsonData:
+      httpHeaderValue1: Token local-dev-token
+
+  # PiSugar host/UPS telemetry (host-tagged) — backs the pisugar dashboard.
+  - name: pisugar
+    uid: wotl-pisugar-ql
+    type: influxdb
+    access: proxy
+    url: http://influxdb:8086
+    isDefault: false
+    jsonData:
+      dbName: pisugar
+      httpHeaderName1: Authorization
+    secureJsonData:
+      httpHeaderValue1: Token local-dev-token
+
   # Flux datasources — back the dashboard template variables.
   - name: laps_flux
     uid: wotl-laps-flux

--- a/local-testing/influx-init/10-create-buckets.sh
+++ b/local-testing/influx-init/10-create-buckets.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 # During first-init the entrypoint runs influxd on INFLUXD_INIT_PORT (9999),
 # not 8086 — 8086 only binds after init completes.
-for bucket in races race_sessions; do
+for bucket in races race_sessions telem pisugar; do
   influx bucket create \
     --name "$bucket" \
     --org "$DOCKER_INFLUXDB_INIT_ORG" \

--- a/local-testing/influx-init/20-create-dbrp.sh
+++ b/local-testing/influx-init/20-create-dbrp.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # Runs once, inside the influxdb container, after 10-create-buckets.sh on first
 # init (empty volume). Creates v1 DBRP mappings so the InfluxQL Grafana
-# datasources (wotl-laps-ql / wotl-races-ql / stats_252) can query the 2.x
-# buckets via the v1 API. The race_sessions bucket is queried only via Flux,
-# so it needs no DBRP.
+# datasources (wotl-laps-ql / wotl-races-ql / wotl-telem-ql / wotl-pisugar-ql /
+# stats_252) can query the 2.x buckets via the v1 API. The race_sessions bucket
+# is queried only via Flux, so it needs no DBRP.
 set -euo pipefail
 
 # During first-init the entrypoint runs influxd on INFLUXD_INIT_PORT (9999),

--- a/local-testing/influx-init/20-create-dbrp.sh
+++ b/local-testing/influx-init/20-create-dbrp.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 # not 8086 — 8086 only binds after init completes.
 HOST="http://localhost:${INFLUXD_INIT_PORT:-9999}"
 
-for db in laps races; do
+for db in laps races telem pisugar; do
   bucket_id=$(influx bucket list \
     --name "$db" \
     --org "$DOCKER_INFLUXDB_INIT_ORG" \

--- a/local-testing/migrations/2026-07-05-stats252-split.flux
+++ b/local-testing/migrations/2026-07-05-stats252-split.flux
@@ -1,0 +1,23 @@
+// One-time split of the legacy stats_252/autogen bucket into the car-agnostic
+// telem bucket (OBD, vin-tagged) and the pisugar bucket (host-tagged).
+//
+// Replace the two placeholders before running:
+//   CURRENT_CAR_VIN   -- the VIN of the single car whose history this is
+//   CURRENT_PI_HOSTNAME -- the hostname that car's Pi reports (telegraf host)
+//
+// Idempotent: ns timestamps + Influx upsert mean a re-run overwrites, not
+// duplicates. Leaves stats_252/autogen intact for rollback.
+
+// OBD measurements -> telem
+from(bucket: "stats_252/autogen")
+  |> range(start: 0)
+  |> filter(fn: (r) => not r._measurement =~ /^pisugar-/)
+  |> set(key: "vin", value: "CURRENT_CAR_VIN")
+  |> to(bucket: "telem")
+
+// PiSugar measurements -> pisugar
+from(bucket: "stats_252/autogen")
+  |> range(start: 0)
+  |> filter(fn: (r) => r._measurement =~ /^pisugar-/)
+  |> set(key: "host", value: "CURRENT_PI_HOSTNAME")
+  |> to(bucket: "pisugar")

--- a/local-testing/migrations/README.md
+++ b/local-testing/migrations/README.md
@@ -1,0 +1,38 @@
+# stats_252 → telem / pisugar migration (one-time)
+
+Splits the legacy `stats_252/autogen` bucket into `telem` (OBD, tagged `vin`)
+and `pisugar` (PiSugar, tagged `host`). Run once, manually, against the target
+InfluxDB after the `telem` and `pisugar` buckets exist.
+
+## Steps
+
+1. Edit `2026-07-05-stats252-split.flux`, replacing `CURRENT_CAR_VIN` with the
+   car's VIN and `CURRENT_PI_HOSTNAME` with the Pi's hostname.
+2. Dry-run against the local stack first (see Verify).
+3. Run against the target:
+   `influx query --org <org> --token <token> --file 2026-07-05-stats252-split.flux`
+4. Verify row counts in `telem` / `pisugar` match the source, then (later,
+   once confident) delete `stats_252/autogen`. It is left intact as rollback.
+
+## Verify locally
+
+    cd local-testing
+    docker compose down -v && docker compose up -d --build influxdb
+    # seed a couple of legacy points:
+    docker compose exec influxdb influx write --org lemongrass --token local-dev-token \
+      --bucket 'stats_252/autogen' \
+      'rpm value=1234
+    pisugar-battery-level value=80'
+    # run the migration (placeholders substituted):
+    docker compose exec influxdb sh -c \
+      "influx query --org lemongrass --token local-dev-token '
+        from(bucket: \"stats_252/autogen\") |> range(start: 0)
+          |> filter(fn: (r) => not r._measurement =~ /^pisugar-/)
+          |> set(key: \"vin\", value: \"TESTVIN\") |> to(bucket: \"telem\")'"
+    # confirm the point landed vin-tagged in telem:
+    docker compose exec influxdb influx query --org lemongrass --token local-dev-token \
+      'from(bucket: "telem") |> range(start: 0) |> filter(fn: (r) => r._measurement == "rpm")'
+
+Expected: the `rpm` point appears in `telem` carrying `vin=TESTVIN`; the
+`pisugar-battery-level` point routes to `pisugar` with `host` when the second
+query is run analogously.

--- a/local-testing/migrations/README.md
+++ b/local-testing/migrations/README.md
@@ -32,7 +32,15 @@ InfluxDB after the `telem` and `pisugar` buckets exist.
     # confirm the point landed vin-tagged in telem:
     docker compose exec influxdb influx query --org lemongrass --token local-dev-token \
       'from(bucket: "telem") |> range(start: 0) |> filter(fn: (r) => r._measurement == "rpm")'
+    # run the pisugar half of the split:
+    docker compose exec influxdb sh -c \
+      "influx query --org lemongrass --token local-dev-token '
+        from(bucket: \"stats_252/autogen\") |> range(start: 0)
+          |> filter(fn: (r) => r._measurement =~ /^pisugar-/)
+          |> set(key: \"host\", value: \"TESTHOST\") |> to(bucket: \"pisugar\")'"
+    # confirm the point landed host-tagged in pisugar:
+    docker compose exec influxdb influx query --org lemongrass --token local-dev-token \
+      'from(bucket: "pisugar") |> range(start: 0) |> filter(fn: (r) => r._measurement == "pisugar-battery-level")'
 
-Expected: the `rpm` point appears in `telem` carrying `vin=TESTVIN`; the
-`pisugar-battery-level` point routes to `pisugar` with `host` when the second
-query is run analogously.
+Expected: the `rpm` point appears in `telem` carrying `vin=TESTVIN`, and the
+`pisugar-battery-level` point appears in `pisugar` carrying `host=TESTHOST`.

--- a/local-testing/migrations/README.md
+++ b/local-testing/migrations/README.md
@@ -9,8 +9,8 @@ InfluxDB after the `telem` and `pisugar` buckets exist.
 1. Edit `2026-07-05-stats252-split.flux`, replacing `CURRENT_CAR_VIN` with the
    car's VIN and `CURRENT_PI_HOSTNAME` with the Pi's hostname.
 2. Dry-run against the local stack first (see Verify).
-3. Run against the target:
-   `influx query --org <org> --token <token> --file 2026-07-05-stats252-split.flux`
+3. Run against the target (paths are relative to the repo root):
+   `influx query --org <org> --token <token> --file local-testing/migrations/2026-07-05-stats252-split.flux`
 4. Verify row counts in `telem` / `pisugar` match the source, then (later,
    once confident) delete `stats_252/autogen`. It is left intact as rollback.
 

--- a/src/lemongrass/_influx.py
+++ b/src/lemongrass/_influx.py
@@ -20,6 +20,12 @@ BUCKET_LAPS = 'laps'
 BUCKET_RACES = 'races'
 BUCKET_SESSIONS = 'race_sessions'
 
+# OBD car telemetry (vin-tagged) and PiSugar host telemetry (host-tagged),
+# born native v2 with bare names. The v2 write API matches the literal bucket
+# name and ignores DBRP, so these must be the exact write targets.
+BUCKET_TELEM = 'telem'
+BUCKET_PISUGAR = 'pisugar'
+
 # Bounded retry for transient failures (connection blips, retryable 5xx). We do
 # NOT honor Retry-After: a downed Cloudflare tunnel returns 530 with
 # Retry-After: 120, which would otherwise hang the CLI for minutes. allowed_methods

--- a/src/lemongrass/pisugar_monitor.py
+++ b/src/lemongrass/pisugar_monitor.py
@@ -5,6 +5,7 @@ import base64
 import json
 import logging
 import os
+import socket
 import sys
 import urllib.error
 import urllib.parse
@@ -35,6 +36,17 @@ def read_credentials():
         return config.get('auth_user'), config.get('auth_password')
     except (FileNotFoundError, json.JSONDecodeError):
         return None, None
+
+
+def _resolve_host():
+    """Host identity for tagging PiSugar (Pi) telemetry.
+
+    PiSugar data describes the Pi, not the car, so it is tagged by host rather
+    than VIN. HOST is wired to the Pi's real hostname in the deploy compose so
+    it matches telegraf's host tag; socket.gethostname() (the container ID under
+    Docker) is only a last-resort fallback.
+    """
+    return os.environ.get("HOST") or socket.gethostname()
 
 
 def login(username, password):
@@ -137,7 +149,7 @@ def write_points(write_api, points):
     reading has no value worth preserving.
     """
     try:
-        write_api.write(bucket='stats_252/autogen', record=points)
+        write_api.write(bucket=_influx.BUCKET_PISUGAR, record=points)
         logger.info("Wrote %d points to InfluxDB", len(points))
     except Exception:
         logger.exception("Failed to write %d points to InfluxDB", len(points))
@@ -153,6 +165,8 @@ def main():
 
     username, password = read_credentials()
     pisugar_token, device_tags = _startup_connect(username, password)
+    device_tags["host"] = _resolve_host()
+    logger.info("Tagging PiSugar telemetry with host=%s", device_tags["host"])
     logger.info("PiSugar device: %s", device_tags)
 
     with _influx.connect() as influx_client:

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -223,7 +223,10 @@ def _resolve_vin(connection):
     try:
         r = obd.OBD.query(connection, obd.commands.VIN, force=True)
         if r.value:
-            obd_vin = str(r.value).strip()
+            val = r.value
+            if isinstance(val, (bytes, bytearray)):
+                val = val.decode("ascii", errors="ignore")
+            obd_vin = str(val).strip()
     except Exception:
         logger.exception("VIN query failed; falling back to CAR_VIN")
 

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -94,7 +94,7 @@ _last_drop_warn_monotonic = float('-inf')
 
 
 def _queue_point(point):
-    """Append a point to the pending batch and mark data as flowing."""
+    """Append a point to the pending batch, tag it with vin, and mark data as flowing."""
     global _last_append_monotonic, _dropped_since_warn, _last_drop_warn_monotonic
     point.tag("vin", _vin)
     with pending_lock:
@@ -464,9 +464,9 @@ def main():
         logger.debug(connection.status())
 
         _connection = connection
-        _query_fuel_type_once(connection)
         _vin = _resolve_vin(connection)
         logger.info("Tagging telemetry with vin=%s", _vin)
+        _query_fuel_type_once(connection)
 
         for command in connection.supported_commands:
             callback = _route_command(command)

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -43,9 +43,7 @@ MAX_PENDING_POINTS = 50_000
 FLUSH_BATCH_SIZE = 5_000
 STATUS_COMMANDS = {"STATUS", "STATUS_DRIVE_CYCLE"}
 
-# Write bucket for both the live flush and spool replay; the v2 write path
-# ignores DBRP so the target bucket must carry this literal name.
-WRITE_BUCKET = 'stats_252/autogen'
+WRITE_BUCKET = _influx.BUCKET_TELEM
 
 # Influx client tuning for the 0.5s pump loop. A short per-request timeout and a
 # single retry keep a downed/hung Influx from blocking the hot path — the durable
@@ -75,6 +73,7 @@ pending_lock = threading.Lock()
 
 _connection = None  # set by main(); lets new_status trigger on-demand DTC lookups
 _spool: Spool | None = None  # set by main()
+_vin = "unknown"  # set by main() via _resolve_vin; tags every queued point
 # Outage state, edge-triggered so a sustained outage logs once (WARN) at onset
 # and once (INFO) on recovery instead of one line per 0.5s pump cycle. Only
 # touched from the main pump thread (flush_points), so no lock is needed.
@@ -97,6 +96,7 @@ _last_drop_warn_monotonic = float('-inf')
 def _queue_point(point):
     """Append a point to the pending batch and mark data as flowing."""
     global _last_append_monotonic, _dropped_since_warn, _last_drop_warn_monotonic
+    point.tag("vin", _vin)
     with pending_lock:
         pending_points.append(point)
         overflow = len(pending_points) - MAX_PENDING_POINTS
@@ -204,6 +204,35 @@ def _query_fuel_type_once(connection):
         return
 
     _queue_point(Point(measurement).field("value", r.value).time(ts))
+
+
+def _resolve_vin(connection):
+    """Resolve the car VIN for tagging: OBD Mode 09, then CAR_VIN env, then 'unknown'.
+
+    VIN is static per session, so main() calls this once and caches the result in
+    the module-level _vin. OBD is the source of truth; CAR_VIN is a fallback (and
+    the only source when Mode 09 is unsupported). A telemetry point is never
+    dropped for want of a VIN -- an unresolved VIN tags 'unknown' and logs.
+    """
+    obd_vin = None
+    try:
+        if connection.supports(obd.commands.VIN):
+            r = obd.OBD.query(connection, obd.commands.VIN, force=True)
+            if r.value:
+                obd_vin = str(r.value).strip()
+    except Exception:
+        logger.exception("VIN query failed; falling back to CAR_VIN")
+
+    env_vin = os.environ.get("CAR_VIN")
+    if obd_vin:
+        if env_vin and env_vin != obd_vin:
+            logger.warning(
+                "OBD VIN %s differs from CAR_VIN %s; using OBD VIN", obd_vin, env_vin)
+        return obd_vin
+    if env_vin:
+        return env_vin
+    logger.warning("VIN unresolved from OBD and CAR_VIN; tagging vin=unknown")
+    return "unknown"
 
 
 def _fetch_and_store_dtcs():
@@ -415,7 +444,7 @@ def _pump(write_api):
 
 def main():
     """Main loop of OBD-II scraping"""
-    global _connection, _last_append_monotonic, _spool
+    global _connection, _last_append_monotonic, _spool, _vin
 
     _spool = Spool.from_env()
 
@@ -436,6 +465,8 @@ def main():
 
         _connection = connection
         _query_fuel_type_once(connection)
+        _vin = _resolve_vin(connection)
+        logger.info("Tagging telemetry with vin=%s", _vin)
 
         for command in connection.supported_commands:
             callback = _route_command(command)

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -211,15 +211,19 @@ def _resolve_vin(connection):
 
     VIN is static per session, so main() calls this once and caches the result in
     the module-level _vin. OBD is the source of truth; CAR_VIN is a fallback (and
-    the only source when Mode 09 is unsupported). A telemetry point is never
+    the only source when the adapter returns no VIN). A telemetry point is never
     dropped for want of a VIN -- an unresolved VIN tags 'unknown' and logs.
+
+    The VIN is force-queried rather than gated on connection.supports(VIN): many
+    adapters (and the local emulator) under-report Mode 09 in the 0900 supported-
+    PIDs bitmask while still answering 0902, so gating on supports() would tag
+    'unknown' when the VIN is actually readable.
     """
     obd_vin = None
     try:
-        if connection.supports(obd.commands.VIN):
-            r = obd.OBD.query(connection, obd.commands.VIN, force=True)
-            if r.value:
-                obd_vin = str(r.value).strip()
+        r = obd.OBD.query(connection, obd.commands.VIN, force=True)
+        if r.value:
+            obd_vin = str(r.value).strip()
     except Exception:
         logger.exception("VIN query failed; falling back to CAR_VIN")
 

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -226,7 +226,8 @@ def _resolve_vin(connection):
             val = r.value
             if isinstance(val, (bytes, bytearray)):
                 val = val.decode("ascii", errors="ignore")
-            obd_vin = str(val).strip()
+            # Mode 09 VINs can arrive null-padded; strip whitespace and NULs.
+            obd_vin = str(val).strip().strip("\x00").strip()
     except Exception:
         logger.exception("VIN query failed; falling back to CAR_VIN")
 

--- a/tests/test_pisugar_monitor.py
+++ b/tests/test_pisugar_monitor.py
@@ -5,6 +5,7 @@ from urllib.error import URLError
 
 import pytest
 
+import lemongrass._influx as _influx
 import lemongrass.pisugar_monitor as _mod
 
 token_expiry = _mod.token_expiry
@@ -135,3 +136,26 @@ class TestStartupConnect:
                 token, _tags = _mod._startup_connect(None, None)
         assert token is None
         mock_login.assert_not_called()
+
+
+class TestResolveHost:
+    def test_uses_host_env_when_set(self, monkeypatch):
+        monkeypatch.setenv("HOST", "car-lemongrass-pi")
+        assert _mod._resolve_host() == "car-lemongrass-pi"
+
+    def test_falls_back_to_gethostname(self, monkeypatch):
+        monkeypatch.delenv("HOST", raising=False)
+        with patch.object(_mod.socket, "gethostname", return_value="fallback-host"):
+            assert _mod._resolve_host() == "fallback-host"
+
+
+class TestWritePointsBucket:
+    def test_writes_to_pisugar_bucket(self):
+        write_api = MagicMock()
+        _mod.write_points(write_api, [_mod.build_point("pisugar-temperature", 42.0)])
+        assert write_api.write.call_args.kwargs["bucket"] == _influx.BUCKET_PISUGAR
+
+    def test_build_point_carries_host_tag_and_no_vin(self):
+        point = _mod.build_point("pisugar-battery-level", 80, {"host": "pi-1"})
+        assert point._tags == {"host": "pi-1"}
+        assert "vin" not in point._tags

--- a/tests/test_telem.py
+++ b/tests/test_telem.py
@@ -292,10 +292,9 @@ class TestResolveVin:
     def setup_method(self):
         _reset()
 
-    def test_uses_obd_vin_when_supported(self, monkeypatch):
+    def test_uses_obd_vin_when_available(self, monkeypatch):
         monkeypatch.delenv("CAR_VIN", raising=False)
         connection = MagicMock()
-        connection.supports.return_value = True
         r = MagicMock()
         r.value = "1FATESTVIN0000001"
         with patch.object(_mod.obd.OBD, "query", return_value=r) as mock_query:
@@ -305,19 +304,31 @@ class TestResolveVin:
         )
         assert vin == "1FATESTVIN0000001"
 
-    def test_falls_back_to_env_when_obd_unsupported(self, monkeypatch):
-        monkeypatch.setenv("CAR_VIN", "ENVVIN00000000001")
+    def test_force_queries_vin_even_when_supports_false(self, monkeypatch):
+        monkeypatch.delenv("CAR_VIN", raising=False)
         connection = MagicMock()
         connection.supports.return_value = False
-        with patch.object(_mod.obd.OBD, "query") as mock_query:
+        r = MagicMock()
+        r.value = "1FATESTVIN0000004"
+        with patch.object(_mod.obd.OBD, "query", return_value=r) as mock_query:
             vin = _mod._resolve_vin(connection)
-        mock_query.assert_not_called()
+        mock_query.assert_called_once_with(
+            connection, _mod.obd.commands.VIN, force=True
+        )
+        assert vin == "1FATESTVIN0000004"
+
+    def test_falls_back_to_env_when_obd_returns_no_value(self, monkeypatch):
+        monkeypatch.setenv("CAR_VIN", "ENVVIN00000000001")
+        connection = MagicMock()
+        r = MagicMock()
+        r.value = None
+        with patch.object(_mod.obd.OBD, "query", return_value=r):
+            vin = _mod._resolve_vin(connection)
         assert vin == "ENVVIN00000000001"
 
     def test_falls_back_to_env_when_obd_query_raises(self, monkeypatch):
         monkeypatch.setenv("CAR_VIN", "ENVVIN00000000002")
         connection = MagicMock()
-        connection.supports.return_value = True
         with patch.object(_mod.obd.OBD, "query", side_effect=Exception("boom")):
             vin = _mod._resolve_vin(connection)
         assert vin == "ENVVIN00000000002"
@@ -325,7 +336,6 @@ class TestResolveVin:
     def test_unknown_when_nothing_resolves(self, monkeypatch):
         monkeypatch.delenv("CAR_VIN", raising=False)
         connection = MagicMock()
-        connection.supports.return_value = True
         r = MagicMock()
         r.value = None
         with patch.object(_mod.obd.OBD, "query", return_value=r):
@@ -335,7 +345,6 @@ class TestResolveVin:
     def test_warns_and_prefers_obd_on_mismatch(self, monkeypatch, caplog):
         monkeypatch.setenv("CAR_VIN", "ENVVIN00000000003")
         connection = MagicMock()
-        connection.supports.return_value = True
         r = MagicMock()
         r.value = "OBDVIN00000000003"
         with patch.object(_mod.obd.OBD, "query", return_value=r), \

--- a/tests/test_telem.py
+++ b/tests/test_telem.py
@@ -293,10 +293,12 @@ class TestResolveVin:
         _reset()
 
     def test_uses_obd_vin_when_available(self, monkeypatch):
+        # python-obd returns Mode 09 VIN as a bytearray; it must be decoded, not
+        # stringified (str(bytearray(...)) yields the literal "bytearray(b'...')").
         monkeypatch.delenv("CAR_VIN", raising=False)
         connection = MagicMock()
         r = MagicMock()
-        r.value = "1FATESTVIN0000001"
+        r.value = bytearray(b"1FATESTVIN0000001")
         with patch.object(_mod.obd.OBD, "query", return_value=r) as mock_query:
             vin = _mod._resolve_vin(connection)
         mock_query.assert_called_once_with(

--- a/tests/test_telem.py
+++ b/tests/test_telem.py
@@ -306,6 +306,16 @@ class TestResolveVin:
         )
         assert vin == "1FATESTVIN0000001"
 
+    def test_strips_null_padding_from_obd_vin(self, monkeypatch):
+        # A real Mode 09 response can be NUL-padded; the tag must not carry NULs.
+        monkeypatch.delenv("CAR_VIN", raising=False)
+        connection = MagicMock()
+        r = MagicMock()
+        r.value = bytearray(b"1FATESTVIN0000001\x00\x00\x00")
+        with patch.object(_mod.obd.OBD, "query", return_value=r):
+            vin = _mod._resolve_vin(connection)
+        assert vin == "1FATESTVIN0000001"
+
     def test_force_queries_vin_even_when_supports_false(self, monkeypatch):
         monkeypatch.delenv("CAR_VIN", raising=False)
         connection = MagicMock()

--- a/tests/test_telem.py
+++ b/tests/test_telem.py
@@ -24,6 +24,7 @@ def _reset():
     _mod._connection = None
     _mod._spool = None
     _mod._spooling = False
+    _mod._vin = "unknown"
 
 
 class TestConnect:
@@ -285,6 +286,63 @@ class TestQueryFuelTypeOnce:
                 patch.object(_mod, "Point", side_effect=capture_point):
             _mod._query_fuel_type_once(connection)
         assert captured_name[0] == "-Fuel-Type"
+
+
+class TestResolveVin:
+    def setup_method(self):
+        _reset()
+
+    def test_uses_obd_vin_when_supported(self, monkeypatch):
+        monkeypatch.delenv("CAR_VIN", raising=False)
+        connection = MagicMock()
+        connection.supports.return_value = True
+        r = MagicMock()
+        r.value = "1FATESTVIN0000001"
+        with patch.object(_mod.obd.OBD, "query", return_value=r) as mock_query:
+            vin = _mod._resolve_vin(connection)
+        mock_query.assert_called_once_with(
+            connection, _mod.obd.commands.VIN, force=True
+        )
+        assert vin == "1FATESTVIN0000001"
+
+    def test_falls_back_to_env_when_obd_unsupported(self, monkeypatch):
+        monkeypatch.setenv("CAR_VIN", "ENVVIN00000000001")
+        connection = MagicMock()
+        connection.supports.return_value = False
+        with patch.object(_mod.obd.OBD, "query") as mock_query:
+            vin = _mod._resolve_vin(connection)
+        mock_query.assert_not_called()
+        assert vin == "ENVVIN00000000001"
+
+    def test_falls_back_to_env_when_obd_query_raises(self, monkeypatch):
+        monkeypatch.setenv("CAR_VIN", "ENVVIN00000000002")
+        connection = MagicMock()
+        connection.supports.return_value = True
+        with patch.object(_mod.obd.OBD, "query", side_effect=Exception("boom")):
+            vin = _mod._resolve_vin(connection)
+        assert vin == "ENVVIN00000000002"
+
+    def test_unknown_when_nothing_resolves(self, monkeypatch):
+        monkeypatch.delenv("CAR_VIN", raising=False)
+        connection = MagicMock()
+        connection.supports.return_value = True
+        r = MagicMock()
+        r.value = None
+        with patch.object(_mod.obd.OBD, "query", return_value=r):
+            vin = _mod._resolve_vin(connection)
+        assert vin == "unknown"
+
+    def test_warns_and_prefers_obd_on_mismatch(self, monkeypatch, caplog):
+        monkeypatch.setenv("CAR_VIN", "ENVVIN00000000003")
+        connection = MagicMock()
+        connection.supports.return_value = True
+        r = MagicMock()
+        r.value = "OBDVIN00000000003"
+        with patch.object(_mod.obd.OBD, "query", return_value=r), \
+                caplog.at_level(logging.WARNING):
+            vin = _mod._resolve_vin(connection)
+        assert vin == "OBDVIN00000000003"
+        assert any("differs from CAR_VIN" in m for m in caplog.messages)
 
 
 class TestNewStatus:
@@ -714,8 +772,9 @@ class TestQueuePoint:
         _mod._last_append_monotonic = 0.0
 
     def test_appends_and_stamps_last_append_time(self):
-        _mod._queue_point("p")
-        assert _mod.pending_points == ["p"]
+        p = Point("p")
+        _mod._queue_point(p)
+        assert _mod.pending_points == [p]
         assert _mod._last_append_monotonic > 0
 
     def test_enqueue_capped_dropping_oldest_with_warning(self, caplog):
@@ -723,11 +782,12 @@ class TestQueuePoint:
         drop must leave a trace in the logs, matching flush_points."""
         _mod._dropped_since_warn = 0
         _mod._last_drop_warn_monotonic = float('-inf')
+        p1, p2, p3, p4 = Point("p1"), Point("p2"), Point("p3"), Point("p4")
         with patch.object(_mod, "MAX_PENDING_POINTS", 3):
-            _mod.pending_points.extend(["p1", "p2", "p3"])
+            _mod.pending_points.extend([p1, p2, p3])
             with caplog.at_level(logging.WARNING):
-                _mod._queue_point("p4")
-        assert _mod.pending_points == ["p2", "p3", "p4"]
+                _mod._queue_point(p4)
+        assert _mod.pending_points == [p2, p3, p4]
         assert any("dropped" in r.message.lower() for r in caplog.records)
 
     def test_enqueue_drop_warning_is_rate_limited(self, caplog):
@@ -735,12 +795,19 @@ class TestQueuePoint:
         saturation would otherwise flood journald with a line per callback."""
         _mod._dropped_since_warn = 0
         _mod._last_drop_warn_monotonic = float('-inf')
+        p1, p2, p3, p4, p5 = (
+            Point("p1"), Point("p2"), Point("p3"), Point("p4"), Point("p5"))
         with patch.object(_mod, "MAX_PENDING_POINTS", 3):
-            _mod.pending_points.extend(["p1", "p2", "p3"])
+            _mod.pending_points.extend([p1, p2, p3])
             with caplog.at_level(logging.WARNING):
-                _mod._queue_point("p4")
-                _mod._queue_point("p5")
+                _mod._queue_point(p4)
+                _mod._queue_point(p5)
         assert sum("dropped" in r.message.lower() for r in caplog.records) == 1
+
+    def test_tags_every_point_with_vin(self):
+        _mod._vin = "1FATESTVIN0000009"
+        _mod._queue_point(_mod.Point("rpm").field("value", 1))
+        assert _mod.pending_points[0]._tags == {"vin": "1FATESTVIN0000009"}
 
 
 class TestConnectionHealthy:


### PR DESCRIPTION
## Summary

Gives OBD telemetry a stable per-car **VIN** identity in a car-agnostic `telem` bucket, and re-homes PiSugar telemetry to its own `host`-tagged `pisugar` bucket — replacing the shared, car-specific `stats_252/autogen` bucket. Bucket names are centralized in `_influx.py` so a rename touches one place.

## Changes

**Telemetry (`telem.py`)**
- Resolves the car VIN once at startup via OBD Mode 09, falling back to `CAR_VIN` env, then `"unknown"` — a point is never dropped for want of identity.
- Tags every OBD `Point` with `vin` at the single `_queue_point` chokepoint; write bucket is now `_influx.BUCKET_TELEM` (`telem`).
- VIN is force-queried rather than gated on `connection.supports(VIN)`: adapters (and the emulator) routinely under-report Mode 09 in the `0900` supported-PIDs bitmask while still answering `0902`, so gating would mistag `unknown` when the VIN is readable.
- The VIN comes back as a `bytearray` from python-obd; it is decoded to a string and stripped of whitespace and NUL padding before tagging (avoiding a literal `bytearray(b'...')` value or a tag carrying embedded `\x00`).

**PiSugar (`pisugar_monitor.py`)**
- Drops all car identity; tags each point with `host` (from `HOST` env, else `socket.gethostname()`) and writes to `_influx.BUCKET_PISUGAR` (`pisugar`).

**Local testing**
- Init scripts create the `telem` and `pisugar` buckets + DBRPs; Grafana gains matching InfluxQL datasources (`wotl-telem-ql`, `wotl-pisugar-ql`).
- Race-control OBD panels read from `telem` and filter by a `vin` template variable; the embedded PiSugar panel reads from `pisugar`. The dedicated PiSugar dashboard reads from `pisugar`, filters by `host`, and is retitled "PiSugar UPS". The legacy `stats_252/autogen` bucket is still created so the migration is exercisable locally.

**Migration**
- One-time, idempotent, non-destructive Flux script (`local-testing/migrations/`) splits `stats_252/autogen` into `telem` (OBD → `vin`) and `pisugar` (PiSugar → `host`) by measurement prefix, leaving the source intact for rollback. Documented with a local verify procedure.

## Testing

- Full unit suite green (600 passed); ruff clean.
- VIN resolution and PiSugar host/bucket tagging covered by unit tests, including regression tests for the force-query, bytearray-decode, and NUL-padding-strip paths.
- Verified end-to-end against the local ELM327 emulator + InfluxDB + Grafana stack: telem tags the emulator VIN, dashboards render OBD data filtered by `vin`, and the migration routes seeded points to both buckets correctly.

## Follow-ups (cross-repo, deploy)

- Wire `HOST` in the deploy compose so PiSugar's `host` tag matches telegraf's.
- Repoint the production race-control PiSugar panel to the `pisugar` datasource (in production it still shares the OBD datasource; the local dashboard is already repointed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate telemetry paths for car data and PiSugar device metrics, with records now tagged by car VIN or host name.
  * Updated local dashboards to support selecting a car or host for filtered views.

* **Bug Fixes**
  * Improved local setup so new telemetry buckets are created and mapped correctly on first start.
  * Kept the legacy data bucket available for rollback and local migration checks.

* **Documentation**
  * Refreshed setup and migration guidance for the new bucket structure and verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
