### PR TITLE
feat(config)!: layered TOML configuration with secrets-only env

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,6 @@
+# Secrets — provide via the environment (never in lemongrass.toml).
 INFLUX_TELEMETRY_TOKEN=
-INFLUX_SYSTEM_TOKEN=
-RACEMONITOR_TOKEN=
+RACEMONITOR_TOKENS=
+
+# Optional: path to a TOML config file (see docs/CONFIGURATION.md).
+# LEMONGRASS_CONFIG=/etc/lemongrass/lemongrass.toml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,9 +36,10 @@ When prod is unavailable, run the full pipeline against a local InfluxDB.
    set -a && source local-testing/.env.local && set +a
    ```
 
-   This sets `INFLUX_URL=http://localhost:8086`, `INFLUX_ORG=lemongrass`, and
-   `INFLUX_TELEMETRY_TOKEN=local-dev-token`. (In prod these are unset and the CLI
-   falls back to `https://influxdb.focism.com` / `focism`.)
+   This sets `LEMONGRASS_CONFIG` to `local-testing/lemongrass.toml` — which points the CLI at
+   the local InfluxDB (`url = http://localhost:8086`, `org = lemongrass`) — and the secret
+   `INFLUX_TELEMETRY_TOKEN=local-dev-token`. (Without a config file the CLI uses its built-in
+   defaults, `https://influxdb.focism.com` / `focism`.)
 
 3. Seed data by running a one-shot pull from RaceMonitor. This calls the RaceMonitor API, so it
    needs your own RaceMonitor API token — this requires a Race Monitor account

--- a/README.md
+++ b/README.md
@@ -332,6 +332,15 @@ The `backfill` subcommand delegates to `lemongrass race-backfill` and supports t
 
 All lap points written to InfluxDB include a `session_id` tag corresponding to the RaceMonitor session ID. In Flux queries you can filter by `session_id` to isolate specific race segments (e.g. Day 1 vs. Day 2). Session metadata is stored in the `race_sessions` bucket.
 
+## Configuration
+
+lemongrass is configured by an optional TOML file named by the `LEMONGRASS_CONFIG` environment
+variable, falling back to built-in defaults. Secrets (`INFLUX_TELEMETRY_TOKEN`,
+`RACEMONITOR_TOKENS`) are supplied via the environment and referenced by `*_env` keys in the
+file — environment variables are not used for any non-secret setting. Copy
+`lemongrass.toml.sample` to get started. See [docs/CONFIGURATION.md](docs/CONFIGURATION.md) for
+the full key reference.
+
 ## Contributing
 
 For development setup, running the test suite, and testing against a local

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ The `backfill` subcommand delegates to `lemongrass race-backfill` and supports t
 | `--validate` | Check that every expected race has metadata and at least one lap in InfluxDB |
 | `--start-date YYYY-MM-DD` | Only include races starting on/after this date (default: 2017-01-01) |
 
-> **Note:** `--upgrade-stored` is mutually exclusive with `--force`, `--start-date`, and `--validate`.
+> **Note:** `--upgrade-stored` is mutually exclusive with `--start-date` and `--validate`; combine it with `--force` to also re-fetch races already at the current schema.
 
 ### Session Tracking
 

--- a/README.md
+++ b/README.md
@@ -321,12 +321,10 @@ The `backfill` subcommand delegates to `lemongrass race-backfill` and supports t
 | `--dry-run` | Print what would be backfilled without writing anything |
 | `--force` | Re-backfill every race, even those already complete and current |
 | `--upgrade-stored` | Re-process laps already in InfluxDB whose `schema_version` is older than current — faster than `--force` because it skips re-fetching from RaceMonitor |
-| `--override RACE_ID:CAR_NUMBER` | Override the default car number for a specific race (repeatable) |
-| `--validate` | Check that every expected race and car has data in InfluxDB |
-| `--start-year YEAR` | Only include races starting in this year or later (default: 2017) |
-| `--car NUMBER` | Default car number for all races (default: 252) |
+| `--validate` | Check that every expected race has metadata and at least one lap in InfluxDB |
+| `--start-date YYYY-MM-DD` | Only include races starting on/after this date (default: 2017-01-01) |
 
-> **Note:** `--upgrade-stored` is mutually exclusive with `--force`, `--override`, `--start-year`, `--car`, and `--validate`.
+> **Note:** `--upgrade-stored` is mutually exclusive with `--force`, `--start-date`, and `--validate`.
 
 ### Session Tracking
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -20,6 +20,32 @@ variable that holds each secret (`*_env` directives):
 | InfluxDB token | `influx.token_env` = `"INFLUX_TELEMETRY_TOKEN"` | value of that var |
 | RaceMonitor token pool | `racemonitor.tokens_env` = `"RACEMONITOR_TOKENS"` | comma-separated; legacy singular `RACEMONITOR_TOKEN` also honored |
 
+## Migrating from environment variables
+
+Earlier releases configured non-secret settings via environment variables. Those
+variables are **no longer read** — after upgrading, any setting still supplied that way
+silently falls back to its built-in default (no error). Move each one into the TOML
+file and point `LEMONGRASS_CONFIG` at it:
+
+| Old env var | TOML key |
+|---|---|
+| `INFLUX_URL` | `influx.url` |
+| `INFLUX_ORG` | `influx.org` |
+| `OBD_PORT` | `telem.obd.port` |
+| `OBD_BAUDRATE` | `telem.obd.baudrate` |
+| `OBD_DEBUG` | `telem.obd.debug` |
+| `CAR_VIN` | `telem.vin` |
+| `TELEM_SPOOL_DIR` | `telem.spool.dir` |
+| `TELEM_SPOOL_MAX_BYTES` | `telem.spool.max_size` |
+| `HOST` | `pisugar.host` |
+
+Only the secrets stay in the environment: `INFLUX_TELEMETRY_TOKEN` and
+`RACEMONITOR_TOKENS` / legacy `RACEMONITOR_TOKEN` (variable names configurable via the
+`*_env` directives above).
+
+The CLI prints a startup warning for each dropped variable it finds still set, except
+`HOST`, which shells commonly export on their own.
+
 ## Validation
 
 Config is validated on load and fails loud rather than silently misbehaving:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -22,10 +22,10 @@ variable that holds each secret (`*_env` directives):
 
 ## Migrating from environment variables
 
-Earlier releases configured non-secret settings via environment variables. Those
-variables are **no longer read** — after upgrading, any setting still supplied that way
-silently falls back to its built-in default (no error). Move each one into the TOML
-file and point `LEMONGRASS_CONFIG` at it:
+Releases up to and including v4.0.0 configured non-secret settings via environment
+variables. Those variables are **no longer read** — after upgrading, any setting still
+supplied that way silently falls back to its built-in default (no error). Move each one
+into the TOML file and point `LEMONGRASS_CONFIG` at it:
 
 | Old env var | TOML key |
 |---|---|
@@ -34,17 +34,12 @@ file and point `LEMONGRASS_CONFIG` at it:
 | `OBD_PORT` | `telem.obd.port` |
 | `OBD_BAUDRATE` | `telem.obd.baudrate` |
 | `OBD_DEBUG` | `telem.obd.debug` |
-| `CAR_VIN` | `telem.vin` |
-| `TELEM_SPOOL_DIR` | `telem.spool.dir` |
-| `TELEM_SPOOL_MAX_BYTES` | `telem.spool.max_size` |
-| `HOST` | `pisugar.host` |
 
 Only the secrets stay in the environment: `INFLUX_TELEMETRY_TOKEN` and
 `RACEMONITOR_TOKENS` / legacy `RACEMONITOR_TOKEN` (variable names configurable via the
 `*_env` directives above).
 
-The CLI prints a startup warning for each dropped variable it finds still set, except
-`HOST`, which shells commonly export on their own.
+The CLI prints a startup warning for each dropped variable it finds still set.
 
 ## Validation
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -48,7 +48,7 @@ Config is validated on load and fails loud rather than silently misbehaving:
 - `LEMONGRASS_CONFIG` set but the file is missing/unreadable → error.
 - Malformed TOML → error naming the file.
 - Unknown keys or sections (e.g. `bucket` vs `buckets`) → error.
-- Wrong value types (e.g. a quoted `default_start_year`) → error.
+- Wrong value types (e.g. a numeric `default_start_date`) → error.
 - An unparseable or non-positive `telem.spool.max_size` → error.
 
 ## Key reference
@@ -64,8 +64,7 @@ Config is validated on load and fails loud rather than silently misbehaving:
 | `influx.buckets.telem` | string | `telem` | OBD telemetry bucket |
 | `influx.buckets.pisugar` | string | `pisugar` | PiSugar telemetry bucket |
 | `races.backfill.search_terms` | list of strings | `["Real Hoopties", "GP du Lac", "Halloween Hoop"]` | RaceMonitor search terms |
-| `races.backfill.default_car_number` | string | `252` | default car number (`--car` overrides) |
-| `races.backfill.default_start_year` | int | `2017` | earliest year (`--start-year` overrides) |
+| `races.backfill.default_start_date` | string | `2017-01-01` | earliest race date, `YYYY-MM-DD` (`--start-date` overrides) |
 | `racemonitor.tokens_env` | string | `RACEMONITOR_TOKENS` | env var holding the token pool |
 | `telem.vin` | string | `""` | VIN fallback when OBD does not report one |
 | `telem.obd.port` | string | `/dev/obd` | OBD serial/socket port |
@@ -101,6 +100,5 @@ token_env = "INFLUX_TOKEN"
 
 [races.backfill]
 search_terms = ["Team2 Endurance", "Winter Grand Prix"]
-default_car_number = "42"
-default_start_year = 2021
+default_start_date = "2021-03-01"
 ```

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,85 @@
+# Configuration
+
+lemongrass reads its non-secret settings from two layers, highest priority first:
+
+1. **A TOML config file** — pointed to by the `LEMONGRASS_CONFIG` environment variable
+   (an absolute path). Optional; if unset, no file is read.
+2. **Built-in defaults** — the values shipped in the code.
+
+Environment variables are used **only for secrets** (see below) — they do not override any
+non-secret setting. With no config file, lemongrass runs on its built-in defaults. Copy
+`lemongrass.toml.sample` (every key at its default) as a starting point and edit down.
+
+## Secrets
+
+Secrets are never stored in the config file. The file instead names the environment
+variable that holds each secret (`*_env` directives):
+
+| Secret | Directive (default) | Env var read |
+|---|---|---|
+| InfluxDB token | `influx.token_env` = `"INFLUX_TELEMETRY_TOKEN"` | value of that var |
+| RaceMonitor token pool | `racemonitor.tokens_env` = `"RACEMONITOR_TOKENS"` | comma-separated; legacy singular `RACEMONITOR_TOKEN` also honored |
+
+## Validation
+
+Config is validated on load and fails loud rather than silently misbehaving:
+
+- `LEMONGRASS_CONFIG` set but the file is missing/unreadable → error.
+- Malformed TOML → error naming the file.
+- Unknown keys or sections (e.g. `bucket` vs `buckets`) → error.
+- Wrong value types (e.g. a quoted `default_start_year`) → error.
+- An unparseable or non-positive `telem.spool.max_size` → error.
+
+## Key reference
+
+| TOML key | Type | Default | Description |
+|---|---|---|---|
+| `influx.url` | string | `https://influxdb.focism.com` | InfluxDB base URL |
+| `influx.org` | string | `focism` | InfluxDB org |
+| `influx.token_env` | string | `INFLUX_TELEMETRY_TOKEN` | env var holding the Influx token |
+| `influx.buckets.laps` | string | `laps` | lap-data bucket |
+| `influx.buckets.races` | string | `races` | race-metadata bucket |
+| `influx.buckets.sessions` | string | `race_sessions` | session bucket |
+| `influx.buckets.telem` | string | `telem` | OBD telemetry bucket |
+| `influx.buckets.pisugar` | string | `pisugar` | PiSugar telemetry bucket |
+| `races.backfill.search_terms` | list of strings | `["Real Hoopties", "GP du Lac", "Halloween Hoop"]` | RaceMonitor search terms |
+| `races.backfill.default_car_number` | string | `252` | default car number (`--car` overrides) |
+| `races.backfill.default_start_year` | int | `2017` | earliest year (`--start-year` overrides) |
+| `racemonitor.tokens_env` | string | `RACEMONITOR_TOKENS` | env var holding the token pool |
+| `telem.vin` | string | `""` | VIN fallback when OBD does not report one |
+| `telem.obd.port` | string | `/dev/obd` | OBD serial/socket port |
+| `telem.obd.baudrate` | int | `0` | baud rate (`0` = auto-detect) |
+| `telem.obd.debug` | bool | `false` | verbose python-obd logging |
+| `telem.spool.dir` | string | `/data/telem-spool` | disk spool directory |
+| `telem.spool.max_size` | size | `1GiB` | spool cap; accepts `1GiB`/`1GB`/bytes int |
+| `pisugar.host` | string | `""` | host tag (`""` = system hostname) |
+| `pisugar.api_url` | string | `http://localhost:8421` | pisugar-server base URL |
+| `pisugar.config_path` | string | `/etc/pisugar-server/config.json` | pisugar credentials file |
+
+## Examples
+
+Override only the bucket names (e.g. a shared InfluxDB):
+
+```toml
+[influx.buckets]
+laps = "team2_laps"
+races = "team2_races"
+sessions = "team2_sessions"
+telem = "team2_telem"
+pisugar = "team2_pisugar"
+```
+
+A fresh fork pointing at its own races and InfluxDB, with the token in a differently named
+env var:
+
+```toml
+[influx]
+url = "https://influx.example.org"
+org = "team2"
+token_env = "INFLUX_TOKEN"
+
+[races.backfill]
+search_terms = ["Team2 Endurance", "Winter Grand Prix"]
+default_car_number = "42"
+default_start_year = 2021
+```

--- a/lemongrass.toml.sample
+++ b/lemongrass.toml.sample
@@ -1,0 +1,42 @@
+# lemongrass configuration — every key shown at its default value.
+# Copy this file, edit what you need, and point LEMONGRASS_CONFIG at it.
+# Precedence (highest wins): this file > built-in default.
+# Environment variables are used ONLY for secrets, named by the *_env keys below;
+# they do NOT override the non-secret settings in this file.
+
+[influx]
+url = "https://influxdb.focism.com"
+org = "focism"
+token_env = "INFLUX_TELEMETRY_TOKEN"       # name of the env var holding the Influx token
+
+[influx.buckets]
+laps = "laps"
+races = "races"
+sessions = "race_sessions"
+telem = "telem"
+pisugar = "pisugar"
+
+[races.backfill]
+search_terms = ["Real Hoopties", "GP du Lac", "Halloween Hoop"]
+default_car_number = "252"                 # overridable per-invocation via --car
+default_start_year = 2017                  # overridable per-invocation via --start-year
+
+[racemonitor]
+tokens_env = "RACEMONITOR_TOKENS"          # env var holding the comma-separated token pool
+
+[telem]
+vin = ""                                   # "" = resolve VIN from OBD
+
+[telem.obd]
+port = "/dev/obd"
+baudrate = 0                               # 0 = auto-detect
+debug = false
+
+[telem.spool]
+dir = "/data/telem-spool"
+max_size = "1GiB"                          # accepts 1GiB/1GB/bytes int
+
+[pisugar]
+host = ""                                  # "" = system hostname
+api_url = "http://localhost:8421"
+config_path = "/etc/pisugar-server/config.json"

--- a/lemongrass.toml.sample
+++ b/lemongrass.toml.sample
@@ -18,8 +18,7 @@ pisugar = "pisugar"
 
 [races.backfill]
 search_terms = ["Real Hoopties", "GP du Lac", "Halloween Hoop"]
-default_car_number = "252"                 # overridable per-invocation via --car
-default_start_year = 2017                  # overridable per-invocation via --start-year
+default_start_date = "2017-01-01"          # earliest race date, overridable via --start-date
 
 [racemonitor]
 tokens_env = "RACEMONITOR_TOKENS"          # env var holding the comma-separated token pool

--- a/local-testing/.env
+++ b/local-testing/.env
@@ -1,4 +1,5 @@
 # Single source of truth for the emulator's TCP port. Compose auto-loads this
 # file (it sits next to docker-compose.yml), so no --env-file flag is needed.
-# Referenced by the elm327 command, its healthcheck, and telem's OBD_PORT URL.
+# Referenced by the elm327 command and its healthcheck, and by telem's generated
+# OBD config (the socket:// URL).
 OBD_EMULATOR_PORT=35000

--- a/local-testing/.env.local
+++ b/local-testing/.env.local
@@ -1,8 +1,8 @@
 # App-side environment for running the lemongrass CLI against the LOCAL stack.
 # Usage:  set -a && source local-testing/.env.local && set +a   (then run `uv run lemongrass ...`)
-# These are non-secret, local-only values and are intentionally committed.
-INFLUX_URL=http://localhost:8086
-INFLUX_ORG=lemongrass
+# Non-secret settings live in local-testing/lemongrass.toml (LEMONGRASS_CONFIG points at it);
+# only the secret token is an env var. Non-secret, local-only values, committed on purpose.
+LEMONGRASS_CONFIG="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/lemongrass.toml"
 INFLUX_TELEMETRY_TOKEN=local-dev-token
 # Required only for `lemongrass races backfill` (pulls from RaceMonitor):
 # RACEMONITOR_TOKEN=

--- a/local-testing/docker-compose.yml
+++ b/local-testing/docker-compose.yml
@@ -57,12 +57,25 @@ services:
     build:
       context: ..
       dockerfile: Dockerfile
-    command: ["lemongrass", "telem"]
+    # Non-secret settings come from a generated TOML config (secrets-only env model).
+    # Generated at startup so the emulator port stays sourced from OBD_EMULATOR_PORT
+    # (compose interpolates ${OBD_EMULATOR_PORT} into the command, same as elm327).
+    command:
+      - /bin/sh
+      - -c
+      - |
+        cat > /tmp/lemongrass.toml <<'TOML'
+        [influx]
+        url = "http://influxdb:8086"
+        org = "lemongrass"
+
+        [telem.obd]
+        port = "socket://elm327:${OBD_EMULATOR_PORT}"
+        baudrate = 38400
+        TOML
+        exec lemongrass telem
     environment:
-      OBD_PORT: socket://elm327:${OBD_EMULATOR_PORT}
-      OBD_BAUDRATE: "38400"
-      INFLUX_URL: http://influxdb:8086
-      INFLUX_ORG: lemongrass
+      LEMONGRASS_CONFIG: /tmp/lemongrass.toml
       INFLUX_TELEMETRY_TOKEN: local-dev-token
     volumes:
       # Persist /data (the spool lives at /data/telem-spool) so buffered points

--- a/local-testing/lemongrass.toml
+++ b/local-testing/lemongrass.toml
@@ -1,0 +1,5 @@
+# Local dev config for running the lemongrass CLI (on the host) against the local stack.
+# Pointed to by LEMONGRASS_CONFIG in local-testing/.env.local. Non-secret, committed on purpose.
+[influx]
+url = "http://localhost:8086"
+org = "lemongrass"

--- a/src/lemongrass/_config.py
+++ b/src/lemongrass/_config.py
@@ -1,5 +1,7 @@
-"""Layered configuration for lemongrass: dataclass defaults, an optional TOML
-file (via LEMONGRASS_CONFIG), and environment-variable overrides.
+"""Layered configuration for lemongrass: dataclass defaults overlaid by an
+optional TOML file (via LEMONGRASS_CONFIG). Environment variables are read only
+for secrets, and only indirectly — a config value such as influx.token_env names
+the env var that holds the secret; the secret itself is never read in this module.
 
 This module is a leaf — it imports nothing else from lemongrass — so any command
 module can source its settings here without an import cycle.
@@ -7,7 +9,7 @@ module can source its settings here without an import cycle.
 import os
 import re
 import tomllib
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from pathlib import Path
 
 _SIZE_RE = re.compile(r'^\s*([0-9]*\.?[0-9]+)\s*([KMGTP]I?B|B)?\s*$', re.IGNORECASE)
@@ -116,13 +118,15 @@ class Config:
 
 
 def load_config():
-    """Build the config: dataclass defaults, overlaid by the TOML file named in
-    LEMONGRASS_CONFIG (if set), overlaid by environment-variable overrides.
+    """Build the config: dataclass defaults overlaid by the TOML file named in
+    LEMONGRASS_CONFIG (if set). There is no environment-override layer — env is
+    used only for secrets, which are referenced indirectly by the *_env config
+    values and read at their point of use, never here.
 
-    Not memoized — called at import/startup only, so reading env fresh each call
-    keeps behavior predictable under test monkeypatching.
+    Not memoized — called at import/startup only, so reading the file fresh each
+    call keeps behavior predictable under test monkeypatching.
     """
-    return _apply_env(_build_config(_read_file()))
+    return _build_config(_read_file())
 
 
 def _read_file():
@@ -252,48 +256,3 @@ def _build_pisugar(d):
         api_url=_typed(d, 'api_url', dflt.api_url, str, 'pisugar'),
         config_path=_typed(d, 'config_path', dflt.config_path, str, 'pisugar'),
     )
-
-
-def _env_int(name, default):
-    raw = os.environ.get(name)
-    if not raw:
-        return default
-    try:
-        return int(raw)
-    except ValueError:
-        raise ConfigError(f"{name} must be an integer, got {raw!r}") from None
-
-
-def _apply_env(cfg):
-    influx = replace(
-        cfg.influx,
-        url=os.environ.get('INFLUX_URL', cfg.influx.url),
-        org=os.environ.get('INFLUX_ORG', cfg.influx.org),
-    )
-    obd = replace(
-        cfg.telem.obd,
-        port=os.environ.get('OBD_PORT', cfg.telem.obd.port),
-        baudrate=_env_int('OBD_BAUDRATE', cfg.telem.obd.baudrate),
-        debug=cfg.telem.obd.debug or bool(os.environ.get('OBD_DEBUG')),
-    )
-    max_size = cfg.telem.spool.max_size
-    raw_max = os.environ.get('TELEM_SPOOL_MAX_SIZE')
-    if raw_max:
-        try:
-            max_size = parse_size(raw_max)
-        except ValueError as e:
-            raise ConfigError(f"TELEM_SPOOL_MAX_SIZE: {e}") from e
-    spool = replace(
-        cfg.telem.spool,
-        dir=os.environ.get('TELEM_SPOOL_DIR', cfg.telem.spool.dir),
-        max_size=max_size,
-    )
-    telem = replace(
-        cfg.telem,
-        vin=os.environ.get('CAR_VIN', cfg.telem.vin),
-        obd=obd,
-        spool=spool,
-    )
-    pisugar = replace(cfg.pisugar,
-                      host=os.environ.get('PISUGAR_HOST', cfg.pisugar.host))
-    return replace(cfg, influx=influx, telem=telem, pisugar=pisugar)

--- a/src/lemongrass/_config.py
+++ b/src/lemongrass/_config.py
@@ -13,20 +13,17 @@ import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
 
-# Non-secret env vars read by pre-config releases and dropped in the
+# Non-secret env vars read by released versions (<= v4.0.0) and dropped in the
 # secrets-only model; a deployment still setting one silently runs on defaults.
-# HOST was also read (pisugar host tag) but is excluded here: zsh exports HOST
-# in every interactive shell, so warning on it would be permanent noise — its
-# migration to pisugar.host is covered in docs/CONFIGURATION.md instead.
+# Vars introduced after v4.0.0 and replaced by config before ever shipping in a
+# release (CAR_VIN, HOST, TELEM_SPOOL_DIR, TELEM_SPOOL_MAX_BYTES) are excluded:
+# they were never a public interface, so there is nothing to migrate.
 _DROPPED_ENV_VARS = {
     'INFLUX_URL': 'influx.url',
     'INFLUX_ORG': 'influx.org',
     'OBD_PORT': 'telem.obd.port',
     'OBD_BAUDRATE': 'telem.obd.baudrate',
     'OBD_DEBUG': 'telem.obd.debug',
-    'CAR_VIN': 'telem.vin',
-    'TELEM_SPOOL_DIR': 'telem.spool.dir',
-    'TELEM_SPOOL_MAX_BYTES': 'telem.spool.max_size',
 }
 
 

--- a/src/lemongrass/_config.py
+++ b/src/lemongrass/_config.py
@@ -8,9 +8,35 @@ module can source its settings here without an import cycle.
 """
 import os
 import re
+import sys
 import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
+
+# Non-secret env vars read by pre-config releases and dropped in the
+# secrets-only model; a deployment still setting one silently runs on defaults.
+# HOST was also read (pisugar host tag) but is excluded here: zsh exports HOST
+# in every interactive shell, so warning on it would be permanent noise — its
+# migration to pisugar.host is covered in docs/CONFIGURATION.md instead.
+_DROPPED_ENV_VARS = {
+    'INFLUX_URL': 'influx.url',
+    'INFLUX_ORG': 'influx.org',
+    'OBD_PORT': 'telem.obd.port',
+    'OBD_BAUDRATE': 'telem.obd.baudrate',
+    'OBD_DEBUG': 'telem.obd.debug',
+    'CAR_VIN': 'telem.vin',
+    'TELEM_SPOOL_DIR': 'telem.spool.dir',
+    'TELEM_SPOOL_MAX_BYTES': 'telem.spool.max_size',
+}
+
+
+def warn_dropped_env_vars():
+    """Print a stderr warning for each legacy non-secret env var still set."""
+    for var, key in sorted(_DROPPED_ENV_VARS.items()):
+        if var in os.environ:
+            print(f"Warning: {var} is set but no longer read; set {key} in the "
+                  "TOML file named by LEMONGRASS_CONFIG instead "
+                  "(see docs/CONFIGURATION.md)", file=sys.stderr)
 
 _SIZE_RE = re.compile(r'^\s*([0-9]*\.?[0-9]+)\s*([KMGTP]I?B|B)?\s*$', re.IGNORECASE)
 _SIZE_UNITS = {

--- a/src/lemongrass/_config.py
+++ b/src/lemongrass/_config.py
@@ -1,0 +1,37 @@
+"""Layered configuration for lemongrass: dataclass defaults, an optional TOML
+file (via LEMONGRASS_CONFIG), and environment-variable overrides.
+
+This module is a leaf — it imports nothing else from lemongrass — so any command
+module can source its settings here without an import cycle.
+"""
+import re
+
+_SIZE_RE = re.compile(r'^\s*([0-9]*\.?[0-9]+)\s*([KMGTP]I?B|B)?\s*$', re.IGNORECASE)
+_SIZE_UNITS = {
+    '': 1, 'B': 1,
+    'KB': 1000, 'MB': 1000 ** 2, 'GB': 1000 ** 3, 'TB': 1000 ** 4, 'PB': 1000 ** 5,
+    'KIB': 1024, 'MIB': 1024 ** 2, 'GIB': 1024 ** 3, 'TIB': 1024 ** 4, 'PIB': 1024 ** 5,
+}
+
+
+def parse_size(value):
+    """Parse a byte size from an int/float (bytes) or a unit string like "1GiB".
+
+    Binary units (KiB..PiB) are powers of 1024; decimal units (KB..PB) powers of
+    1000; a bare number or a `B` suffix is bytes. Case-insensitive, whitespace and
+    fractions allowed. Raises ValueError on an unparseable or non-positive value.
+    """
+    if isinstance(value, bool):
+        raise ValueError(f"invalid size: {value!r}")
+    if isinstance(value, (int, float)):
+        n = int(value)
+    elif isinstance(value, str):
+        m = _SIZE_RE.match(value)
+        if not m:
+            raise ValueError(f"invalid size: {value!r}")
+        n = int(float(m.group(1)) * _SIZE_UNITS[(m.group(2) or '').upper()])
+    else:
+        raise ValueError(f"invalid size: {value!r}")
+    if n <= 0:
+        raise ValueError(f"size must be positive: {value!r}")
+    return n

--- a/src/lemongrass/_config.py
+++ b/src/lemongrass/_config.py
@@ -94,8 +94,7 @@ class InfluxConfig:
 @dataclass(frozen=True)
 class BackfillConfig:
     search_terms: tuple = ('Real Hoopties', 'GP du Lac', 'Halloween Hoop')
-    default_car_number: str = '252'
-    default_start_year: int = 2017
+    default_start_date: str = '2017-01-01'
 
 
 @dataclass(frozen=True)
@@ -231,16 +230,13 @@ def _build_influx(d):
 def _build_races(d):
     _reject_unknown(d, {'backfill'}, 'races')
     bf = d.get('backfill', {})
-    _reject_unknown(bf, {'search_terms', 'default_car_number', 'default_start_year'},
-                    'races.backfill')
+    _reject_unknown(bf, {'search_terms', 'default_start_date'}, 'races.backfill')
     dflt = BackfillConfig()
     return RacesConfig(backfill=BackfillConfig(
         search_terms=_typed(bf, 'search_terms', dflt.search_terms, tuple,
                             'races.backfill'),
-        default_car_number=_typed(bf, 'default_car_number', dflt.default_car_number,
+        default_start_date=_typed(bf, 'default_start_date', dflt.default_start_date,
                                   str, 'races.backfill'),
-        default_start_year=_typed(bf, 'default_start_year', dflt.default_start_year,
-                                  int, 'races.backfill'),
     ))
 
 

--- a/src/lemongrass/_config.py
+++ b/src/lemongrass/_config.py
@@ -30,6 +30,10 @@ def parse_size(value):
     if isinstance(value, bool):
         raise ValueError(f"invalid size: {value!r}")
     if isinstance(value, (int, float)):
+        if isinstance(value, float) and not value.is_integer():
+            raise ValueError(
+                f"size must be a whole number of bytes: {value!r}"
+                " (for fractional units use a string like \"1.5GiB\")")
         n = int(value)
     elif isinstance(value, str):
         m = _SIZE_RE.match(value)
@@ -145,6 +149,8 @@ def _read_file():
 
 
 def _reject_unknown(d, allowed, where):
+    if not isinstance(d, dict):
+        raise ConfigError(f"[{where}] must be a table, not {type(d).__name__}")
     extra = set(d) - allowed
     if extra:
         raise ConfigError(f"unknown key(s) in [{where}]: {', '.join(sorted(extra))}")

--- a/src/lemongrass/_config.py
+++ b/src/lemongrass/_config.py
@@ -4,7 +4,11 @@ file (via LEMONGRASS_CONFIG), and environment-variable overrides.
 This module is a leaf — it imports nothing else from lemongrass — so any command
 module can source its settings here without an import cycle.
 """
+import os
 import re
+import tomllib
+from dataclasses import dataclass, field, replace
+from pathlib import Path
 
 _SIZE_RE = re.compile(r'^\s*([0-9]*\.?[0-9]+)\s*([KMGTP]I?B|B)?\s*$', re.IGNORECASE)
 _SIZE_UNITS = {
@@ -35,3 +39,261 @@ def parse_size(value):
     if n <= 0:
         raise ValueError(f"size must be positive: {value!r}")
     return n
+
+
+class ConfigError(Exception):
+    """Raised for a malformed/unreadable config file or invalid config values."""
+
+
+@dataclass(frozen=True)
+class Buckets:
+    laps: str = 'laps'
+    races: str = 'races'
+    sessions: str = 'race_sessions'
+    telem: str = 'telem'
+    pisugar: str = 'pisugar'
+
+
+@dataclass(frozen=True)
+class InfluxConfig:
+    url: str = 'https://influxdb.focism.com'
+    org: str = 'focism'
+    token_env: str = 'INFLUX_TELEMETRY_TOKEN'
+    buckets: Buckets = field(default_factory=Buckets)
+
+
+@dataclass(frozen=True)
+class BackfillConfig:
+    search_terms: tuple = ('Real Hoopties', 'GP du Lac', 'Halloween Hoop')
+    default_car_number: str = '252'
+    default_start_year: int = 2017
+
+
+@dataclass(frozen=True)
+class RacesConfig:
+    backfill: BackfillConfig = field(default_factory=BackfillConfig)
+
+
+@dataclass(frozen=True)
+class RaceMonitorConfig:
+    tokens_env: str = 'RACEMONITOR_TOKENS'
+
+
+@dataclass(frozen=True)
+class ObdConfig:
+    port: str = '/dev/obd'
+    baudrate: int = 0
+    debug: bool = False
+
+
+@dataclass(frozen=True)
+class SpoolConfig:
+    dir: str = '/data/telem-spool'
+    max_size: int = 1024 ** 3
+
+
+@dataclass(frozen=True)
+class TelemConfig:
+    vin: str = ''
+    obd: ObdConfig = field(default_factory=ObdConfig)
+    spool: SpoolConfig = field(default_factory=SpoolConfig)
+
+
+@dataclass(frozen=True)
+class PisugarConfig:
+    host: str = ''
+    api_url: str = 'http://localhost:8421'
+    config_path: str = '/etc/pisugar-server/config.json'
+
+
+@dataclass(frozen=True)
+class Config:
+    influx: InfluxConfig = field(default_factory=InfluxConfig)
+    races: RacesConfig = field(default_factory=RacesConfig)
+    racemonitor: RaceMonitorConfig = field(default_factory=RaceMonitorConfig)
+    telem: TelemConfig = field(default_factory=TelemConfig)
+    pisugar: PisugarConfig = field(default_factory=PisugarConfig)
+
+
+def load_config():
+    """Build the config: dataclass defaults, overlaid by the TOML file named in
+    LEMONGRASS_CONFIG (if set), overlaid by environment-variable overrides.
+
+    Not memoized — called at import/startup only, so reading env fresh each call
+    keeps behavior predictable under test monkeypatching.
+    """
+    return _apply_env(_build_config(_read_file()))
+
+
+def _read_file():
+    path = os.environ.get('LEMONGRASS_CONFIG')
+    if not path:
+        return {}
+    p = Path(path)
+    try:
+        raw = p.read_bytes()
+    except OSError as e:
+        raise ConfigError(f"LEMONGRASS_CONFIG={path!r} could not be read: {e}") from e
+    try:
+        return tomllib.loads(raw.decode('utf-8'))
+    except (tomllib.TOMLDecodeError, UnicodeDecodeError) as e:
+        raise ConfigError(f"LEMONGRASS_CONFIG={path!r} is not valid TOML: {e}") from e
+
+
+def _reject_unknown(d, allowed, where):
+    extra = set(d) - allowed
+    if extra:
+        raise ConfigError(f"unknown key(s) in [{where}]: {', '.join(sorted(extra))}")
+
+
+def _typed(d, key, default, kind, where):
+    if key not in d:
+        return default
+    v = d[key]
+    if kind is str and not isinstance(v, str):
+        raise ConfigError(f"{where}.{key} must be a string")
+    if kind is int and (isinstance(v, bool) or not isinstance(v, int)):
+        raise ConfigError(f"{where}.{key} must be an integer")
+    if kind is bool and not isinstance(v, bool):
+        raise ConfigError(f"{where}.{key} must be a boolean")
+    if kind is tuple:
+        if not (isinstance(v, list) and all(isinstance(x, str) for x in v)):
+            raise ConfigError(f"{where}.{key} must be a list of strings")
+        return tuple(v)
+    return v
+
+
+def _build_config(data):
+    _reject_unknown(data, {'influx', 'races', 'racemonitor', 'telem', 'pisugar'},
+                    'top level')
+    return Config(
+        influx=_build_influx(data.get('influx', {})),
+        races=_build_races(data.get('races', {})),
+        racemonitor=_build_racemonitor(data.get('racemonitor', {})),
+        telem=_build_telem(data.get('telem', {})),
+        pisugar=_build_pisugar(data.get('pisugar', {})),
+    )
+
+
+def _build_influx(d):
+    _reject_unknown(d, {'url', 'org', 'token_env', 'buckets'}, 'influx')
+    b = d.get('buckets', {})
+    _reject_unknown(b, {'laps', 'races', 'sessions', 'telem', 'pisugar'},
+                    'influx.buckets')
+    dflt, bd = InfluxConfig(), Buckets()
+    return InfluxConfig(
+        url=_typed(d, 'url', dflt.url, str, 'influx'),
+        org=_typed(d, 'org', dflt.org, str, 'influx'),
+        token_env=_typed(d, 'token_env', dflt.token_env, str, 'influx'),
+        buckets=Buckets(
+            laps=_typed(b, 'laps', bd.laps, str, 'influx.buckets'),
+            races=_typed(b, 'races', bd.races, str, 'influx.buckets'),
+            sessions=_typed(b, 'sessions', bd.sessions, str, 'influx.buckets'),
+            telem=_typed(b, 'telem', bd.telem, str, 'influx.buckets'),
+            pisugar=_typed(b, 'pisugar', bd.pisugar, str, 'influx.buckets'),
+        ),
+    )
+
+
+def _build_races(d):
+    _reject_unknown(d, {'backfill'}, 'races')
+    bf = d.get('backfill', {})
+    _reject_unknown(bf, {'search_terms', 'default_car_number', 'default_start_year'},
+                    'races.backfill')
+    dflt = BackfillConfig()
+    return RacesConfig(backfill=BackfillConfig(
+        search_terms=_typed(bf, 'search_terms', dflt.search_terms, tuple,
+                            'races.backfill'),
+        default_car_number=_typed(bf, 'default_car_number', dflt.default_car_number,
+                                  str, 'races.backfill'),
+        default_start_year=_typed(bf, 'default_start_year', dflt.default_start_year,
+                                  int, 'races.backfill'),
+    ))
+
+
+def _build_racemonitor(d):
+    _reject_unknown(d, {'tokens_env'}, 'racemonitor')
+    dflt = RaceMonitorConfig()
+    return RaceMonitorConfig(
+        tokens_env=_typed(d, 'tokens_env', dflt.tokens_env, str, 'racemonitor'))
+
+
+def _build_telem(d):
+    _reject_unknown(d, {'vin', 'obd', 'spool'}, 'telem')
+    obd_d, spool_d = d.get('obd', {}), d.get('spool', {})
+    _reject_unknown(obd_d, {'port', 'baudrate', 'debug'}, 'telem.obd')
+    _reject_unknown(spool_d, {'dir', 'max_size'}, 'telem.spool')
+    dflt, od, sd = TelemConfig(), ObdConfig(), SpoolConfig()
+    max_size = sd.max_size
+    if 'max_size' in spool_d:
+        try:
+            max_size = parse_size(spool_d['max_size'])
+        except ValueError as e:
+            raise ConfigError(f"telem.spool.max_size: {e}") from e
+    return TelemConfig(
+        vin=_typed(d, 'vin', dflt.vin, str, 'telem'),
+        obd=ObdConfig(
+            port=_typed(obd_d, 'port', od.port, str, 'telem.obd'),
+            baudrate=_typed(obd_d, 'baudrate', od.baudrate, int, 'telem.obd'),
+            debug=_typed(obd_d, 'debug', od.debug, bool, 'telem.obd'),
+        ),
+        spool=SpoolConfig(
+            dir=_typed(spool_d, 'dir', sd.dir, str, 'telem.spool'),
+            max_size=max_size,
+        ),
+    )
+
+
+def _build_pisugar(d):
+    _reject_unknown(d, {'host', 'api_url', 'config_path'}, 'pisugar')
+    dflt = PisugarConfig()
+    return PisugarConfig(
+        host=_typed(d, 'host', dflt.host, str, 'pisugar'),
+        api_url=_typed(d, 'api_url', dflt.api_url, str, 'pisugar'),
+        config_path=_typed(d, 'config_path', dflt.config_path, str, 'pisugar'),
+    )
+
+
+def _env_int(name, default):
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        raise ConfigError(f"{name} must be an integer, got {raw!r}") from None
+
+
+def _apply_env(cfg):
+    influx = replace(
+        cfg.influx,
+        url=os.environ.get('INFLUX_URL', cfg.influx.url),
+        org=os.environ.get('INFLUX_ORG', cfg.influx.org),
+    )
+    obd = replace(
+        cfg.telem.obd,
+        port=os.environ.get('OBD_PORT', cfg.telem.obd.port),
+        baudrate=_env_int('OBD_BAUDRATE', cfg.telem.obd.baudrate),
+        debug=cfg.telem.obd.debug or bool(os.environ.get('OBD_DEBUG')),
+    )
+    max_size = cfg.telem.spool.max_size
+    raw_max = os.environ.get('TELEM_SPOOL_MAX_SIZE')
+    if raw_max:
+        try:
+            max_size = parse_size(raw_max)
+        except ValueError as e:
+            raise ConfigError(f"TELEM_SPOOL_MAX_SIZE: {e}") from e
+    spool = replace(
+        cfg.telem.spool,
+        dir=os.environ.get('TELEM_SPOOL_DIR', cfg.telem.spool.dir),
+        max_size=max_size,
+    )
+    telem = replace(
+        cfg.telem,
+        vin=os.environ.get('CAR_VIN', cfg.telem.vin),
+        obd=obd,
+        spool=spool,
+    )
+    pisugar = replace(cfg.pisugar,
+                      host=os.environ.get('PISUGAR_HOST', cfg.pisugar.host))
+    return replace(cfg, influx=influx, telem=telem, pisugar=pisugar)

--- a/src/lemongrass/_env.py
+++ b/src/lemongrass/_env.py
@@ -3,8 +3,11 @@ import os
 
 
 def resolve_tokens() -> str | list[str]:
-    """Return tokens from RACEMONITOR_TOKENS (comma-separated) or fall back to RACEMONITOR_TOKEN."""
-    multi = os.environ.get('RACEMONITOR_TOKENS')
+    """Return tokens from the configured pool var (comma-separated) or fall back
+    to the legacy singular RACEMONITOR_TOKEN."""
+    from lemongrass import _config
+    pool_var = _config.load_config().racemonitor.tokens_env
+    multi = os.environ.get(pool_var)
     if multi:
         tokens = [t.strip() for t in multi.split(',') if t.strip()]
         if len(tokens) > 1:

--- a/src/lemongrass/_env.py
+++ b/src/lemongrass/_env.py
@@ -1,12 +1,25 @@
 """Environment variable helpers shared across lemongrass commands."""
 import os
 
+_LEGACY_TOKEN_VAR = 'RACEMONITOR_TOKEN'
+
+
+def _pool_var() -> str:
+    from lemongrass import _config
+    return _config.load_config().racemonitor.tokens_env
+
+
+def _legacy_applies(pool_var: str) -> bool:
+    # The legacy singular var is honored only alongside the default pool var; a
+    # deployment that names its own pool var must not pick up a stale leftover.
+    from lemongrass import _config
+    return pool_var == _config.RaceMonitorConfig().tokens_env
+
 
 def resolve_tokens() -> str | list[str]:
     """Return tokens from the configured pool var (comma-separated) or fall back
     to the legacy singular RACEMONITOR_TOKEN."""
-    from lemongrass import _config
-    pool_var = _config.load_config().racemonitor.tokens_env
+    pool_var = _pool_var()
     multi = os.environ.get(pool_var)
     if multi:
         tokens = [t.strip() for t in multi.split(',') if t.strip()]
@@ -14,4 +27,14 @@ def resolve_tokens() -> str | list[str]:
             return tokens
         if tokens:
             return tokens[0]
-    return os.environ.get('RACEMONITOR_TOKEN', '')
+    if _legacy_applies(pool_var):
+        return os.environ.get(_LEGACY_TOKEN_VAR, '')
+    return ''
+
+
+def tokens_env_hint() -> str:
+    """Name the env var(s) consulted by resolve_tokens(), for error messages."""
+    pool_var = _pool_var()
+    if _legacy_applies(pool_var):
+        return f"{pool_var} or {_LEGACY_TOKEN_VAR}"
+    return pool_var

--- a/src/lemongrass/_influx.py
+++ b/src/lemongrass/_influx.py
@@ -11,20 +11,25 @@ import sys
 
 from urllib3 import Retry
 
-INFLUX_URL = os.environ.get('INFLUX_URL', 'https://influxdb.focism.com')
-INFLUX_ORG = os.environ.get('INFLUX_ORG', 'focism')
+from lemongrass import _config
+
+_cfg = _config.load_config()
+
+INFLUX_URL = _cfg.influx.url
+INFLUX_ORG = _cfg.influx.org
 
 # Bucket names, shared across the write paths and Flux queries (and created by
-# local-testing/influx-init). Single source of truth so a rename touches one place.
-BUCKET_LAPS = 'laps'
-BUCKET_RACES = 'races'
-BUCKET_SESSIONS = 'race_sessions'
+# local-testing/influx-init). Sourced from the config layer; defaults are the
+# historical literals so a no-config deployment is unchanged.
+BUCKET_LAPS = _cfg.influx.buckets.laps
+BUCKET_RACES = _cfg.influx.buckets.races
+BUCKET_SESSIONS = _cfg.influx.buckets.sessions
 
 # OBD car telemetry (vin-tagged) and PiSugar host telemetry (host-tagged),
 # born native v2 with bare names. The v2 write API matches the literal bucket
 # name and ignores DBRP, so these must be the exact write targets.
-BUCKET_TELEM = 'telem'
-BUCKET_PISUGAR = 'pisugar'
+BUCKET_TELEM = _cfg.influx.buckets.telem
+BUCKET_PISUGAR = _cfg.influx.buckets.pisugar
 
 # Bounded retry for transient failures (connection blips, retryable 5xx). We do
 # NOT honor Retry-After: a downed Cloudflare tunnel returns 530 with
@@ -61,7 +66,7 @@ def connect(timeout=None, retries=INFLUX_RETRIES):
     spool; when timeout is None the influxdb-client library default (10s) applies
     so batch callers are unaffected.
     """
-    token = os.environ.get('INFLUX_TELEMETRY_TOKEN')
+    token = os.environ.get(_config.load_config().influx.token_env)
     if not token:
         logging.error("INFLUX_TELEMETRY_TOKEN environment variable not set")
         sys.exit(1)

--- a/src/lemongrass/_influx.py
+++ b/src/lemongrass/_influx.py
@@ -1,7 +1,7 @@
 """Shared InfluxDB connection settings for lemongrass commands.
 
-Centralizes the URL/org (env-overridable, defaulting to prod), the retry policy,
-and the token-reading client factory so every command constructs its
+Centralizes the URL/org (from the config layer, defaulting to prod), the retry
+policy, and the token-reading client factory so every command constructs its
 InfluxDBClient the same way.
 """
 import logging
@@ -58,17 +58,19 @@ INFLUX_RETRIES = build_retries(3)
 def connect(timeout=None, retries=INFLUX_RETRIES):
     """Return an InfluxDBClient wired with the shared URL/org/retries.
 
-    Reads the token from INFLUX_TELEMETRY_TOKEN; logs an error and exits with
-    status 1 if it is unset. The InfluxDBClient import is deferred so importing
-    this module (which every command does) stays cheap.
+    Reads the token from the env var named by `influx.token_env` (default
+    INFLUX_TELEMETRY_TOKEN); logs an error and exits with status 1 if it is
+    unset. The InfluxDBClient import is deferred so importing this module
+    (which every command does) stays cheap.
 
     `timeout` (ms) and `retries` let the telemetry hot loop fail fast to its
     spool; when timeout is None the influxdb-client library default (10s) applies
     so batch callers are unaffected.
     """
-    token = os.environ.get(_config.load_config().influx.token_env)
+    token_env = _config.load_config().influx.token_env
+    token = os.environ.get(token_env)
     if not token:
-        logging.error("INFLUX_TELEMETRY_TOKEN environment variable not set")
+        logging.error("%s environment variable not set", token_env)
         sys.exit(1)
     from influxdb_client import InfluxDBClient
     kwargs = {'url': INFLUX_URL, 'token': token, 'org': INFLUX_ORG,

--- a/src/lemongrass/_spool.py
+++ b/src/lemongrass/_spool.py
@@ -116,7 +116,7 @@ class Spool:
     def _enforce_cap(self):
         # Count both live (.lp) and quarantined (.bad) files toward the cap: a
         # recurring stream of poison/unreadable files must not accumulate .bad
-        # files past TELEM_SPOOL_MAX_BYTES on a constrained device. Both suffixes
+        # files past telem.spool.max_size on a constrained device. Both suffixes
         # are zero-padded-sequence names, so a plain name sort is oldest-first.
         files = sorted(
             [*self.dir.glob(f'*{_SUFFIX}'), *self.dir.glob(f'*{_BAD_SUFFIX}')],

--- a/src/lemongrass/_spool.py
+++ b/src/lemongrass/_spool.py
@@ -34,13 +34,10 @@ class Spool:
         self.enabled = self._ensure_dir()
 
     @classmethod
-    def from_env(cls):
-        return cls(
-            os.environ.get('TELEM_SPOOL_DIR', DEFAULT_SPOOL_DIR),
-            max_bytes=int(
-                os.environ.get('TELEM_SPOOL_MAX_BYTES', DEFAULT_MAX_BYTES)
-            ),
-        )
+    def from_config(cls):
+        from lemongrass import _config
+        spool = _config.load_config().telem.spool
+        return cls(spool.dir, max_bytes=spool.max_size)
 
     def _ensure_dir(self):
         try:

--- a/src/lemongrass/cli.py
+++ b/src/lemongrass/cli.py
@@ -7,7 +7,10 @@ from influxdb_client.rest import ApiException
 from race_monitor import RaceMonitorError, RaceMonitorHTTPError
 from urllib3.exceptions import HTTPError
 
-from lemongrass import _influx
+# _influx is imported lazily inside main(): importing it loads the config file,
+# and a malformed LEMONGRASS_CONFIG must not crash the dispatcher (or --help)
+# with a traceback before it can report the error cleanly.
+from lemongrass._config import ConfigError, warn_dropped_env_vars
 
 _COMMANDS = {
     "laps": "lemongrass.laps",
@@ -75,6 +78,8 @@ def _report_race_monitor_error(exc):
 
 def main():
     """Dispatch to the subcommand named by the first CLI argument."""
+    warn_dropped_env_vars()
+
     if len(sys.argv) >= 2 and sys.argv[1] in ("-h", "--help"):
         print("Usage: lemongrass <command> [args]")
         print(f"Commands: {', '.join(_COMMANDS)}")
@@ -93,7 +98,11 @@ def main():
     # request.
     try:
         result = importlib.import_module(_COMMANDS[cmd]).main()
+    except ConfigError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
     except (ApiException, HTTPError) as exc:
+        from lemongrass import _influx
         if _influx_unreachable(exc):
             print(f"Error: cannot reach InfluxDB at {_influx.INFLUX_URL}", file=sys.stderr)
         else:

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -28,7 +28,7 @@ from influxdb_client import Point, WritePrecision
 from influxdb_client.client.write_api import SYNCHRONOUS
 from race_monitor import RaceMonitorClient, get_streaming_command
 
-from lemongrass import _influx
+from lemongrass import _config, _influx
 from lemongrass._env import resolve_tokens
 
 UNDERLINE = "-" * 80
@@ -202,9 +202,9 @@ def main():
 
     # Validate the influx token up front so we fail fast before the RaceMonitor
     # setup work below; _influx.connect() reads it again at construction time.
-    if (args.network_mode and not args.dry_run
-            and not os.environ.get('INFLUX_TELEMETRY_TOKEN')):
-        logging.error("INFLUX_TELEMETRY_TOKEN environment variable not set")
+    influx_token_env = _config.load_config().influx.token_env
+    if args.network_mode and not args.dry_run and not os.environ.get(influx_token_env):
+        logging.error("%s environment variable not set", influx_token_env)
         sys.exit(1)
 
     opts = RaceOptions(

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -28,7 +28,7 @@ from influxdb_client import Point, WritePrecision
 from influxdb_client.client.write_api import SYNCHRONOUS
 from race_monitor import RaceMonitorClient, get_streaming_command
 
-from lemongrass import _config, _influx
+from lemongrass import _config, _env, _influx
 from lemongrass._env import resolve_tokens
 
 UNDERLINE = "-" * 80
@@ -197,7 +197,7 @@ def main():
 
     tokens = resolve_tokens()
     if not tokens:
-        logging.error("RACEMONITOR_TOKENS or RACEMONITOR_TOKEN environment variable not set")
+        logging.error("%s environment variable not set", _env.tokens_env_hint())
         sys.exit(1)
 
     # Validate the influx token up front so we fail fast before the RaceMonitor

--- a/src/lemongrass/pisugar_monitor.py
+++ b/src/lemongrass/pisugar_monitor.py
@@ -16,13 +16,14 @@ from time import sleep, time
 from influxdb_client import Point
 from influxdb_client.client.write_api import SYNCHRONOUS
 
-from lemongrass import _influx
+from lemongrass import _config, _influx
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger('pisugar-monitor')
 
-PISUGAR_API = "http://localhost:8421"
-PISUGAR_CONFIG = "/etc/pisugar-server/config.json"
+_pisugar_cfg = _config.load_config().pisugar
+PISUGAR_API = _pisugar_cfg.api_url
+PISUGAR_CONFIG = _pisugar_cfg.config_path
 TOKEN_REFRESH_MARGIN = 300  # seconds before expiry to proactively refresh
 HTTP_TIMEOUT_S = 5  # a wedged pisugar-server must not hang the monitor forever
 STARTUP_RETRY_DELAY_S = 5
@@ -42,11 +43,11 @@ def _resolve_host():
     """Host identity for tagging PiSugar (Pi) telemetry.
 
     PiSugar data describes the Pi, not the car, so it is tagged by host rather
-    than VIN. HOST is wired to the Pi's real hostname in the deploy compose so
-    it matches telegraf's host tag; socket.gethostname() (the container ID under
-    Docker) is only a last-resort fallback.
+    than VIN. pisugar.host is set to the Pi's real hostname in the deploy config
+    so it matches telegraf's host tag; socket.gethostname() (the container ID
+    under Docker) is only a last-resort fallback.
     """
-    return os.environ.get("HOST") or socket.gethostname()
+    return _config.load_config().pisugar.host or socket.gethostname()
 
 
 def login(username, password):
@@ -159,8 +160,9 @@ def main():
     """Main loop: read PiSugar metrics and push to InfluxDB."""
     # Validate the influx token up front so we fail fast before the pisugar login
     # below; _influx.connect() reads it again at construction time.
-    if not os.environ.get('INFLUX_TELEMETRY_TOKEN'):
-        logger.error("INFLUX_TELEMETRY_TOKEN environment variable not set")
+    token_env = _config.load_config().influx.token_env
+    if not os.environ.get(token_env):
+        logger.error("%s environment variable not set", token_env)
         sys.exit(1)
 
     username, password = read_credentials()

--- a/src/lemongrass/race_backfill.py
+++ b/src/lemongrass/race_backfill.py
@@ -48,12 +48,13 @@ from datetime import UTC, datetime, timedelta
 
 from race_monitor import RaceMonitorClient
 
-from lemongrass import _influx
+from lemongrass import _config, _influx
 from lemongrass._env import resolve_tokens
 
-LEMONS_SEARCH_TERMS = ['Real Hoopties', 'GP du Lac', 'Halloween Hoop']
-DEFAULT_CAR_NUMBER = '252'
-DEFAULT_START_YEAR = 2017
+_backfill_cfg = _config.load_config().races.backfill
+LEMONS_SEARCH_TERMS = _backfill_cfg.search_terms
+DEFAULT_CAR_NUMBER = _backfill_cfg.default_car_number
+DEFAULT_START_YEAR = _backfill_cfg.default_start_year
 EPOCH_START = '1970-01-01T00:00:00Z'
 
 WINDOW_PAD_S = _influx.WINDOW_PAD_S

--- a/src/lemongrass/race_backfill.py
+++ b/src/lemongrass/race_backfill.py
@@ -2,8 +2,8 @@
 """Discover and backfill historical 24 Hours of Lemons lap data.
 
 Searches the RaceMonitor API for past Real Hoopties, GP du Lac, and Halloween
-Hoop races and writes lap data for a given car number to the laps/races InfluxDB
-buckets by invoking `lemongrass laps -n` for each race found.
+Hoop races and writes fieldwide lap data to the laps/races InfluxDB buckets by
+invoking `lemongrass laps -n` for each race found.
 
 Assumes `lemongrass` is installed as a CLI tool. If running from the repo, prefix
 commands with `uv run` (e.g. `uv run lemongrass race-backfill`).
@@ -12,7 +12,7 @@ Usage:
     # Preview what would be backfilled (no writes)
     lemongrass race-backfill --dry-run
 
-    # Run the backfill (default car 252, from 2017 onwards). Races whose laps are
+    # Run the backfill (fieldwide, from 2017-01-01 onwards). Races whose laps are
     # already complete and written under the current schema version are skipped.
     lemongrass race-backfill
 
@@ -20,14 +20,11 @@ Usage:
     # (e.g. after bumping SCHEMA_VERSION in laps to migrate historical data)
     lemongrass race-backfill --force
 
-    # Override car number for a specific race (e.g. 2022 Hoopties used car 253)
-    lemongrass race-backfill --override 120037:253
-
     # Validate that backfilled races have data in InfluxDB
-    lemongrass race-backfill --validate --override 120037:253
+    lemongrass race-backfill --validate
 
-    # Backfill from a different year or for a different default car
-    lemongrass race-backfill --start-year 2023 --car 82
+    # Backfill from a different start date
+    lemongrass race-backfill --start-date 2023-06-01
 
     # Re-write laps stored under an older schema version without re-fetching from
     # RaceMonitor (faster than --force when only the schema tag changed)

--- a/src/lemongrass/race_backfill.py
+++ b/src/lemongrass/race_backfill.py
@@ -44,7 +44,7 @@ import argparse
 import logging
 import subprocess
 import sys
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 
 from race_monitor import RaceMonitorClient
 
@@ -53,21 +53,20 @@ from lemongrass._env import resolve_tokens
 
 _backfill_cfg = _config.load_config().races.backfill
 LEMONS_SEARCH_TERMS = _backfill_cfg.search_terms
-DEFAULT_CAR_NUMBER = _backfill_cfg.default_car_number
-DEFAULT_START_YEAR = _backfill_cfg.default_start_year
+DEFAULT_START_DATE = _backfill_cfg.default_start_date
 EPOCH_START = '1970-01-01T00:00:00Z'
 
 WINDOW_PAD_S = _influx.WINDOW_PAD_S
 
 
-class _OverrideAction(argparse.Action):
-    """argparse Action that accumulates RACE_ID:CAR_NUMBER pairs into a dict."""
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        overrides = getattr(namespace, self.dest) or {}
-        race_id, car = values.split(':', 1)
-        overrides[race_id] = car
-        setattr(namespace, self.dest, overrides)
+def _parse_start_date(value):
+    """Parse a YYYY-MM-DD start date into a UTC-midnight epoch; exit 1 on bad input."""
+    try:
+        d = date.fromisoformat(value)
+    except ValueError:
+        logging.error("invalid --start-date %r: expected YYYY-MM-DD", value)
+        sys.exit(1)
+    return int(datetime(d.year, d.month, d.day, tzinfo=UTC).timestamp())
 
 
 def _build_parser():
@@ -76,14 +75,9 @@ def _build_parser():
         description='Discover and backfill historical Lemons lap data.')
     parser.add_argument('--dry-run', dest='dry_run', action='store_true', default=False,
                         help='Print what would be run without writing anything')
-    parser.add_argument('--override', dest='overrides', metavar='RACE_ID:CAR_NUMBER',
-                        action=_OverrideAction, default={},
-                        help='Override car number for a specific race (repeatable)')
-    parser.add_argument('--start-year', dest='start_year', type=int,
-                        default=DEFAULT_START_YEAR,
-                        help=f'Earliest year to include (default: {DEFAULT_START_YEAR})')
-    parser.add_argument('--car', dest='car_number', default=DEFAULT_CAR_NUMBER,
-                        help=f'Default car number (default: {DEFAULT_CAR_NUMBER})')
+    parser.add_argument('--start-date', dest='start_date', default=DEFAULT_START_DATE,
+                        help=f'Earliest race date to include, YYYY-MM-DD '
+                             f'(default: {DEFAULT_START_DATE})')
     parser.add_argument('--validate', dest='validate', action='store_true', default=False,
                         help='Check that every backfilled race has data in the new buckets')
     parser.add_argument('--force', dest='force', action='store_true', default=False,
@@ -92,15 +86,14 @@ def _build_parser():
     parser.add_argument('--upgrade-stored', dest='upgrade_stored', action='store_true',
                        default=False,
                        help='Re-backfill stored races with schema versions older than current; '
-                            'mutually exclusive with --override, --start-year, '
-                            '--car, and --validate. Combine with --force to also re-fetch '
-                            'races already at the current schema (re-queries every race from '
-                            'RaceMonitor, subject to its rate limit)')
+                            'mutually exclusive with --start-date and --validate. Combine with '
+                            '--force to also re-fetch races already at the current schema '
+                            '(re-queries every race from RaceMonitor, subject to its rate limit)')
     return parser
 
 
-def find_matching_races(client, start_year_epoc):
-    """Search for matching Lemons races at or after start_year_epoc.
+def find_matching_races(client, start_epoc):
+    """Search for matching Lemons races at or after start_epoc.
 
     Makes one API call per search term and deduplicates by race ID.
     """
@@ -108,30 +101,15 @@ def find_matching_races(client, start_year_epoc):
     for term in LEMONS_SEARCH_TERMS:
         resp = client.results.search_results(term)
         for race in resp.get('Races', []):
-            if race['StartDateEpoc'] >= start_year_epoc:
+            if race['StartDateEpoc'] >= start_epoc:
                 seen[race['ID']] = race
     return sorted(seen.values(), key=lambda r: r['StartDateEpoc'])
 
 
-def build_pairs(races, default_car, overrides):
-    """Return (race_id, car_number) pairs for all races, applying overrides."""
-    return [(str(race['ID']), resolve_car_number(str(race['ID']), default_car, overrides))
-            for race in races]
-
-
-def resolve_car_number(race_id, default, overrides):
-    """Return the override car number for race_id, or default if none is set."""
-    return overrides.get(str(race_id), default)
-
-
-def validate_backfill(pairs, query_api):
-    """Check every race has metadata and every expected car has laps; show counts."""
-    by_race = {}
-    for race_id, car_number in pairs:
-        by_race.setdefault(race_id, []).append(car_number)
-
+def validate_backfill(race_ids, query_api):
+    """Check every race has metadata and at least one lap in the field; show counts."""
     all_ok = True
-    for race_id, expected_cars in sorted(by_race.items()):
+    for race_id in sorted(set(race_ids)):
         race_tables = query_api.query(
             f'from(bucket: "{_influx.BUCKET_RACES}")\n'
             f'  |> range(start: {EPOCH_START})\n'
@@ -166,53 +144,44 @@ def validate_backfill(pairs, query_api):
             f'  |> filter(fn: (r) => r._measurement == "lap"\n'
             f'      and r.race_id == "{race_id}"\n'
             f'      and r._field == "lap_no")\n'
-            f'  |> group(columns: ["car_number"])\n'
             f'  |> count()'
         )
-        actual = {r.values['car_number']: r.values['_value']
-                  for t in lap_tables for r in t.records}
+        total = sum(r.get_value() for t in lap_tables for r in t.records)
 
-        missing = sorted(set(expected_cars) - set(actual))
-        if missing:
-            logging.warning("race %s (%s): MISSING cars %s | have: %s",
-                            race_id, race_name, missing,
-                            [f'{c}={actual[c]}laps' for c in sorted(actual)])
+        if total == 0:
+            logging.warning("race %s (%s): NO laps in field", race_id, race_name)
             all_ok = False
         else:
-            logging.info("race %s (%s): OK | cars: %s",
-                         race_id, race_name,
-                         [f'{c}={actual[c]}laps' for c in sorted(actual)])
+            logging.info("race %s (%s): OK | %d laps", race_id, race_name, total)
 
     return all_ok
 
 
-def run_backfill(races, default_car, overrides, dry_run=False, force=False):
-    """Run `lemongrass laps -n` for each race, using per-race car number overrides where set.
+def run_backfill(races, dry_run=False, force=False):
+    """Run `lemongrass laps -n` for each race (fieldwide historical import).
 
-    Unless force is set, passes --skip-if-complete so `lemongrass laps` skips races whose
-    laps are already complete and written under the current schema version.
+    Unless force is set, passes --skip-if-complete so `lemongrass laps` skips races
+    whose laps are already complete and written under the current schema version.
+    Returns the list of race IDs that failed.
     """
     failures = []
     for race in races:
         race_id = str(race['ID'])
-        car_number = resolve_car_number(race_id, default_car, overrides)
         cmd = ['lemongrass', 'laps', '-n']
         if not force:
             cmd.append('--skip-if-complete')
-        cmd += [race_id, car_number]
+        cmd.append(race_id)
         if dry_run:
-            logging.info("Would backfill race %s (%s) car %s",
-                         race_id, race['Name'], car_number)
+            logging.info("Would backfill race %s (%s)", race_id, race['Name'])
             continue
-        logging.info("Backfilling race %s (%s) car %s",
-                     race_id, race['Name'], car_number)
+        logging.info("Backfilling race %s (%s)", race_id, race['Name'])
         result = subprocess.run(cmd, capture_output=False)
         if result.returncode == 130:
             logging.info("laps was interrupted; stopping backfill.")
             break
         if result.returncode != 0:
-            logging.error("Backfill failed for race %s car %s", race_id, car_number)
-            failures.append((race_id, car_number))
+            logging.error("Backfill failed for race %s", race_id)
+            failures.append(race_id)
     if failures:
         logging.error("%d race(s) failed: %s", len(failures), failures)
     return failures
@@ -326,23 +295,10 @@ def main():
     """Entry point: parse args, discover races, then backfill or validate."""
     args = _build_parser().parse_args()
 
-    bad = _influx.invalid_flux_ids(
-        [args.car_number, *args.overrides.keys(), *args.overrides.values()])
-    if bad:
-        logging.error("invalid identifier(s): %s", ", ".join(repr(b) for b in bad))
-        sys.exit(1)
-
     if args.upgrade_stored:
-        exclusive = [
-            bool(args.overrides),
-            args.start_year != DEFAULT_START_YEAR,
-            args.car_number != DEFAULT_CAR_NUMBER,
-            args.validate,
-        ]
-        if any(exclusive):
+        if args.start_date != DEFAULT_START_DATE or args.validate:
             logging.error(
-                "--upgrade-stored is mutually exclusive with --override, "
-                "--start-year, --car, and --validate")
+                "--upgrade-stored is mutually exclusive with --start-date and --validate")
             sys.exit(1)
         try:
             with _influx.connect() as influx_client:
@@ -358,21 +314,20 @@ def main():
         logging.error("%s environment variable not set", _env.tokens_env_hint())
         sys.exit(1)
 
-    start_year_epoc = int(datetime(args.start_year, 1, 1, tzinfo=UTC).timestamp())
+    start_epoc = _parse_start_date(args.start_date)
 
     try:
         with RaceMonitorClient(api_token=tokens) as client:
-            races = find_matching_races(client, start_year_epoc)
+            races = find_matching_races(client, start_epoc)
             logging.info("Found %d matching races", len(races))
 
             if args.validate:
-                pairs = build_pairs(races, args.car_number, args.overrides)
+                race_ids = [str(r['ID']) for r in races]
                 with _influx.connect() as influx_client:
-                    ok = validate_backfill(pairs, influx_client.query_api())
+                    ok = validate_backfill(race_ids, influx_client.query_api())
                 sys.exit(0 if ok else 1)
 
-            failures = run_backfill(races, args.car_number, args.overrides,
-                                    dry_run=args.dry_run, force=args.force)
+            failures = run_backfill(races, dry_run=args.dry_run, force=args.force)
             if failures:
                 sys.exit(1)
     except KeyboardInterrupt:

--- a/src/lemongrass/race_backfill.py
+++ b/src/lemongrass/race_backfill.py
@@ -48,7 +48,7 @@ from datetime import UTC, datetime, timedelta
 
 from race_monitor import RaceMonitorClient
 
-from lemongrass import _config, _influx
+from lemongrass import _config, _env, _influx
 from lemongrass._env import resolve_tokens
 
 _backfill_cfg = _config.load_config().races.backfill
@@ -355,7 +355,7 @@ def main():
 
     tokens = resolve_tokens()
     if not tokens:
-        logging.error("RACEMONITOR_TOKENS or RACEMONITOR_TOKEN environment variable not set")
+        logging.error("%s environment variable not set", _env.tokens_env_hint())
         sys.exit(1)
 
     start_year_epoc = int(datetime(args.start_year, 1, 1, tzinfo=UTC).timestamp())

--- a/src/lemongrass/race_backfill.py
+++ b/src/lemongrass/race_backfill.py
@@ -104,7 +104,7 @@ def find_matching_races(client, start_epoc):
 
 
 def validate_backfill(race_ids, query_api):
-    """Check every race has metadata and at least one lap in the field; show counts."""
+    """Check every race has metadata and at least one lap in the field; log lap counts."""
     all_ok = True
     for race_id in sorted(set(race_ids)):
         race_tables = query_api.query(

--- a/src/lemongrass/race_diagnose.py
+++ b/src/lemongrass/race_diagnose.py
@@ -26,7 +26,7 @@ from datetime import UTC, datetime
 
 from race_monitor import RaceMonitorClient
 
-from lemongrass import _influx
+from lemongrass import _config, _influx
 from lemongrass._env import resolve_tokens
 
 EPOCH_START = '1970-01-01T00:00:00Z'
@@ -133,13 +133,14 @@ def main():
         sys.exit(1)
 
     rm_token = resolve_tokens()
-    influx_token = os.environ.get('INFLUX_TELEMETRY_TOKEN')
+    influx_token_env = _config.load_config().influx.token_env
+    influx_token = os.environ.get(influx_token_env)
 
     if not rm_token:
         print("RACEMONITOR_TOKENS or RACEMONITOR_TOKEN not set")
         sys.exit(1)
     if not influx_token:
-        print("INFLUX_TELEMETRY_TOKEN not set")
+        print(f"{influx_token_env} not set")
         sys.exit(1)
 
     with RaceMonitorClient(api_token=rm_token) as client:

--- a/src/lemongrass/race_diagnose.py
+++ b/src/lemongrass/race_diagnose.py
@@ -26,7 +26,7 @@ from datetime import UTC, datetime
 
 from race_monitor import RaceMonitorClient
 
-from lemongrass import _config, _influx
+from lemongrass import _config, _env, _influx
 from lemongrass._env import resolve_tokens
 
 EPOCH_START = '1970-01-01T00:00:00Z'
@@ -137,7 +137,7 @@ def main():
     influx_token = os.environ.get(influx_token_env)
 
     if not rm_token:
-        print("RACEMONITOR_TOKENS or RACEMONITOR_TOKEN not set")
+        print(f"{_env.tokens_env_hint()} not set")
         sys.exit(1)
     if not influx_token:
         print(f"{influx_token_env} not set")

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -2,7 +2,6 @@
 """Sends OBD-II measurements to InfluxDB."""
 
 import logging
-import os
 import sys
 import threading
 from datetime import UTC, datetime
@@ -12,7 +11,7 @@ import obd
 from influxdb_client import Point
 from influxdb_client.client.write_api import SYNCHRONOUS
 
-from lemongrass import _influx
+from lemongrass import _config, _influx
 from lemongrass._spool import Spool
 
 logging.basicConfig(level=logging.INFO)
@@ -207,12 +206,13 @@ def _query_fuel_type_once(connection):
 
 
 def _resolve_vin(connection):
-    """Resolve the car VIN for tagging: OBD Mode 09, then CAR_VIN env, then 'unknown'.
+    """Resolve the car VIN for tagging: OBD Mode 09, then the configured VIN, then 'unknown'.
 
     VIN is static per session, so main() calls this once and caches the result in
-    the module-level _vin. OBD is the source of truth; CAR_VIN is a fallback (and
-    the only source when the adapter returns no VIN). A telemetry point is never
-    dropped for want of a VIN -- an unresolved VIN tags 'unknown' and logs.
+    the module-level _vin. OBD is the source of truth; the configured VIN
+    (telem.vin) is a fallback (and the only source when the adapter returns no
+    VIN). A telemetry point is never dropped for want of a VIN -- an unresolved
+    VIN tags 'unknown' and logs.
 
     The VIN is force-queried rather than gated on connection.supports(VIN): many
     adapters (and the local emulator) under-report Mode 09 in the 0900 supported-
@@ -229,17 +229,17 @@ def _resolve_vin(connection):
             # Mode 09 VINs can arrive null-padded; strip whitespace and NULs.
             obd_vin = str(val).strip().strip("\x00").strip()
     except Exception:
-        logger.exception("VIN query failed; falling back to CAR_VIN")
+        logger.exception("VIN query failed; falling back to configured VIN")
 
-    env_vin = os.environ.get("CAR_VIN")
+    cfg_vin = _config.load_config().telem.vin or None
     if obd_vin:
-        if env_vin and env_vin != obd_vin:
+        if cfg_vin and cfg_vin != obd_vin:
             logger.warning(
-                "OBD VIN %s differs from CAR_VIN %s; using OBD VIN", obd_vin, env_vin)
+                "OBD VIN %s differs from configured VIN %s; using OBD VIN", obd_vin, cfg_vin)
         return obd_vin
-    if env_vin:
-        return env_vin
-    logger.warning("VIN unresolved from OBD and CAR_VIN; tagging vin=unknown")
+    if cfg_vin:
+        return cfg_vin
+    logger.warning("VIN unresolved from OBD and config; tagging vin=unknown")
     return "unknown"
 
 
@@ -340,31 +340,28 @@ def new_status(r):
 def connect():
     """Open an OBD-II connection on the configured serial port.
 
-    Defaults to the ``/dev/obd`` udev symlink (passed into the container via a
-    device mapping). ``OBD_PORT`` overrides it for host-based testing.
+    The port comes from ``telem.obd.port``, defaulting to the ``/dev/obd`` udev
+    symlink (passed into the container via a device mapping).
 
-    ``OBD_BAUDRATE`` optionally pins the baud rate. Real USB adapters leave it
-    unset so python-obd auto-detects; the emulator's ``socket://`` transport
-    needs it set (e.g. 38400) because python-obd only skips auto-baud for
-    ``/dev/pts`` pseudo-terminals, not TCP sockets.
+    ``telem.obd.baudrate`` (0 = auto-detect) optionally pins the baud rate. Real
+    USB adapters leave it unset so python-obd auto-detects; the emulator's
+    ``socket://`` transport needs it set (e.g. 38400) because python-obd only
+    skips auto-baud for ``/dev/pts`` pseudo-terminals, not TCP sockets.
     """
-    kwargs = {'portstr': os.environ.get('OBD_PORT', '/dev/obd')}
-    baud = os.environ.get('OBD_BAUDRATE')
-    if baud:
-        try:
-            kwargs['baudrate'] = int(baud)
-        except ValueError:
-            raise ValueError(f"OBD_BAUDRATE must be an integer, got {baud!r}") from None
+    obd_cfg = _config.load_config().telem.obd
+    kwargs = {'portstr': obd_cfg.port}
+    if obd_cfg.baudrate:
+        kwargs['baudrate'] = obd_cfg.baudrate
     return obd.Async(**kwargs)
 
 
 def _configure_obd_logging():
-    """Enable python-obd DEBUG logging only when OBD_DEBUG is set.
+    """Enable python-obd DEBUG logging only when telem.obd.debug is set.
 
     DEBUG logs every serial send/receive; with dozens of watched PIDs cycling
     continuously that is sustained journald I/O and SD-card wear on the Pi.
     """
-    if os.environ.get('OBD_DEBUG'):
+    if _config.load_config().telem.obd.debug:
         obd.logger.setLevel(obd.logging.DEBUG)
 
 

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -454,7 +454,7 @@ def main():
     """Main loop of OBD-II scraping"""
     global _connection, _last_append_monotonic, _spool, _vin
 
-    _spool = Spool.from_env()
+    _spool = Spool.from_config()
 
     with _influx.connect(timeout=WRITE_TIMEOUT_MS, retries=WRITE_RETRIES) as influx_client:
         write_api = influx_client.write_api(write_options=SYNCHRONOUS)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+import os
+import subprocess
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -6,7 +8,39 @@ import pytest
 import lemongrass.cli as cli
 
 
+class TestConfigErrorHandling:
+    """A broken LEMONGRASS_CONFIG must surface as a one-line error, not a
+    traceback — and must not take down `--help`, which needs no config. Runs in
+    a subprocess because the failure happens at module import time."""
+
+    def _run(self, args, tmp_path):
+        env = dict(os.environ, LEMONGRASS_CONFIG=str(tmp_path / "nope.toml"))
+        return subprocess.run(
+            [sys.executable, "-c", "from lemongrass.cli import main; main()", *args],
+            capture_output=True, text=True, env=env, timeout=60)
+
+    def test_help_works_with_broken_config(self, tmp_path):
+        res = self._run(["--help"], tmp_path)
+        assert res.returncode == 0
+        assert "Usage:" in res.stdout
+        assert "Traceback" not in res.stderr
+
+    def test_command_reports_config_error_without_traceback(self, tmp_path):
+        res = self._run(["race-diagnose", "1", "2"], tmp_path)
+        assert res.returncode == 1
+        assert "Error:" in res.stderr
+        assert "nope.toml" in res.stderr
+        assert "Traceback" not in res.stderr
+
+
 class TestDispatcher:
+    def test_warns_about_dropped_env_vars_at_startup(self, monkeypatch, capsys):
+        monkeypatch.setenv("OBD_PORT", "/dev/ttyUSB0")
+        with patch.object(sys, 'argv', ['lemongrass']):
+            with pytest.raises(SystemExit):
+                cli.main()
+        assert "OBD_PORT" in capsys.readouterr().err
+
     def test_no_args_exits_nonzero(self):
         with patch.object(sys, 'argv', ['lemongrass']):
             with pytest.raises(SystemExit) as exc:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,24 @@
+import pytest
+
+from lemongrass import _config
+
+
+class TestParseSize:
+    @pytest.mark.parametrize("value,expected", [
+        (1073741824, 1073741824),      # int bytes passthrough
+        ("1024", 1024),                # bare number = bytes
+        ("512B", 512),                 # B suffix = bytes
+        ("1GiB", 1073741824),          # binary
+        ("1 gib", 1073741824),         # whitespace + lowercase
+        ("500MiB", 524288000),         # binary
+        ("1GB", 1000000000),           # decimal
+        ("1.5GB", 1500000000),         # fraction
+        (2.0, 2),                      # float floored to int
+    ])
+    def test_parses_valid(self, value, expected):
+        assert _config.parse_size(value) == expected
+
+    @pytest.mark.parametrize("value", ["1XB", "-1GiB", "GiB", "", 0, -5, "0GiB", True])
+    def test_rejects_invalid(self, value):
+        with pytest.raises(ValueError):
+            _config.parse_size(value)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,8 +21,11 @@ class TestParseSize:
     def test_parses_valid(self, value, expected):
         assert _config.parse_size(value) == expected
 
-    @pytest.mark.parametrize("value", ["1XB", "-1GiB", "GiB", "", 0, -5, "0GiB", True])
+    @pytest.mark.parametrize("value", ["1XB", "-1GiB", "GiB", "", 0, -5, "0GiB", True,
+                                       1.5, 0.5])
     def test_rejects_invalid(self, value):
+        # Non-integer floats are rejected rather than truncated: a TOML
+        # `max_size = 1.5` (user meant "1.5GiB") must not become a 1-byte cap.
         with pytest.raises(ValueError):
             _config.parse_size(value)
 
@@ -121,10 +124,30 @@ class TestValidation:
         with pytest.raises(_config.ConfigError, match="must be an integer"):
             _config.load_config()
 
+    @pytest.mark.parametrize("body,section", [
+        ("[telem]\nobd = 5", "telem.obd"),                     # scalar where table expected
+        ("[[influx.buckets]]\nlaps = 'x'", "influx.buckets"),  # array-of-tables mistake
+        ("[influx]\nbuckets = 'laps'", "influx.buckets"),      # string where table expected
+        ("influx = 5", "influx"),                              # scalar top-level section
+    ])
+    def test_non_table_section_raises_config_error(self, tmp_path, monkeypatch,
+                                                   body, section):
+        _write_cfg(tmp_path, monkeypatch, body)
+        with pytest.raises(_config.ConfigError, match=f"{section}.*must be a table"):
+            _config.load_config()
+
     def test_bad_max_size_raises(self, tmp_path, monkeypatch):
         _write_cfg(tmp_path, monkeypatch, """
             [telem.spool]
             max_size = "1XB"
+        """)
+        with pytest.raises(_config.ConfigError, match="max_size"):
+            _config.load_config()
+
+    def test_fractional_max_size_raises(self, tmp_path, monkeypatch):
+        _write_cfg(tmp_path, monkeypatch, """
+            [telem.spool]
+            max_size = 1.5
         """)
         with pytest.raises(_config.ConfigError, match="max_size"):
             _config.load_config()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
 import textwrap
+from pathlib import Path
 
 import pytest
 
@@ -163,3 +164,9 @@ class TestSecretsOnlyEnv:
         monkeypatch.delenv("LEMONGRASS_CONFIG", raising=False)
         monkeypatch.setenv("BUCKETS_LAPS", "ignored")
         assert _config.load_config().influx.buckets.laps == "laps"
+
+
+def test_sample_file_reproduces_defaults(monkeypatch):
+    sample = Path(__file__).resolve().parents[1] / "lemongrass.toml.sample"
+    monkeypatch.setenv("LEMONGRASS_CONFIG", str(sample))
+    assert _config.load_config() == _config.Config()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -44,8 +44,7 @@ class TestDefaults:
         assert c.influx.buckets.pisugar == "pisugar"
         assert c.races.backfill.search_terms == (
             "Real Hoopties", "GP du Lac", "Halloween Hoop")
-        assert c.races.backfill.default_car_number == "252"
-        assert c.races.backfill.default_start_year == 2017
+        assert c.races.backfill.default_start_date == "2017-01-01"
         assert c.racemonitor.tokens_env == "RACEMONITOR_TOKENS"
         assert c.telem.vin == ""
         assert c.telem.obd.port == "/dev/obd"
@@ -83,8 +82,7 @@ class TestFileOverlay:
             org = "team"
             [races.backfill]
             search_terms = ["Foo", "Bar"]
-            default_car_number = "99"
-            default_start_year = 2020
+            default_start_date = "2020-05-01"
             [telem.spool]
             max_size = "2GiB"
         """)
@@ -92,8 +90,7 @@ class TestFileOverlay:
         assert c.influx.url == "http://localhost:8086"
         assert c.influx.org == "team"
         assert c.races.backfill.search_terms == ("Foo", "Bar")
-        assert c.races.backfill.default_car_number == "99"
-        assert c.races.backfill.default_start_year == 2020
+        assert c.races.backfill.default_start_date == "2020-05-01"
         assert c.telem.spool.max_size == 2 * 1024 ** 3
 
 
@@ -119,9 +116,9 @@ class TestValidation:
     def test_wrong_type_raises(self, tmp_path, monkeypatch):
         _write_cfg(tmp_path, monkeypatch, """
             [races.backfill]
-            default_start_year = "2017"
+            default_start_date = 2017
         """)
-        with pytest.raises(_config.ConfigError, match="must be an integer"):
+        with pytest.raises(_config.ConfigError, match="must be a string"):
             _config.load_config()
 
     @pytest.mark.parametrize("body,section", [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,5 @@
+import textwrap
+
 import pytest
 
 from lemongrass import _config
@@ -22,3 +24,133 @@ class TestParseSize:
     def test_rejects_invalid(self, value):
         with pytest.raises(ValueError):
             _config.parse_size(value)
+
+
+class TestDefaults:
+    def test_defaults_match_todays_literals(self, monkeypatch):
+        monkeypatch.delenv("LEMONGRASS_CONFIG", raising=False)
+        for var in ("INFLUX_URL", "INFLUX_ORG", "OBD_PORT", "OBD_BAUDRATE",
+                    "OBD_DEBUG", "CAR_VIN", "TELEM_SPOOL_DIR",
+                    "TELEM_SPOOL_MAX_SIZE", "PISUGAR_HOST"):
+            monkeypatch.delenv(var, raising=False)
+        c = _config.load_config()
+        assert c.influx.url == "https://influxdb.focism.com"
+        assert c.influx.org == "focism"
+        assert c.influx.token_env == "INFLUX_TELEMETRY_TOKEN"
+        assert c.influx.buckets.laps == "laps"
+        assert c.influx.buckets.races == "races"
+        assert c.influx.buckets.sessions == "race_sessions"
+        assert c.influx.buckets.telem == "telem"
+        assert c.influx.buckets.pisugar == "pisugar"
+        assert c.races.backfill.search_terms == (
+            "Real Hoopties", "GP du Lac", "Halloween Hoop")
+        assert c.races.backfill.default_car_number == "252"
+        assert c.races.backfill.default_start_year == 2017
+        assert c.racemonitor.tokens_env == "RACEMONITOR_TOKENS"
+        assert c.telem.vin == ""
+        assert c.telem.obd.port == "/dev/obd"
+        assert c.telem.obd.baudrate == 0
+        assert c.telem.obd.debug is False
+        assert c.telem.spool.dir == "/data/telem-spool"
+        assert c.telem.spool.max_size == 1073741824
+        assert c.pisugar.host == ""
+        assert c.pisugar.api_url == "http://localhost:8421"
+        assert c.pisugar.config_path == "/etc/pisugar-server/config.json"
+
+
+def _write_cfg(tmp_path, monkeypatch, body):
+    p = tmp_path / "lemongrass.toml"
+    p.write_text(textwrap.dedent(body))
+    monkeypatch.setenv("LEMONGRASS_CONFIG", str(p))
+    return p
+
+
+class TestFileOverlay:
+    def test_partial_overlay_keeps_other_defaults(self, tmp_path, monkeypatch):
+        _write_cfg(tmp_path, monkeypatch, """
+            [influx.buckets]
+            laps = "my_laps"
+        """)
+        c = _config.load_config()
+        assert c.influx.buckets.laps == "my_laps"       # overridden
+        assert c.influx.buckets.races == "races"        # default kept
+        assert c.influx.url == "https://influxdb.focism.com"
+
+    def test_full_sections_overlay(self, tmp_path, monkeypatch):
+        _write_cfg(tmp_path, monkeypatch, """
+            [influx]
+            url = "http://localhost:8086"
+            org = "team"
+            [races.backfill]
+            search_terms = ["Foo", "Bar"]
+            default_car_number = "99"
+            default_start_year = 2020
+            [telem.spool]
+            max_size = "2GiB"
+        """)
+        c = _config.load_config()
+        assert c.influx.url == "http://localhost:8086"
+        assert c.influx.org == "team"
+        assert c.races.backfill.search_terms == ("Foo", "Bar")
+        assert c.races.backfill.default_car_number == "99"
+        assert c.races.backfill.default_start_year == 2020
+        assert c.telem.spool.max_size == 2 * 1024 ** 3
+
+
+class TestValidation:
+    def test_missing_file_raises(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LEMONGRASS_CONFIG", str(tmp_path / "nope.toml"))
+        with pytest.raises(_config.ConfigError, match="could not be read"):
+            _config.load_config()
+
+    def test_malformed_toml_raises(self, tmp_path, monkeypatch):
+        _write_cfg(tmp_path, monkeypatch, "this is = = not toml")
+        with pytest.raises(_config.ConfigError, match="not valid TOML"):
+            _config.load_config()
+
+    def test_unknown_key_raises(self, tmp_path, monkeypatch):
+        _write_cfg(tmp_path, monkeypatch, """
+            [influx]
+            bucket = "typo"
+        """)
+        with pytest.raises(_config.ConfigError, match="unknown key"):
+            _config.load_config()
+
+    def test_wrong_type_raises(self, tmp_path, monkeypatch):
+        _write_cfg(tmp_path, monkeypatch, """
+            [races.backfill]
+            default_start_year = "2017"
+        """)
+        with pytest.raises(_config.ConfigError, match="must be an integer"):
+            _config.load_config()
+
+    def test_bad_max_size_raises(self, tmp_path, monkeypatch):
+        _write_cfg(tmp_path, monkeypatch, """
+            [telem.spool]
+            max_size = "1XB"
+        """)
+        with pytest.raises(_config.ConfigError, match="max_size"):
+            _config.load_config()
+
+
+class TestEnvPrecedence:
+    def test_env_overrides_file(self, tmp_path, monkeypatch):
+        _write_cfg(tmp_path, monkeypatch, """
+            [influx]
+            url = "http://from-file:8086"
+        """)
+        monkeypatch.setenv("INFLUX_URL", "http://from-env:9999")
+        assert _config.load_config().influx.url == "http://from-env:9999"
+
+    def test_env_size_and_int_coercion(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("LEMONGRASS_CONFIG", raising=False)
+        monkeypatch.setenv("TELEM_SPOOL_MAX_SIZE", "512MiB")
+        monkeypatch.setenv("OBD_BAUDRATE", "38400")
+        c = _config.load_config()
+        assert c.telem.spool.max_size == 512 * 1024 ** 2
+        assert c.telem.obd.baudrate == 38400
+
+    def test_buckets_have_no_env_override(self, monkeypatch):
+        monkeypatch.delenv("LEMONGRASS_CONFIG", raising=False)
+        monkeypatch.setenv("BUCKETS_LAPS", "ignored")
+        assert _config.load_config().influx.buckets.laps == "laps"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -201,11 +201,11 @@ class TestDroppedEnvVarWarning:
     def test_warns_for_each_dropped_var_set(self, monkeypatch, capsys):
         self._clear_all(monkeypatch)
         monkeypatch.setenv("OBD_PORT", "/dev/ttyUSB0")
-        monkeypatch.setenv("CAR_VIN", "VIN123")
+        monkeypatch.setenv("INFLUX_URL", "http://old:8086")
         _config.warn_dropped_env_vars()
         err = capsys.readouterr().err
         assert "OBD_PORT" in err and "telem.obd.port" in err
-        assert "CAR_VIN" in err and "telem.vin" in err
+        assert "INFLUX_URL" in err and "influx.url" in err
         assert "no longer read" in err
 
     def test_silent_when_no_dropped_vars_set(self, monkeypatch, capsys):
@@ -213,11 +213,13 @@ class TestDroppedEnvVarWarning:
         _config.warn_dropped_env_vars()
         assert capsys.readouterr().err == ""
 
-    def test_host_is_not_warned_about(self, monkeypatch, capsys):
-        # HOST was read pre-pivot but zsh exports it in every interactive shell,
-        # so warning on it would be permanent noise; docs cover its migration.
+    def test_never_released_vars_are_not_warned_about(self, monkeypatch, capsys):
+        # CAR_VIN, HOST, and the spool vars were added after v4.0.0 and never
+        # shipped in a release, so no deployment can have configured them via
+        # env — they don't belong in a migration warning.
         self._clear_all(monkeypatch)
-        monkeypatch.setenv("HOST", "some-host")
+        for var in ("CAR_VIN", "HOST", "TELEM_SPOOL_DIR", "TELEM_SPOOL_MAX_BYTES"):
+            monkeypatch.setenv(var, "x")
         _config.warn_dropped_env_vars()
         assert capsys.readouterr().err == ""
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -189,7 +189,61 @@ class TestSecretsOnlyEnv:
         assert _config.load_config().influx.buckets.laps == "laps"
 
 
+class TestDroppedEnvVarWarning:
+    """The secrets-only pivot stopped reading the old non-secret env vars; a
+    deployment that still sets them silently falls back to defaults, so startup
+    must call that out."""
+
+    def _clear_all(self, monkeypatch):
+        for var in _config._DROPPED_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+
+    def test_warns_for_each_dropped_var_set(self, monkeypatch, capsys):
+        self._clear_all(monkeypatch)
+        monkeypatch.setenv("OBD_PORT", "/dev/ttyUSB0")
+        monkeypatch.setenv("CAR_VIN", "VIN123")
+        _config.warn_dropped_env_vars()
+        err = capsys.readouterr().err
+        assert "OBD_PORT" in err and "telem.obd.port" in err
+        assert "CAR_VIN" in err and "telem.vin" in err
+        assert "no longer read" in err
+
+    def test_silent_when_no_dropped_vars_set(self, monkeypatch, capsys):
+        self._clear_all(monkeypatch)
+        _config.warn_dropped_env_vars()
+        assert capsys.readouterr().err == ""
+
+    def test_host_is_not_warned_about(self, monkeypatch, capsys):
+        # HOST was read pre-pivot but zsh exports it in every interactive shell,
+        # so warning on it would be permanent noise; docs cover its migration.
+        self._clear_all(monkeypatch)
+        monkeypatch.setenv("HOST", "some-host")
+        _config.warn_dropped_env_vars()
+        assert capsys.readouterr().err == ""
+
+
 def test_sample_file_reproduces_defaults(monkeypatch):
     sample = Path(__file__).resolve().parents[1] / "lemongrass.toml.sample"
     monkeypatch.setenv("LEMONGRASS_CONFIG", str(sample))
     assert _config.load_config() == _config.Config()
+
+
+def test_sample_file_lists_every_key():
+    """Equality with Config() can't catch a newly added field that's simply
+    absent from the sample (both sides get the default); require the sample to
+    spell out every key explicitly."""
+    import dataclasses
+    import tomllib
+
+    sample = Path(__file__).resolve().parents[1] / "lemongrass.toml.sample"
+    data = tomllib.loads(sample.read_text())
+
+    def assert_covered(dc_value, section, where):
+        for f in dataclasses.fields(dc_value):
+            key = f"{where}{f.name}"
+            assert f.name in section, f"lemongrass.toml.sample is missing {key}"
+            child = getattr(dc_value, f.name)
+            if dataclasses.is_dataclass(child):
+                assert_covered(child, section[f.name], f"{key}.")
+
+    assert_covered(_config.Config(), data, "")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,10 +29,6 @@ class TestParseSize:
 class TestDefaults:
     def test_defaults_match_todays_literals(self, monkeypatch):
         monkeypatch.delenv("LEMONGRASS_CONFIG", raising=False)
-        for var in ("INFLUX_URL", "INFLUX_ORG", "OBD_PORT", "OBD_BAUDRATE",
-                    "OBD_DEBUG", "CAR_VIN", "TELEM_SPOOL_DIR",
-                    "TELEM_SPOOL_MAX_SIZE", "PISUGAR_HOST"):
-            monkeypatch.delenv(var, raising=False)
         c = _config.load_config()
         assert c.influx.url == "https://influxdb.focism.com"
         assert c.influx.org == "focism"
@@ -133,22 +129,35 @@ class TestValidation:
             _config.load_config()
 
 
-class TestEnvPrecedence:
-    def test_env_overrides_file(self, tmp_path, monkeypatch):
+class TestSecretsOnlyEnv:
+    def test_non_secret_env_vars_are_ignored(self, tmp_path, monkeypatch):
         _write_cfg(tmp_path, monkeypatch, """
             [influx]
             url = "http://from-file:8086"
         """)
-        monkeypatch.setenv("INFLUX_URL", "http://from-env:9999")
-        assert _config.load_config().influx.url == "http://from-env:9999"
-
-    def test_env_size_and_int_coercion(self, tmp_path, monkeypatch):
-        monkeypatch.delenv("LEMONGRASS_CONFIG", raising=False)
-        monkeypatch.setenv("TELEM_SPOOL_MAX_SIZE", "512MiB")
-        monkeypatch.setenv("OBD_BAUDRATE", "38400")
+        # Legacy non-secret env vars no longer affect the loaded config.
+        for var, val in [
+            ("INFLUX_URL", "http://from-env:9999"),
+            ("INFLUX_ORG", "env-org"),
+            ("OBD_PORT", "/dev/env-obd"),
+            ("OBD_BAUDRATE", "38400"),
+            ("OBD_DEBUG", "1"),
+            ("CAR_VIN", "ENVVIN"),
+            ("TELEM_SPOOL_DIR", "/env/spool"),
+            ("TELEM_SPOOL_MAX_SIZE", "512MiB"),
+            ("PISUGAR_HOST", "env-host"),
+        ]:
+            monkeypatch.setenv(var, val)
         c = _config.load_config()
-        assert c.telem.spool.max_size == 512 * 1024 ** 2
-        assert c.telem.obd.baudrate == 38400
+        assert c.influx.url == "http://from-file:8086"   # file wins
+        assert c.influx.org == "focism"                  # default kept; env ignored
+        assert c.telem.obd.port == "/dev/obd"
+        assert c.telem.obd.baudrate == 0
+        assert c.telem.obd.debug is False
+        assert c.telem.vin == ""
+        assert c.telem.spool.dir == "/data/telem-spool"
+        assert c.telem.spool.max_size == 1073741824
+        assert c.pisugar.host == ""
 
     def test_buckets_have_no_env_override(self, monkeypatch):
         monkeypatch.delenv("LEMONGRASS_CONFIG", raising=False)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,23 @@
+from lemongrass import _env
+
+
+def test_reads_default_pool_var(monkeypatch):
+    monkeypatch.delenv("LEMONGRASS_CONFIG", raising=False)
+    monkeypatch.setenv("RACEMONITOR_TOKENS", "a,b,c")
+    assert _env.resolve_tokens() == ["a", "b", "c"]
+
+
+def test_single_token_returns_str(monkeypatch):
+    monkeypatch.delenv("LEMONGRASS_CONFIG", raising=False)
+    monkeypatch.delenv("RACEMONITOR_TOKENS", raising=False)
+    monkeypatch.setenv("RACEMONITOR_TOKEN", "solo")
+    assert _env.resolve_tokens() == "solo"
+
+
+def test_pool_var_name_is_configurable(monkeypatch, tmp_path):
+    cfg = tmp_path / "c.toml"
+    cfg.write_text('[racemonitor]\ntokens_env = "MY_POOL"\n')
+    monkeypatch.setenv("LEMONGRASS_CONFIG", str(cfg))
+    monkeypatch.delenv("RACEMONITOR_TOKENS", raising=False)
+    monkeypatch.setenv("MY_POOL", "x,y")
+    assert _env.resolve_tokens() == ["x", "y"]

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -21,3 +21,24 @@ def test_pool_var_name_is_configurable(monkeypatch, tmp_path):
     monkeypatch.delenv("RACEMONITOR_TOKENS", raising=False)
     monkeypatch.setenv("MY_POOL", "x,y")
     assert _env.resolve_tokens() == ["x", "y"]
+
+
+def test_custom_pool_var_ignores_stale_legacy_token(monkeypatch, tmp_path):
+    cfg = tmp_path / "c.toml"
+    cfg.write_text('[racemonitor]\ntokens_env = "MY_POOL"\n')
+    monkeypatch.setenv("LEMONGRASS_CONFIG", str(cfg))
+    monkeypatch.delenv("MY_POOL", raising=False)
+    monkeypatch.setenv("RACEMONITOR_TOKEN", "stale-legacy")
+    assert _env.resolve_tokens() == ""
+
+
+def test_hint_names_both_vars_for_default_pool(monkeypatch):
+    monkeypatch.delenv("LEMONGRASS_CONFIG", raising=False)
+    assert _env.tokens_env_hint() == "RACEMONITOR_TOKENS or RACEMONITOR_TOKEN"
+
+
+def test_hint_names_only_the_custom_pool_var(monkeypatch, tmp_path):
+    cfg = tmp_path / "c.toml"
+    cfg.write_text('[racemonitor]\ntokens_env = "MY_POOL"\n')
+    monkeypatch.setenv("LEMONGRASS_CONFIG", str(cfg))
+    assert _env.tokens_env_hint() == "MY_POOL"

--- a/tests/test_influx.py
+++ b/tests/test_influx.py
@@ -15,12 +15,13 @@ def test_defaults_match_prod(monkeypatch):
     assert reloaded.INFLUX_ORG == 'focism'
 
 
-def test_env_overrides(monkeypatch):
+def test_env_does_not_override_influx_constants(monkeypatch):
+    monkeypatch.delenv('LEMONGRASS_CONFIG', raising=False)
     monkeypatch.setenv('INFLUX_URL', 'http://localhost:8086')
     monkeypatch.setenv('INFLUX_ORG', 'lemongrass')
     reloaded = importlib.reload(influx_mod)
-    assert reloaded.INFLUX_URL == 'http://localhost:8086'
-    assert reloaded.INFLUX_ORG == 'lemongrass'
+    assert reloaded.INFLUX_URL == 'https://influxdb.focism.com'
+    assert reloaded.INFLUX_ORG == 'focism'
     monkeypatch.delenv('INFLUX_URL', raising=False)
     monkeypatch.delenv('INFLUX_ORG', raising=False)
     importlib.reload(influx_mod)  # restore default module state for later tests

--- a/tests/test_influx.py
+++ b/tests/test_influx.py
@@ -96,6 +96,20 @@ def test_build_retries_shares_transient_policy_with_fewer_attempts():
     assert trimmed.backoff_max == 10
 
 
+def test_connect_reads_token_from_configured_env_var(monkeypatch, tmp_path):
+    cfg = tmp_path / "c.toml"
+    cfg.write_text('[influx]\ntoken_env = "MY_TOKEN"\n')
+    monkeypatch.setenv('LEMONGRASS_CONFIG', str(cfg))
+    monkeypatch.delenv('INFLUX_TELEMETRY_TOKEN', raising=False)
+    monkeypatch.setenv('MY_TOKEN', 'via-directive')
+    reloaded = importlib.reload(influx_mod)
+    with mock.patch('influxdb_client.InfluxDBClient') as client_cls:
+        reloaded.connect()
+    assert client_cls.call_args.kwargs['token'] == 'via-directive'
+    monkeypatch.delenv('LEMONGRASS_CONFIG', raising=False)
+    importlib.reload(influx_mod)  # restore default module state for later tests
+
+
 class TestInvalidFluxIds:
     def test_clean_ids_pass(self):
         from lemongrass import _influx

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -3513,6 +3513,34 @@ class TestMainMissingToken:
                    for r in caplog.records)
 
 
+class TestMainInfluxTokenPreflight:
+    _ARGV: ClassVar[list] = ['lemongrass-laps', '-n', '12345', '42']
+
+    def test_logs_error_and_exits_when_influx_token_not_set(self, caplog):
+        with patch.dict(os.environ, {'RACEMONITOR_TOKENS': 'TOKEN'}, clear=True):
+            with patch.object(_mod.sys, 'argv', self._ARGV):
+                with caplog.at_level(logging.ERROR):
+                    with pytest.raises(SystemExit) as exc_info:
+                        _mod.main()
+        assert exc_info.value.code == 1
+        assert any('INFLUX_TELEMETRY_TOKEN' in r.message for r in caplog.records)
+
+    def test_honors_configured_token_env_var(self, caplog, tmp_path):
+        cfg = tmp_path / "c.toml"
+        cfg.write_text('[influx]\ntoken_env = "MY_INFLUX_TOKEN"\n')
+        env = {
+            'RACEMONITOR_TOKENS': 'TOKEN',
+            'LEMONGRASS_CONFIG': str(cfg),
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with patch.object(_mod.sys, 'argv', self._ARGV):
+                with caplog.at_level(logging.ERROR):
+                    with pytest.raises(SystemExit) as exc_info:
+                        _mod.main()
+        assert exc_info.value.code == 1
+        assert any('MY_INFLUX_TOKEN' in r.message for r in caplog.records)
+
+
 class TestMainFluxIdValidation:
     """laps.main() interpolates race_id/car_number into Flux delete predicates and
     queries, so it must reject unsafe identifiers before touching RaceMonitor/Influx,

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -3512,6 +3512,18 @@ class TestMainMissingToken:
         assert any('RACEMONITOR_TOKENS' in r.message and 'RACEMONITOR_TOKEN' in r.message
                    for r in caplog.records)
 
+    def test_no_token_error_honors_configured_pool_var(self, caplog, tmp_path):
+        cfg = tmp_path / "c.toml"
+        cfg.write_text('[racemonitor]\ntokens_env = "MY_POOL"\n')
+        env = {'RACEMONITOR_TOKEN': 'stale-legacy', 'LEMONGRASS_CONFIG': str(cfg)}
+        with patch.dict(os.environ, env, clear=True):
+            with patch.object(_mod.sys, 'argv', ['laps', '12345', '42']):
+                with caplog.at_level(logging.ERROR):
+                    with pytest.raises(SystemExit) as exc_info:
+                        _mod.main()
+        assert exc_info.value.code == 1
+        assert any('MY_POOL' in r.message for r in caplog.records)
+
 
 class TestMainInfluxTokenPreflight:
     _ARGV: ClassVar[list] = ['lemongrass-laps', '-n', '12345', '42']

--- a/tests/test_pisugar_monitor.py
+++ b/tests/test_pisugar_monitor.py
@@ -93,6 +93,20 @@ class TestMain:
         assert exc.value.code == 1
         login.assert_not_called()
 
+    def test_honors_configured_token_env_var(self, monkeypatch, tmp_path):
+        cfg = tmp_path / "c.toml"
+        cfg.write_text('[influx]\ntoken_env = "MY_INFLUX_TOKEN"\n')
+        monkeypatch.setenv("LEMONGRASS_CONFIG", str(cfg))
+        monkeypatch.delenv("INFLUX_TELEMETRY_TOKEN", raising=False)
+        monkeypatch.delenv("MY_INFLUX_TOKEN", raising=False)
+        login = MagicMock()
+        with patch.object(_mod, 'login', login), \
+                patch.object(_mod, 'read_credentials', return_value=('admin', 'secret')):
+            with pytest.raises(SystemExit) as exc:
+                _mod.main()
+        assert exc.value.code == 1
+        login.assert_not_called()
+
 
 class TestExecCommandCoercion:
     def test_raw_mode_preserves_version_strings(self):
@@ -139,12 +153,14 @@ class TestStartupConnect:
 
 
 class TestResolveHost:
-    def test_uses_host_env_when_set(self, monkeypatch):
-        monkeypatch.setenv("HOST", "car-lemongrass-pi")
+    def test_uses_configured_host_when_set(self, monkeypatch, tmp_path):
+        cfg = tmp_path / "c.toml"
+        cfg.write_text('[pisugar]\nhost = "car-lemongrass-pi"\n')
+        monkeypatch.setenv("LEMONGRASS_CONFIG", str(cfg))
         assert _mod._resolve_host() == "car-lemongrass-pi"
 
     def test_falls_back_to_gethostname(self, monkeypatch):
-        monkeypatch.delenv("HOST", raising=False)
+        monkeypatch.delenv("LEMONGRASS_CONFIG", raising=False)
         with patch.object(_mod.socket, "gethostname", return_value="fallback-host"):
             assert _mod._resolve_host() == "fallback-host"
 

--- a/tests/test_race_backfill.py
+++ b/tests/test_race_backfill.py
@@ -31,7 +31,7 @@ class TestFindMatchingRaces:
 
     def test_searches_each_lemons_term(self):
         client = self._client({})
-        _mod.find_matching_races(client, start_year_epoc=EPOC_2021)
+        _mod.find_matching_races(client, start_epoc=EPOC_2021)
         called_terms = [c.args[0] for c in client.results.search_results.call_args_list]
         for term in _mod.LEMONS_SEARCH_TERMS:
             assert term in called_terms
@@ -40,7 +40,7 @@ class TestFindMatchingRaces:
         client = self._client({
             'Real Hoopties': [_make_race(1, 'Real Hoopties 2022', EPOC_2022)],
         })
-        races = _mod.find_matching_races(client, start_year_epoc=EPOC_2021)
+        races = _mod.find_matching_races(client, start_epoc=EPOC_2021)
         assert len(races) == 1
         assert races[0]['ID'] == 1
 
@@ -48,7 +48,7 @@ class TestFindMatchingRaces:
         client = self._client({
             'Real Hoopties': [_make_race(1, 'Real Hoopties 2020', EPOC_2020)],
         })
-        races = _mod.find_matching_races(client, start_year_epoc=EPOC_2021)
+        races = _mod.find_matching_races(client, start_epoc=EPOC_2021)
         assert races == []
 
     def test_deduplicates_races_appearing_in_multiple_searches(self):
@@ -57,7 +57,7 @@ class TestFindMatchingRaces:
             'GP du Lac': [],
             'Halloween Hoop': [_make_race(1, 'Real Hoopties Halloween 2022', EPOC_2022)],
         })
-        races = _mod.find_matching_races(client, start_year_epoc=EPOC_2021)
+        races = _mod.find_matching_races(client, start_epoc=EPOC_2021)
         assert len(races) == 1
 
     def test_returns_races_sorted_by_start_date(self):
@@ -67,19 +67,8 @@ class TestFindMatchingRaces:
                 _make_race(1, 'Real Hoopties 2022', EPOC_2022),
             ],
         })
-        races = _mod.find_matching_races(client, start_year_epoc=EPOC_2021)
+        races = _mod.find_matching_races(client, start_epoc=EPOC_2021)
         assert [r['ID'] for r in races] == [1, 2]
-
-
-class TestResolveCarNumber:
-    def test_returns_default_when_no_override(self):
-        assert _mod.resolve_car_number('101', default='252', overrides={}) == '252'
-
-    def test_returns_override_when_present(self):
-        assert _mod.resolve_car_number('101', default='252', overrides={'101': '253'}) == '253'
-
-    def test_override_does_not_affect_other_races(self):
-        assert _mod.resolve_car_number('202', default='252', overrides={'101': '253'}) == '252'
 
 
 class TestRunBackfill:
@@ -92,50 +81,33 @@ class TestRunBackfill:
     def test_calls_laps_for_each_race(self):
         with patch.object(_mod.subprocess, 'run') as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
-            _mod.run_backfill(self._races(), default_car='252', overrides={})
+            _mod.run_backfill(self._races())
         assert mock_run.call_count == 2
 
-    def test_uses_override_car_number(self):
+    def test_command_has_no_car_argument(self):
         with patch.object(_mod.subprocess, 'run') as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
-            _mod.run_backfill(self._races(), default_car='252', overrides={'101': '253'})
-        calls = [c.args[0] for c in mock_run.call_args_list]
-        assert '253' in calls[0]
-        assert '252' in calls[1]
+            _mod.run_backfill(self._races()[:1])
+        cmd = mock_run.call_args.args[0]
+        assert cmd == ['lemongrass', 'laps', '-n', '--skip-if-complete', '101']
 
     def test_dry_run_does_not_call_subprocess(self):
         with patch.object(_mod.subprocess, 'run') as mock_run:
-            _mod.run_backfill(self._races(), default_car='252', overrides={}, dry_run=True)
+            _mod.run_backfill(self._races(), dry_run=True)
         mock_run.assert_not_called()
 
-    def test_dry_run_logs_race_name_and_car(self, caplog):
+    def test_dry_run_logs_race_name(self, caplog):
         import logging
         with caplog.at_level(logging.INFO, logger='root'):
-            _mod.run_backfill(self._races(), default_car='252', overrides={}, dry_run=True)
-        assert any('Real Hoopties 2022' in r.message and '252' in r.message
-                   for r in caplog.records)
-
-    def test_dry_run_logs_override_car(self, caplog):
-        import logging
-        with caplog.at_level(logging.INFO, logger='root'):
-            _mod.run_backfill(self._races(), default_car='252',
-                              overrides={'101': '253'}, dry_run=True)
-        assert any('Real Hoopties 2022' in r.message and '253' in r.message
-                   for r in caplog.records)
-
-    def test_subprocess_invokes_lemongrass_laps(self):
-        with patch.object(_mod.subprocess, 'run') as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
-            _mod.run_backfill(self._races()[:1], default_car='252', overrides={})
-        cmd = mock_run.call_args.args[0]
-        assert cmd[:2] == ['lemongrass', 'laps']
+            _mod.run_backfill(self._races(), dry_run=True)
+        assert any('Real Hoopties 2022' in r.message for r in caplog.records)
 
     def test_failure_summary_logged_when_any_race_fails(self, caplog):
         import logging
         with patch.object(_mod.subprocess, 'run') as mock_run:
             mock_run.return_value = MagicMock(returncode=1)
             with caplog.at_level(logging.ERROR, logger='root'):
-                _mod.run_backfill(self._races(), default_car='252', overrides={})
+                _mod.run_backfill(self._races())
         assert any('2 race(s) failed' in r.message for r in caplog.records)
 
     def test_no_failure_summary_when_all_succeed(self, caplog):
@@ -143,59 +115,37 @@ class TestRunBackfill:
         with patch.object(_mod.subprocess, 'run') as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
             with caplog.at_level(logging.ERROR, logger='root'):
-                _mod.run_backfill(self._races(), default_car='252', overrides={})
+                _mod.run_backfill(self._races())
         assert not any('failed' in r.message for r in caplog.records)
 
     def test_returns_failed_race_ids(self):
         with patch.object(_mod.subprocess, 'run') as mock_run:
             mock_run.side_effect = [MagicMock(returncode=0), MagicMock(returncode=1)]
-            failures = _mod.run_backfill(self._races(), default_car='252', overrides={})
-        assert failures == [('202', '252')]
+            failures = _mod.run_backfill(self._races())
+        assert failures == ['202']
 
     def test_returns_empty_list_when_all_succeed(self):
         with patch.object(_mod.subprocess, 'run') as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
-            failures = _mod.run_backfill(self._races(), default_car='252', overrides={})
+            failures = _mod.run_backfill(self._races())
         assert failures == []
 
     def test_passes_skip_if_complete_by_default(self):
         with patch.object(_mod.subprocess, 'run') as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
-            _mod.run_backfill(self._races()[:1], default_car='252', overrides={})
+            _mod.run_backfill(self._races()[:1])
         assert '--skip-if-complete' in mock_run.call_args.args[0]
 
     def test_omits_skip_if_complete_when_forced(self):
         with patch.object(_mod.subprocess, 'run') as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
-            _mod.run_backfill(self._races()[:1], default_car='252', overrides={}, force=True)
+            _mod.run_backfill(self._races()[:1], force=True)
         assert '--skip-if-complete' not in mock_run.call_args.args[0]
 
 
-class TestBuildPairs:
-    def test_builds_pairs_from_races(self):
-        races = [_make_race(101, 'Real Hoopties 2022', EPOC_2022)]
-        pairs = _mod.build_pairs(races, default_car='252', overrides={})
-        assert pairs == [('101', '252')]
-
-    def test_applies_override_to_matching_race(self):
-        races = [_make_race(101, 'Real Hoopties 2022', EPOC_2022)]
-        pairs = _mod.build_pairs(races, default_car='252', overrides={'101': '253'})
-        assert pairs == [('101', '253')]
-
-    def test_builds_multiple_pairs(self):
-        races = [
-            _make_race(101, 'Real Hoopties 2022', EPOC_2022),
-            _make_race(202, 'GP du Lac 2022', EPOC_2022),
-        ]
-        pairs = _mod.build_pairs(races, default_car='252', overrides={'101': '253'})
-        assert pairs == [('101', '253'), ('202', '252')]
-
-
 class TestValidateBackfill:
-    def _make_query_api(self, race_name='My Race', actual_cars=None,
+    def _make_query_api(self, race_name='My Race', lap_count=0,
                         race_start=None, race_end_epoc=1672531200):
-        if actual_cars is None:
-            actual_cars = {}
         if race_start is None:
             race_start = datetime(2022, 1, 1, tzinfo=UTC)
 
@@ -211,79 +161,76 @@ class TestValidateBackfill:
                     rec.get_value.return_value = race_end_epoc
                     table.records = [rec]
             else:
-                table.records = []
-                for car, count in actual_cars.items():
+                if lap_count:
                     rec = MagicMock()
-                    rec.values = {'car_number': car, '_value': count}
-                    table.records.append(rec)
+                    rec.get_value.return_value = lap_count
+                    table.records = [rec]
+                else:
+                    table.records = []
             return [table]
 
         api = MagicMock()
         api.query.side_effect = fake_query
         return api
 
-    def test_returns_true_when_all_expected_cars_present(self):
-        query_api = self._make_query_api(actual_cars={'42': 10, '99': 5})
-        result = _mod.validate_backfill([('101', '42'), ('101', '99')], query_api)
-        assert result is True
+    def test_returns_true_when_race_has_laps(self):
+        query_api = self._make_query_api(lap_count=15)
+        assert _mod.validate_backfill(['101'], query_api) is True
 
-    def test_returns_false_when_a_car_is_missing(self):
-        query_api = self._make_query_api(actual_cars={'42': 10})
-        result = _mod.validate_backfill([('101', '42'), ('101', '99')], query_api)
-        assert result is False
+    def test_returns_false_when_race_has_no_laps(self):
+        query_api = self._make_query_api(lap_count=0)
+        assert _mod.validate_backfill(['101'], query_api) is False
 
     def test_returns_false_when_race_metadata_missing(self):
-        query_api = self._make_query_api(race_name=None, actual_cars={'42': 10})
-        result = _mod.validate_backfill([('101', '42')], query_api)
-        assert result is False
+        query_api = self._make_query_api(race_name=None, lap_count=15)
+        assert _mod.validate_backfill(['101'], query_api) is False
 
     def test_logs_race_name_in_output(self, caplog):
         import logging
-        query_api = self._make_query_api(race_name='Lemons 2026', actual_cars={'42': 10})
+        query_api = self._make_query_api(race_name='Lemons 2026', lap_count=15)
         with caplog.at_level(logging.INFO, logger='root'):
-            _mod.validate_backfill([('101', '42')], query_api)
+            _mod.validate_backfill(['101'], query_api)
         assert any('Lemons 2026' in r.message for r in caplog.records)
 
-    def test_logs_ok_with_car_numbers_and_lap_counts(self, caplog):
+    def test_logs_ok_with_lap_count(self, caplog):
         import logging
-        query_api = self._make_query_api(actual_cars={'42': 10, '99': 5})
+        query_api = self._make_query_api(lap_count=15)
         with caplog.at_level(logging.INFO, logger='root'):
-            _mod.validate_backfill([('101', '42'), ('101', '99')], query_api)
-        assert any('OK' in r.message and '42' in r.message and '10' in r.message
-                   for r in caplog.records)
+            _mod.validate_backfill(['101'], query_api)
+        assert any('OK' in r.message and '15' in r.message for r in caplog.records)
 
-    def test_logs_missing_cars(self, caplog):
+    def test_logs_warning_when_no_laps(self, caplog):
         import logging
-        query_api = self._make_query_api(actual_cars={'42': 10})
+        query_api = self._make_query_api(lap_count=0)
         with caplog.at_level(logging.WARNING, logger='root'):
-            _mod.validate_backfill([('101', '42'), ('101', '99')], query_api)
-        assert any('MISSING' in r.message and '99' in r.message for r in caplog.records)
+            _mod.validate_backfill(['101'], query_api)
+        assert any('NO laps' in r.message for r in caplog.records)
 
     def test_laps_not_queried_when_race_metadata_missing(self):
         query_api = self._make_query_api(race_name=None)
-        _mod.validate_backfill([('101', '42')], query_api)
+        _mod.validate_backfill(['101'], query_api)
         assert query_api.query.call_count == 1
 
     def test_laps_query_scoped_to_race_time_bounds(self):
         race_start = datetime(2022, 6, 1, tzinfo=UTC)
-        query_api = self._make_query_api(actual_cars={'42': 10},
-                                         race_start=race_start, race_end_epoc=1672531200)
-        _mod.validate_backfill([('101', '42')], query_api)
+        query_api = self._make_query_api(lap_count=10, race_start=race_start,
+                                         race_end_epoc=1672531200)
+        _mod.validate_backfill(['101'], query_api)
         laps_flux = query_api.query.call_args_list[1].args[0]
         assert '1970-01-01' not in laps_flux
         assert '2022-05-31' in laps_flux  # race_start (2022-06-01) padded back one day
 
     def test_races_query_filters_by_end_time_epoc_field(self):
-        query_api = self._make_query_api(actual_cars={'42': 10})
-        _mod.validate_backfill([('101', '42')], query_api)
+        query_api = self._make_query_api(lap_count=10)
+        _mod.validate_backfill(['101'], query_api)
         races_flux = query_api.query.call_args_list[0].args[0]
         assert '_field == "end_time_epoc"' in races_flux
 
     def test_logs_warning_when_end_time_epoc_zero(self, caplog):
         import logging
-        query_api = self._make_query_api(actual_cars={'42': 10}, race_end_epoc=0)
+        query_api = self._make_query_api(lap_count=10, race_end_epoc=0)
         with caplog.at_level(logging.WARNING, logger='root'):
-            _mod.validate_backfill([('101', '42')], query_api)
+            _mod.validate_backfill(['101'], query_api)
         assert any('end_time_epoc' in r.message for r in caplog.records
                    if r.levelno == logging.WARNING)
 
@@ -524,6 +471,24 @@ class TestUpgradeStoredArgParsing:
         assert args.force is True
 
 
+class TestParseStartDate:
+    def test_valid_date_returns_utc_midnight_epoch(self):
+        assert _mod._parse_start_date('2021-01-01') == EPOC_2021
+
+    def test_bad_format_exits_1(self):
+        with pytest.raises(SystemExit) as exc:
+            _mod._parse_start_date('01/01/2021')
+        assert exc.value.code == 1
+
+    def test_start_date_arg_default_from_config(self):
+        args = _mod._build_parser().parse_args([])
+        assert args.start_date == _mod.DEFAULT_START_DATE
+
+    def test_start_date_arg_override(self):
+        args = _mod._build_parser().parse_args(['--start-date', '2023-06-01'])
+        assert args.start_date == '2023-06-01'
+
+
 class TestArgParsing:
     def test_dry_run_flag(self):
         args = _mod._build_parser().parse_args(['--dry-run'])
@@ -532,19 +497,6 @@ class TestArgParsing:
     def test_dry_run_default(self):
         args = _mod._build_parser().parse_args([])
         assert args.dry_run is False
-
-    def test_override_single(self):
-        args = _mod._build_parser().parse_args(['--override', '12345:253'])
-        assert args.overrides == {'12345': '253'}
-
-    def test_override_multiple(self):
-        args = _mod._build_parser().parse_args(
-            ['--override', '12345:253', '--override', '99999:84'])
-        assert args.overrides == {'12345': '253', '99999': '84'}
-
-    def test_override_default_empty(self):
-        args = _mod._build_parser().parse_args([])
-        assert args.overrides == {}
 
     def test_validate_flag_accepted(self):
         args = _mod._build_parser().parse_args(['--validate'])
@@ -608,23 +560,6 @@ class TestMainTokenResolution:
         assert any('MY_POOL' in r.message for r in caplog.records)
 
 
-class TestInputValidation:
-    def test_car_number_with_quote_exits_1(self):
-        import lemongrass.race_backfill as rb
-        with patch.object(sys, 'argv', ['lemongrass-race-backfill', '--car', 'x"y']):
-            with pytest.raises(SystemExit) as exc:
-                rb.main()
-        assert exc.value.code == 1
-
-    def test_override_with_quote_exits_1(self):
-        import lemongrass.race_backfill as rb
-        with patch.object(sys, 'argv',
-                          ['lemongrass-race-backfill', '--override', '123:x"y']):
-            with pytest.raises(SystemExit) as exc:
-                rb.main()
-        assert exc.value.code == 1
-
-
 class TestValidateWindowPadding:
     def test_lap_query_padded_one_day_each_side(self):
         import lemongrass.race_backfill as rb
@@ -642,7 +577,7 @@ class TestValidateWindowPadding:
         lap_table.records = []
         query_api.query.side_effect = [[race_table], [lap_table]]
 
-        rb.validate_backfill([('999', '42')], query_api)
+        rb.validate_backfill(['999'], query_api)
         lap_flux = query_api.query.call_args_list[1].args[0]
         assert 'start: 2020-01-01T00:00:00Z' in lap_flux
         assert 'stop: 2020-01-05T00:00:00Z' in lap_flux
@@ -653,15 +588,13 @@ def test_backfill_defaults_come_from_config(monkeypatch, tmp_path):
     cfg.write_text(
         '[races.backfill]\n'
         'search_terms = ["Enduro X"]\n'
-        'default_car_number = "77"\n'
-        'default_start_year = 2019\n'
+        'default_start_date = "2019-03-15"\n'
     )
     monkeypatch.setenv("LEMONGRASS_CONFIG", str(cfg))
     from lemongrass import race_backfill
     reloaded = importlib.reload(race_backfill)
     assert reloaded.LEMONS_SEARCH_TERMS == ("Enduro X",)
-    assert reloaded.DEFAULT_CAR_NUMBER == "77"
-    assert reloaded.DEFAULT_START_YEAR == 2019
+    assert reloaded.DEFAULT_START_DATE == "2019-03-15"
     monkeypatch.delenv("LEMONGRASS_CONFIG", raising=False)
     importlib.reload(race_backfill)  # restore default module state
 

--- a/tests/test_race_backfill.py
+++ b/tests/test_race_backfill.py
@@ -592,9 +592,11 @@ def test_backfill_defaults_come_from_config(monkeypatch, tmp_path):
     )
     monkeypatch.setenv("LEMONGRASS_CONFIG", str(cfg))
     from lemongrass import race_backfill
-    reloaded = importlib.reload(race_backfill)
-    assert reloaded.LEMONS_SEARCH_TERMS == ("Enduro X",)
-    assert reloaded.DEFAULT_START_DATE == "2019-03-15"
-    monkeypatch.delenv("LEMONGRASS_CONFIG", raising=False)
-    importlib.reload(race_backfill)  # restore default module state
+    try:
+        reloaded = importlib.reload(race_backfill)
+        assert reloaded.LEMONS_SEARCH_TERMS == ("Enduro X",)
+        assert reloaded.DEFAULT_START_DATE == "2019-03-15"
+    finally:
+        monkeypatch.delenv("LEMONGRASS_CONFIG", raising=False)
+        importlib.reload(race_backfill)  # restore default module state
 

--- a/tests/test_race_backfill.py
+++ b/tests/test_race_backfill.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 import sys
 from datetime import UTC, datetime
@@ -632,4 +633,22 @@ class TestValidateWindowPadding:
         lap_flux = query_api.query.call_args_list[1].args[0]
         assert 'start: 2020-01-01T00:00:00Z' in lap_flux
         assert 'stop: 2020-01-05T00:00:00Z' in lap_flux
+
+
+def test_backfill_defaults_come_from_config(monkeypatch, tmp_path):
+    cfg = tmp_path / "c.toml"
+    cfg.write_text(
+        '[races.backfill]\n'
+        'search_terms = ["Enduro X"]\n'
+        'default_car_number = "77"\n'
+        'default_start_year = 2019\n'
+    )
+    monkeypatch.setenv("LEMONGRASS_CONFIG", str(cfg))
+    from lemongrass import race_backfill
+    reloaded = importlib.reload(race_backfill)
+    assert reloaded.LEMONS_SEARCH_TERMS == ("Enduro X",)
+    assert reloaded.DEFAULT_CAR_NUMBER == "77"
+    assert reloaded.DEFAULT_START_YEAR == 2019
+    monkeypatch.delenv("LEMONGRASS_CONFIG", raising=False)
+    importlib.reload(race_backfill)  # restore default module state
 

--- a/tests/test_race_backfill.py
+++ b/tests/test_race_backfill.py
@@ -594,6 +594,19 @@ class TestMainTokenResolution:
                     _mod.main()
         assert exc_info.value.code == 1
 
+    def test_no_token_error_honors_configured_pool_var(self, caplog, tmp_path):
+        import logging
+        cfg = tmp_path / "c.toml"
+        cfg.write_text('[racemonitor]\ntokens_env = "MY_POOL"\n')
+        env = {'RACEMONITOR_TOKEN': 'stale-legacy', 'LEMONGRASS_CONFIG': str(cfg)}
+        with patch.dict(os.environ, env, clear=True):
+            with patch.object(sys, 'argv', ['race-backfill']):
+                with caplog.at_level(logging.ERROR):
+                    with pytest.raises(SystemExit) as exc_info:
+                        _mod.main()
+        assert exc_info.value.code == 1
+        assert any('MY_POOL' in r.message for r in caplog.records)
+
 
 class TestInputValidation:
     def test_car_number_with_quote_exits_1(self):

--- a/tests/test_race_diagnose.py
+++ b/tests/test_race_diagnose.py
@@ -61,6 +61,21 @@ class TestMainTokenResolution:
         assert 'RACEMONITOR_TOKENS' in out
         assert 'RACEMONITOR_TOKEN' in out
 
+    def test_honors_configured_token_env_var(self, capsys, tmp_path):
+        cfg = tmp_path / "c.toml"
+        cfg.write_text('[influx]\ntoken_env = "MY_INFLUX_TOKEN"\n')
+        env = {
+            'RACEMONITOR_TOKENS': 'TOKEN1',
+            'LEMONGRASS_CONFIG': str(cfg),
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with patch.object(sys, 'argv', ['race-diagnose', '12345', '42']):
+                with pytest.raises(SystemExit) as exc_info:
+                    _mod.main()
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert 'MY_INFLUX_TOKEN not set' in out
+
 
 class TestInputValidation:
     def test_race_id_with_quote_exits_before_any_query(self):

--- a/tests/test_race_diagnose.py
+++ b/tests/test_race_diagnose.py
@@ -61,6 +61,22 @@ class TestMainTokenResolution:
         assert 'RACEMONITOR_TOKENS' in out
         assert 'RACEMONITOR_TOKEN' in out
 
+    def test_no_token_message_honors_configured_pool_var(self, capsys, tmp_path):
+        cfg = tmp_path / "c.toml"
+        cfg.write_text('[racemonitor]\ntokens_env = "MY_POOL"\n')
+        env = {
+            'INFLUX_TELEMETRY_TOKEN': 'ITOKEN',
+            'RACEMONITOR_TOKEN': 'stale-legacy',
+            'LEMONGRASS_CONFIG': str(cfg),
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with patch.object(sys, 'argv', ['race-diagnose', '12345', '42']):
+                with pytest.raises(SystemExit) as exc_info:
+                    _mod.main()
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert 'MY_POOL not set' in out
+
     def test_honors_configured_token_env_var(self, capsys, tmp_path):
         cfg = tmp_path / "c.toml"
         cfg.write_text('[influx]\ntoken_env = "MY_INFLUX_TOKEN"\n')

--- a/tests/test_spool.py
+++ b/tests/test_spool.py
@@ -13,20 +13,25 @@ def _pt(measurement, value):
 
 
 class TestConfig:
-    def test_from_env_defaults(self, monkeypatch):
-        monkeypatch.delenv("TELEM_SPOOL_DIR", raising=False)
-        monkeypatch.delenv("TELEM_SPOOL_MAX_BYTES", raising=False)
+    def test_from_config_defaults(self, monkeypatch):
+        monkeypatch.delenv("LEMONGRASS_CONFIG", raising=False)
         monkeypatch.setattr(Spool, "_ensure_dir", lambda self: True)
-        s = Spool.from_env()
+        s = Spool.from_config()
         assert str(s.dir) == DEFAULT_SPOOL_DIR
         assert s.max_bytes == DEFAULT_MAX_BYTES
 
-    def test_from_env_overrides(self, monkeypatch, tmp_path):
-        monkeypatch.setenv("TELEM_SPOOL_DIR", str(tmp_path / "spool"))
-        monkeypatch.setenv("TELEM_SPOOL_MAX_BYTES", "12345")
-        s = Spool.from_env()
+    def test_from_config_reads_file(self, monkeypatch, tmp_path):
+        cfg = tmp_path / "c.toml"
+        cfg.write_text(
+            '[telem.spool]\n'
+            f'dir = "{tmp_path / "spool"}"\n'
+            'max_size = "2GiB"\n'
+        )
+        monkeypatch.setenv("LEMONGRASS_CONFIG", str(cfg))
+        monkeypatch.setattr(Spool, "_ensure_dir", lambda self: True)
+        s = Spool.from_config()
         assert str(s.dir) == str(tmp_path / "spool")
-        assert s.max_bytes == 12345
+        assert s.max_bytes == 2 * 1024 ** 3
 
 
 class TestAppend:

--- a/tests/test_telem.py
+++ b/tests/test_telem.py
@@ -29,31 +29,33 @@ def _reset():
 
 class TestConnect:
     def test_defaults_to_obd_symlink(self, monkeypatch):
-        monkeypatch.delenv("OBD_PORT", raising=False)
-        monkeypatch.delenv("OBD_BAUDRATE", raising=False)
+        monkeypatch.delenv("LEMONGRASS_CONFIG", raising=False)
         with patch.object(_mod.obd, "Async") as mock_async:
             _mod.connect()
         mock_async.assert_called_once_with(portstr="/dev/obd")
 
-    def test_uses_obd_port_env_override(self, monkeypatch):
-        monkeypatch.setenv("OBD_PORT", "/dev/ttyUSB0")
-        monkeypatch.delenv("OBD_BAUDRATE", raising=False)
+    def test_uses_configured_port(self, monkeypatch, tmp_path):
+        cfg = tmp_path / "c.toml"
+        cfg.write_text('[telem.obd]\nport = "/dev/ttyUSB0"\n')
+        monkeypatch.setenv("LEMONGRASS_CONFIG", str(cfg))
         with patch.object(_mod.obd, "Async") as mock_async:
             _mod.connect()
         mock_async.assert_called_once_with(portstr="/dev/ttyUSB0")
 
-    def test_passes_baudrate_when_set(self, monkeypatch):
-        monkeypatch.setenv("OBD_PORT", "socket://elm327:35000")
-        monkeypatch.setenv("OBD_BAUDRATE", "38400")
+    def test_passes_baudrate_when_set(self, monkeypatch, tmp_path):
+        cfg = tmp_path / "c.toml"
+        cfg.write_text('[telem.obd]\nport = "socket://elm327:35000"\nbaudrate = 38400\n')
+        monkeypatch.setenv("LEMONGRASS_CONFIG", str(cfg))
         with patch.object(_mod.obd, "Async") as mock_async:
             _mod.connect()
         mock_async.assert_called_once_with(
             portstr="socket://elm327:35000", baudrate=38400
         )
 
-    def test_omits_baudrate_when_unset(self, monkeypatch):
-        monkeypatch.setenv("OBD_PORT", "/dev/obd")
-        monkeypatch.delenv("OBD_BAUDRATE", raising=False)
+    def test_omits_baudrate_when_zero(self, monkeypatch, tmp_path):
+        cfg = tmp_path / "c.toml"
+        cfg.write_text('[telem.obd]\nport = "/dev/obd"\nbaudrate = 0\n')
+        monkeypatch.setenv("LEMONGRASS_CONFIG", str(cfg))
         with patch.object(_mod.obd, "Async") as mock_async:
             _mod.connect()
         _, kwargs = mock_async.call_args
@@ -171,13 +173,15 @@ class TestNewFuelStatus:
 
 class TestConfigureObdLogging:
     def test_no_debug_by_default(self, monkeypatch):
-        monkeypatch.delenv("OBD_DEBUG", raising=False)
+        monkeypatch.delenv("LEMONGRASS_CONFIG", raising=False)
         with patch.object(_mod.obd.logger, "setLevel") as mock_set_level:
             _mod._configure_obd_logging()
         mock_set_level.assert_not_called()
 
-    def test_debug_enabled_via_env(self, monkeypatch):
-        monkeypatch.setenv("OBD_DEBUG", "1")
+    def test_debug_enabled_via_config(self, monkeypatch, tmp_path):
+        cfg = tmp_path / "c.toml"
+        cfg.write_text('[telem.obd]\ndebug = true\n')
+        monkeypatch.setenv("LEMONGRASS_CONFIG", str(cfg))
         with patch.object(_mod.obd.logger, "setLevel") as mock_set_level:
             _mod._configure_obd_logging()
         mock_set_level.assert_called_once_with(logging.DEBUG)
@@ -295,7 +299,7 @@ class TestResolveVin:
     def test_uses_obd_vin_when_available(self, monkeypatch):
         # python-obd returns Mode 09 VIN as a bytearray; it must be decoded, not
         # stringified (str(bytearray(...)) yields the literal "bytearray(b'...')").
-        monkeypatch.delenv("CAR_VIN", raising=False)
+        monkeypatch.delenv("LEMONGRASS_CONFIG", raising=False)
         connection = MagicMock()
         r = MagicMock()
         r.value = bytearray(b"1FATESTVIN0000001")
@@ -308,7 +312,7 @@ class TestResolveVin:
 
     def test_strips_null_padding_from_obd_vin(self, monkeypatch):
         # A real Mode 09 response can be NUL-padded; the tag must not carry NULs.
-        monkeypatch.delenv("CAR_VIN", raising=False)
+        monkeypatch.delenv("LEMONGRASS_CONFIG", raising=False)
         connection = MagicMock()
         r = MagicMock()
         r.value = bytearray(b"1FATESTVIN0000001\x00\x00\x00")
@@ -317,7 +321,7 @@ class TestResolveVin:
         assert vin == "1FATESTVIN0000001"
 
     def test_force_queries_vin_even_when_supports_false(self, monkeypatch):
-        monkeypatch.delenv("CAR_VIN", raising=False)
+        monkeypatch.delenv("LEMONGRASS_CONFIG", raising=False)
         connection = MagicMock()
         connection.supports.return_value = False
         r = MagicMock()
@@ -329,24 +333,28 @@ class TestResolveVin:
         )
         assert vin == "1FATESTVIN0000004"
 
-    def test_falls_back_to_env_when_obd_returns_no_value(self, monkeypatch):
-        monkeypatch.setenv("CAR_VIN", "ENVVIN00000000001")
+    def test_falls_back_to_config_vin_when_obd_returns_no_value(self, monkeypatch, tmp_path):
+        cfg = tmp_path / "c.toml"
+        cfg.write_text('[telem]\nvin = "CFGVIN00000000001"\n')
+        monkeypatch.setenv("LEMONGRASS_CONFIG", str(cfg))
         connection = MagicMock()
         r = MagicMock()
         r.value = None
         with patch.object(_mod.obd.OBD, "query", return_value=r):
             vin = _mod._resolve_vin(connection)
-        assert vin == "ENVVIN00000000001"
+        assert vin == "CFGVIN00000000001"
 
-    def test_falls_back_to_env_when_obd_query_raises(self, monkeypatch):
-        monkeypatch.setenv("CAR_VIN", "ENVVIN00000000002")
+    def test_falls_back_to_config_vin_when_obd_query_raises(self, monkeypatch, tmp_path):
+        cfg = tmp_path / "c.toml"
+        cfg.write_text('[telem]\nvin = "CFGVIN00000000002"\n')
+        monkeypatch.setenv("LEMONGRASS_CONFIG", str(cfg))
         connection = MagicMock()
         with patch.object(_mod.obd.OBD, "query", side_effect=Exception("boom")):
             vin = _mod._resolve_vin(connection)
-        assert vin == "ENVVIN00000000002"
+        assert vin == "CFGVIN00000000002"
 
     def test_unknown_when_nothing_resolves(self, monkeypatch):
-        monkeypatch.delenv("CAR_VIN", raising=False)
+        monkeypatch.delenv("LEMONGRASS_CONFIG", raising=False)
         connection = MagicMock()
         r = MagicMock()
         r.value = None
@@ -354,8 +362,10 @@ class TestResolveVin:
             vin = _mod._resolve_vin(connection)
         assert vin == "unknown"
 
-    def test_warns_and_prefers_obd_on_mismatch(self, monkeypatch, caplog):
-        monkeypatch.setenv("CAR_VIN", "ENVVIN00000000003")
+    def test_warns_and_prefers_obd_on_mismatch(self, monkeypatch, tmp_path, caplog):
+        cfg = tmp_path / "c.toml"
+        cfg.write_text('[telem]\nvin = "CFGVIN00000000003"\n')
+        monkeypatch.setenv("LEMONGRASS_CONFIG", str(cfg))
         connection = MagicMock()
         r = MagicMock()
         r.value = "OBDVIN00000000003"
@@ -363,7 +373,7 @@ class TestResolveVin:
                 caplog.at_level(logging.WARNING):
             vin = _mod._resolve_vin(connection)
         assert vin == "OBDVIN00000000003"
-        assert any("differs from CAR_VIN" in m for m in caplog.messages)
+        assert any("differs from configured VIN" in m for m in caplog.messages)
 
 
 class TestNewStatus:

--- a/tests/test_telem.py
+++ b/tests/test_telem.py
@@ -626,7 +626,7 @@ class TestInfluxConnectTuning:
         """The hot loop must build its Influx client with a short timeout and a
         trimmed retry budget so a downed Influx fails fast to the spool."""
         with patch.object(_mod._influx, "connect") as influx_connect, \
-                patch.object(_mod.Spool, "from_env"), \
+                patch.object(_mod.Spool, "from_config"), \
                 patch.object(_mod, "_configure_obd_logging"), \
                 patch.object(_mod, "connect", side_effect=RuntimeError("stop")):
             with pytest.raises(RuntimeError, match="stop"):

--- a/tests/test_telem_integration.py
+++ b/tests/test_telem_integration.py
@@ -73,9 +73,14 @@ def emulator():
 
 
 @pytest.fixture
-def connection(emulator, monkeypatch):
-    monkeypatch.setenv("OBD_PORT", emulator.url)
-    monkeypatch.setenv("OBD_BAUDRATE", "38400")
+def connection(emulator, monkeypatch, tmp_path):
+    cfg = tmp_path / "c.toml"
+    cfg.write_text(
+        '[telem.obd]\n'
+        f'port = "{emulator.url}"\n'
+        'baudrate = 38400\n'
+    )
+    monkeypatch.setenv("LEMONGRASS_CONFIG", str(cfg))
     conn = telem.connect()
     yield conn
     conn.close()


### PR DESCRIPTION
## Summary

Adds a layered configuration system: every non-secret setting (bucket names, InfluxDB URL/org, RaceMonitor search terms, OBD/spool/pisugar knobs, backfill defaults) is now configurable from a single optional TOML file, discovered via `LEMONGRASS_CONFIG`. Secrets are never stored in the file — they are referenced by name and read from the environment.

The `race-backfill` command is also simplified to what it actually does: it always imports the whole field, so the vestigial per-car selection surface is removed and its year-granularity start filter is replaced with a `YYYY-MM-DD` start date.

## Configuration model

Non-secret settings resolve from two layers, highest priority first:

1. A TOML file named by `LEMONGRASS_CONFIG` (absolute path; optional).
2. Built-in defaults (equal to the historical literals).

The environment is used **only for secrets**, and only indirectly: `influx.token_env` names the env var holding the Influx token, and `racemonitor.tokens_env` names the env var holding the RaceMonitor token pool. The legacy singular `RACEMONITOR_TOKEN` is honored only alongside the default pool var name, so a deployment with a custom `tokens_env` can't silently pick up a stale leftover token. With no config file, behavior is the built-in defaults.

A new leaf module `src/lemongrass/_config.py` owns the frozen-dataclass schema, a `parse_size()` byte-string parser (`1GiB`/`1GB`/bytes; fractional bare numbers rejected rather than truncated), and `load_config()` with fail-loud validation (unreadable/malformed file, unknown keys, non-table sections, wrong types, bad sizes — every error names the offending key). Existing modules keep their public names but source values from `load_config()`.

## ⚠️ Breaking change

The non-secret environment variables read by released versions (v4.0.0 and earlier) are **no longer read**: `INFLUX_URL`, `INFLUX_ORG`, `OBD_PORT`, `OBD_BAUDRATE`, `OBD_DEBUG`. Deployments configured via these env vars must move those settings into a `lemongrass.toml` and set `LEMONGRASS_CONFIG`, keeping only `INFLUX_TELEMETRY_TOKEN` / `RACEMONITOR_TOKENS` in the environment. `docs/CONFIGURATION.md` includes a var→key migration table, and the CLI prints a startup warning for each dropped var it finds still set. (The unreleased post-4.0.0 vars `CAR_VIN`, `HOST`, `TELEM_SPOOL_DIR`, and `TELEM_SPOOL_MAX_BYTES` are also replaced by config keys, but they never shipped, so they need no migration.)

The `race-backfill` command surface also changes, with no migration shim:

- Config keys `races.backfill.default_car_number` and `races.backfill.default_start_year` are removed and are no longer accepted; the new `races.backfill.default_start_date` (string, `YYYY-MM-DD`, default `2017-01-01`) replaces them.
- CLI flags `--car`, `--override`, and `--start-year` are removed; `--start-date YYYY-MM-DD` replaces `--start-year`. `--upgrade-stored` remains mutually exclusive with `--start-date` and `--validate` (but composes with `--force`).

## What changed

- `_config.py` — schema, `parse_size()`, `load_config()`, validation, dropped-env-var startup warning.
- `_influx`, `_env`, `_spool` (`Spool.from_env` → `from_config`), `telem`, `pisugar_monitor`, `race_backfill`, and the `laps` / `race-diagnose` token preflights all source from config; every secret read goes through the configured `token_env` / `tokens_env`, and every missing-token error names the configured variable.
- `race_backfill` drops the car-selection surface (`--car`, `--override`, `_OverrideAction`, `resolve_car_number`, `build_pairs`, and the per-car validation) — `run_backfill` runs `lemongrass laps -n <race_id>` fieldwide and `validate_backfill` becomes a "race has ≥1 lap" check over a race-ID list. A new `_parse_start_date` validates `--start-date` at point-of-use into a UTC-midnight epoch.
- CLI dispatcher reports a malformed/missing `LEMONGRASS_CONFIG` as a one-line error (no traceback); `lemongrass --help` works regardless of config state.
- Local-testing stack (`docker-compose.yml`, `.env.local`, `CONTRIBUTING.md`) and the integration-test fixture migrated to `LEMONGRASS_CONFIG`.
- Docs: `lemongrass.toml.sample` (every key at its default), `docs/CONFIGURATION.md` (reference + migration table), README section, and a drift-guard test tying the sample to the dataclass defaults, including requiring every schema key to be listed. `.env.sample` reduced to secrets + the config pointer.

## Testing

- `uv run pytest -q` — 648 passed, 4 deselected (integration).
- `uv run ruff check src tests` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional configuration-file support via `LEMONGRASS_CONFIG`, including secret-only environment variables and config-driven defaults.
  * Racetrack backfill flow now supports `--start-date` and `--validate`, replacing `--override`, `--start-year`, and per-car options.

* **Documentation**
  * Added a full `lemongrass.toml.sample` and new `docs/CONFIGURATION.md` covering config precedence, token env names, and examples.
  * Updated local testing, contributing, and README race backfill documentation.

* **Bug Fixes**
  * Improved CLI handling for missing/invalid config (clear one-line errors; no tracebacks).
  * Enhanced error messages when required token environment variables are not set, including the configured env var name.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->
