### PR TITLE
fix(race-backfill): re-backfill in-process to stop 429 rate-limit exhaustion

### DIFF
--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -234,63 +234,78 @@ def main():
 
     try:
         with RaceMonitorClient(api_token=tokens) as client:
-            race_details = client.race.details(race_id)
-
-            start_epoc = 0
-            if race_details['Successful']:
-                race_name = race_details['Race']['Name']
-                start_epoc = race_details['Race']['StartDateEpoc']
-                logging.debug("StartDateEpoc: %s", start_epoc)
-                start_date = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(start_epoc))
-                end_epoc = race_details['Race']['EndDateEpoc']
-                end_date = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(end_epoc))
-                race_track = race_details['Race']['Track']
-                print(UNDERLINE)
-                print(f"Race {race_id}")
-                print(
-                    f"{race_name}\tStarted: {start_date:>}\n"
-                    f"{race_track}\t\t\tEnds: {end_date:>}"
-                )
-                print(UNDERLINE)
-
-            metadata = _resolve_race_metadata(race_details, client) if opts.network_mode else None
-
-            if opts.selected_class:
-                logging.info("Sorting results for class %s.", opts.selected_class.upper())
-
-            response = client.race.is_live(race_id)
-
-            is_live = response.get('Successful') and response.get('IsLive')
-            if car_number is None and (args.monitor_mode or is_live):
-                logging.error("car_number is required for live/monitor mode")
-                sys.exit(1)
-            if car_number is not None and not is_live and not args.monitor_mode:
-                logging.warning("car_number provided but ignored in historical fieldwide mode")
-
-            if not response['Successful']:
-                return 1
-
-            if not opts.network_mode:
-                return _run_race(
-                    RaceContext(race_id, car_number, client, None, start_epoc, metadata=metadata),
-                    opts, response)
-
-            if opts.dry_run:
-                return _run_race(
-                    RaceContext(race_id, car_number, client, None, start_epoc, metadata=metadata),
-                    opts, response)
-
-            with _influx.connect() as influx_client:
-                write_api = influx_client.write_api(write_options=SYNCHRONOUS)
-                delete_api = influx_client.delete_api()
-                query_api = influx_client.query_api()
-                return _run_race(
-                    RaceContext(race_id, car_number, client, write_api, start_epoc,
-                                metadata=metadata, delete_api=delete_api,
-                                query_api=query_api), opts, response)
+            return backfill_race(race_id, car_number, client, opts)
     except KeyboardInterrupt:
         logging.info("Interrupted, exiting.")
         sys.exit(130)
+
+
+def backfill_race(race_id, car_number, client, opts):
+    """Fetch and process one race using an already-open RaceMonitorClient.
+
+    Extracted from main() so a batch caller (race-backfill --upgrade-stored) can
+    reuse a single client — and therefore a single process-wide rate-limiter
+    window — across many races, instead of paying a fresh rate-limit window per
+    subprocess and overrunning the server's per-token budget at each boundary.
+
+    Returns an int exit status (0 ok, non-zero failure). KeyboardInterrupt (and
+    any RaceMonitorError, e.g. 429 exhaustion) propagates to the caller so a
+    batch loop can decide whether to stop or record-and-continue.
+    """
+    race_details = client.race.details(race_id)
+
+    start_epoc = 0
+    if race_details['Successful']:
+        race_name = race_details['Race']['Name']
+        start_epoc = race_details['Race']['StartDateEpoc']
+        logging.debug("StartDateEpoc: %s", start_epoc)
+        start_date = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(start_epoc))
+        end_epoc = race_details['Race']['EndDateEpoc']
+        end_date = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(end_epoc))
+        race_track = race_details['Race']['Track']
+        print(UNDERLINE)
+        print(f"Race {race_id}")
+        print(
+            f"{race_name}\tStarted: {start_date:>}\n"
+            f"{race_track}\t\t\tEnds: {end_date:>}"
+        )
+        print(UNDERLINE)
+
+    metadata = _resolve_race_metadata(race_details, client) if opts.network_mode else None
+
+    if opts.selected_class:
+        logging.info("Sorting results for class %s.", opts.selected_class.upper())
+
+    response = client.race.is_live(race_id)
+
+    is_live = response.get('Successful') and response.get('IsLive')
+    if car_number is None and (opts.monitor_mode or is_live):
+        logging.error("car_number is required for live/monitor mode")
+        return 1
+    if car_number is not None and not is_live and not opts.monitor_mode:
+        logging.warning("car_number provided but ignored in historical fieldwide mode")
+
+    if not response['Successful']:
+        return 1
+
+    if not opts.network_mode:
+        return _run_race(
+            RaceContext(race_id, car_number, client, None, start_epoc, metadata=metadata),
+            opts, response)
+
+    if opts.dry_run:
+        return _run_race(
+            RaceContext(race_id, car_number, client, None, start_epoc, metadata=metadata),
+            opts, response)
+
+    with _influx.connect() as influx_client:
+        write_api = influx_client.write_api(write_options=SYNCHRONOUS)
+        delete_api = influx_client.delete_api()
+        query_api = influx_client.query_api()
+        return _run_race(
+            RaceContext(race_id, car_number, client, write_api, start_epoc,
+                        metadata=metadata, delete_api=delete_api,
+                        query_api=query_api), opts, response)
 
 
 def _run_race(ctx, opts, response):

--- a/src/lemongrass/race_backfill.py
+++ b/src/lemongrass/race_backfill.py
@@ -39,7 +39,6 @@ Required environment variables:
 
 import argparse
 import logging
-import subprocess
 import sys
 from datetime import UTC, date, datetime, timedelta
 
@@ -154,31 +153,85 @@ def validate_backfill(race_ids, query_api):
     return all_ok
 
 
-def run_backfill(races, dry_run=False, force=False):
-    """Run `lemongrass laps -n` for each race (fieldwide historical import).
+def _open_client():
+    """Open the single RaceMonitorClient shared across a whole backfill run.
 
-    Unless force is set, passes --skip-if-complete so `lemongrass laps` skips races
-    whose laps are already complete and written under the current schema version.
-    Returns the list of race IDs that failed.
+    One client means one process-wide rate-limiter window for every race, so
+    requests stay paced under the server's per-token budget instead of each race
+    bursting a fresh window (the old subprocess-per-race behaviour). Exits with
+    status 1 if no API token is configured.
     """
+    tokens = resolve_tokens()
+    if not tokens:
+        logging.error("%s environment variable not set", _env.tokens_env_hint())
+        sys.exit(1)
+    return RaceMonitorClient(api_token=tokens)
+
+
+def _backfill_one_race(client, race_id, opts, failures, fail_prefix):
+    """Backfill one race in-process with the shared client, recording failures.
+
+    Returns True if the loop should stop (an interrupt propagated). Any other
+    error — including RaceMonitor rate-limit exhaustion — is logged with
+    `fail_prefix` and recorded, and the caller continues to the next race.
+    """
+    from lemongrass.laps import backfill_race
+    try:
+        rc = backfill_race(race_id, None, client, opts)
+    except KeyboardInterrupt:
+        logging.info("laps was interrupted; stopping.")
+        return True
+    except SystemExit as exc:
+        if exc.code == 130:
+            logging.info("laps was interrupted; stopping.")
+            return True
+        logging.error("%s failed for race %s", fail_prefix, race_id)
+        failures.append(race_id)
+        return False
+    except Exception as exc:
+        # One-line reason (e.g. RaceMonitorHTTPError(429)) rather than a full
+        # traceback per race, matching the old subprocess failure log.
+        logging.error("%s failed for race %s: %s", fail_prefix, race_id, exc)
+        failures.append(race_id)
+        return False
+    if rc != 0:
+        logging.error("%s failed for race %s", fail_prefix, race_id)
+        failures.append(race_id)
+    return False
+
+
+def run_backfill(races, dry_run=False, force=False):
+    """Backfill each race in-process (fieldwide historical import).
+
+    Unless force is set, skip_if_complete makes each race consult Influx first and
+    skip — with no RaceMonitor fetch — any race whose laps are already complete and
+    written under the current schema version. All races share one RaceMonitorClient
+    (and its rate-limiter window). Returns the list of race IDs that failed.
+    """
+    from lemongrass.laps import RaceOptions, _influx_only_skip
+
     failures = []
-    for race in races:
-        race_id = str(race['ID'])
-        cmd = ['lemongrass', 'laps', '-n']
-        if not force:
-            cmd.append('--skip-if-complete')
-        cmd.append(race_id)
-        if dry_run:
-            logging.info("Would backfill race %s (%s)", race_id, race['Name'])
-            continue
-        logging.info("Backfilling race %s (%s)", race_id, race['Name'])
-        result = subprocess.run(cmd, capture_output=False)
-        if result.returncode == 130:
-            logging.info("laps was interrupted; stopping backfill.")
-            break
-        if result.returncode != 0:
-            logging.error("Backfill failed for race %s", race_id)
-            failures.append(race_id)
+    opts = RaceOptions(network_mode=True, skip_if_complete=not force)
+    client = None
+    try:
+        for race in races:
+            race_id = str(race['ID'])
+            if dry_run:
+                logging.info("Would backfill race %s (%s)", race_id, race['Name'])
+                continue
+            if opts.skip_if_complete and _influx_only_skip(race_id):
+                logging.info(
+                    "SKIP: race %s (%s) already complete and current "
+                    "(from Influx, no RaceMonitor fetch)", race_id, race['Name'])
+                continue
+            logging.info("Backfilling race %s (%s)", race_id, race['Name'])
+            if client is None:
+                client = _open_client()
+            if _backfill_one_race(client, race_id, opts, failures, "Backfill"):
+                break
+    finally:
+        if client is not None:
+            client.close()
     if failures:
         logging.error("%d race(s) failed: %s", len(failures), failures)
     return failures
@@ -190,9 +243,12 @@ def run_upgrade_stored(query_api, dry_run=False, force=False):
     A race is skipped only when both its laps and its standings are at the current
     SCHEMA_VERSION; laps that are current but whose standings are stale or missing
     are re-backfilled. force=True re-backfills every stored race regardless.
-    Re-backfill calls `lemongrass laps -n <race_id>` with no car_number (fieldwide mode).
+    Every race is re-backfilled in-process through a single shared RaceMonitorClient,
+    so its rate-limiter window carries across races (a fresh subprocess per race
+    resets that window and lets each race burst past the server's per-token budget
+    the previous race just spent). Re-backfill runs fieldwide (car_number=None).
     """
-    from lemongrass.laps import SCHEMA_VERSION
+    from lemongrass.laps import SCHEMA_VERSION, RaceOptions
 
     races_tables = query_api.query(
         f'from(bucket: "{_influx.BUCKET_RACES}")\n'
@@ -206,82 +262,89 @@ def run_upgrade_stored(query_api, dry_run=False, force=False):
             stored_races[race_id] = record.values.get('race_name', 'unknown')
 
     failures = []
-    for race_id, race_name in sorted(stored_races.items()):
-        total_tables = query_api.query(
-            f'from(bucket: "{_influx.BUCKET_LAPS}")\n'
-            f'  |> range(start: {EPOCH_START})\n'
-            f'  |> filter(fn: (r) => r._measurement == "lap"\n'
-            f'      and r.race_id == "{race_id}" and r._field == "lap_no")\n'
-            f'  |> count()'
-        )
-        total = sum(r.get_value() for t in total_tables for r in t.records)
-
-        current_tables = query_api.query(
-            f'from(bucket: "{_influx.BUCKET_LAPS}")\n'
-            f'  |> range(start: {EPOCH_START})\n'
-            f'  |> filter(fn: (r) => r._measurement == "lap"\n'
-            f'      and r.race_id == "{race_id}"\n'
-            f'      and r._field == "schema_version" and r._value == {SCHEMA_VERSION})\n'
-            f'  |> count()'
-        )
-        current = sum(r.get_value() for t in current_tables for r in t.records)
-
-        if total == 0:
-            logging.info("race %s (%s): no laps stored, skipping", race_id, race_name)
-            continue
-
-        if current == total and not force:
-            # Laps are current and we're not forcing; only skip if standings are
-            # fresh too. A prior re-backfill whose standings phase failed leaves v4
-            # laps but stale or missing standings, which a lap-only check would
-            # wrongly treat as migrated. Standings are queried lazily, only once
-            # laps are current. (--force bypasses this and re-backfills regardless.)
-            std_total_tables = query_api.query(
+    # network_mode=True mirrors the historical `lemongrass laps -n <id>` invocation
+    # this loop used to shell out to, minus the per-subprocess rate-limiter reset.
+    opts = RaceOptions(network_mode=True)
+    # One RaceMonitorClient — and thus one rate-limiter window — is shared across
+    # every race, created lazily on the first re-backfill and closed in finally.
+    client = None
+    try:
+        for race_id, race_name in sorted(stored_races.items()):
+            total_tables = query_api.query(
                 f'from(bucket: "{_influx.BUCKET_LAPS}")\n'
                 f'  |> range(start: {EPOCH_START})\n'
-                f'  |> filter(fn: (r) => r._measurement == "standings"\n'
-                f'      and r.race_id == "{race_id}" and r._field == "position")\n'
+                f'  |> filter(fn: (r) => r._measurement == "lap"\n'
+                f'      and r.race_id == "{race_id}" and r._field == "lap_no")\n'
                 f'  |> count()'
             )
-            std_total = sum(r.get_value() for t in std_total_tables for r in t.records)
+            total = sum(r.get_value() for t in total_tables for r in t.records)
 
-            std_current_tables = query_api.query(
+            current_tables = query_api.query(
                 f'from(bucket: "{_influx.BUCKET_LAPS}")\n'
                 f'  |> range(start: {EPOCH_START})\n'
-                f'  |> filter(fn: (r) => r._measurement == "standings"\n'
+                f'  |> filter(fn: (r) => r._measurement == "lap"\n'
                 f'      and r.race_id == "{race_id}"\n'
                 f'      and r._field == "schema_version" and r._value == {SCHEMA_VERSION})\n'
                 f'  |> count()'
             )
-            std_current = sum(r.get_value() for t in std_current_tables for r in t.records)
+            current = sum(r.get_value() for t in current_tables for r in t.records)
 
-            if std_total > 0 and std_current == std_total:
-                logging.info("race %s (%s): already at schema v%d, skipping",
-                            race_id, race_name, SCHEMA_VERSION)
+            if total == 0:
+                logging.info("race %s (%s): no laps stored, skipping", race_id, race_name)
                 continue
 
-            logging.info(
-                "race %s (%s): laps current but standings stale/missing (%d/%d), %s",
-                race_id, race_name, std_current, std_total,
-                "would re-backfill" if dry_run else "re-backfilling")
-        elif current == total:  # current == total and force
-            logging.info("race %s (%s): already current, %s",
-                        race_id, race_name,
-                        "would force re-backfill" if dry_run else "force re-backfilling")
-        else:
-            logging.info("race %s (%s): stale (%d/%d at current schema), %s",
-                        race_id, race_name, current, total,
-                        "would re-backfill" if dry_run else "re-backfilling")
-        if dry_run:
-            continue
+            if current == total and not force:
+                # Laps are current and we're not forcing; only skip if standings are
+                # fresh too. A prior re-backfill whose standings phase failed leaves v4
+                # laps but stale or missing standings, which a lap-only check would
+                # wrongly treat as migrated. Standings are queried lazily, only once
+                # laps are current. (--force bypasses this and re-backfills regardless.)
+                std_total_tables = query_api.query(
+                    f'from(bucket: "{_influx.BUCKET_LAPS}")\n'
+                    f'  |> range(start: {EPOCH_START})\n'
+                    f'  |> filter(fn: (r) => r._measurement == "standings"\n'
+                    f'      and r.race_id == "{race_id}" and r._field == "position")\n'
+                    f'  |> count()'
+                )
+                std_total = sum(r.get_value() for t in std_total_tables for r in t.records)
 
-        result = subprocess.run(['lemongrass', 'laps', '-n', str(race_id)], capture_output=False)
-        if result.returncode == 130:
-            logging.info("laps was interrupted; stopping upgrade.")
-            break
-        if result.returncode != 0:
-            logging.error("Re-backfill failed for race %s", race_id)
-            failures.append(race_id)
+                std_current_tables = query_api.query(
+                    f'from(bucket: "{_influx.BUCKET_LAPS}")\n'
+                    f'  |> range(start: {EPOCH_START})\n'
+                    f'  |> filter(fn: (r) => r._measurement == "standings"\n'
+                    f'      and r.race_id == "{race_id}"\n'
+                    f'      and r._field == "schema_version" and r._value == {SCHEMA_VERSION})\n'
+                    f'  |> count()'
+                )
+                std_current = sum(r.get_value() for t in std_current_tables for r in t.records)
+
+                if std_total > 0 and std_current == std_total:
+                    logging.info("race %s (%s): already at schema v%d, skipping",
+                                race_id, race_name, SCHEMA_VERSION)
+                    continue
+
+                logging.info(
+                    "race %s (%s): laps current but standings stale/missing (%d/%d), %s",
+                    race_id, race_name, std_current, std_total,
+                    "would re-backfill" if dry_run else "re-backfilling")
+            elif current == total:  # current == total and force
+                logging.info("race %s (%s): already current, %s",
+                            race_id, race_name,
+                            "would force re-backfill" if dry_run else "force re-backfilling")
+            else:
+                logging.info("race %s (%s): stale (%d/%d at current schema), %s",
+                            race_id, race_name, current, total,
+                            "would re-backfill" if dry_run else "re-backfilling")
+            if dry_run:
+                continue
+
+            if client is None:
+                client = _open_client()
+            if _backfill_one_race(client, str(race_id), opts, failures, "Re-backfill"):
+                break
+    finally:
+        if client is not None:
+            client.close()
 
     if failures:
         logging.error("%d race(s) failed to upgrade: %s", len(failures), failures)

--- a/src/lemongrass/race_backfill.py
+++ b/src/lemongrass/race_backfill.py
@@ -2,11 +2,13 @@
 """Discover and backfill historical 24 Hours of Lemons lap data.
 
 Searches the RaceMonitor API for past Real Hoopties, GP du Lac, and Halloween
-Hoop races and writes fieldwide lap data to the laps/races InfluxDB buckets by
-invoking `lemongrass laps -n` for each race found.
+Hoop races and writes fieldwide lap data to the laps/races InfluxDB buckets. Each
+race is backfilled in-process through a single shared RaceMonitorClient, so the
+rate-limiter window carries across the whole run and requests stay paced under
+the server's per-token budget.
 
-Assumes `lemongrass` is installed as a CLI tool. If running from the repo, prefix
-commands with `uv run` (e.g. `uv run lemongrass race-backfill`).
+If running from the repo, prefix commands with `uv run`
+(e.g. `uv run lemongrass race-backfill`).
 
 Usage:
     # Preview what would be backfilled (no writes)
@@ -42,7 +44,7 @@ import logging
 import sys
 from datetime import UTC, date, datetime, timedelta
 
-from race_monitor import RaceMonitorClient
+from race_monitor import RaceMonitorClient, RaceMonitorError
 
 from lemongrass import _config, _env, _influx
 from lemongrass._env import resolve_tokens
@@ -171,9 +173,12 @@ def _open_client():
 def _backfill_one_race(client, race_id, opts, failures, fail_prefix):
     """Backfill one race in-process with the shared client, recording failures.
 
-    Returns True if the loop should stop (an interrupt propagated). Any other
-    error — including RaceMonitor rate-limit exhaustion — is logged with
-    `fail_prefix` and recorded, and the caller continues to the next race.
+    Returns True if the loop should stop (an interrupt propagated). An
+    operational RaceMonitor error — including rate-limit exhaustion (429) — is
+    logged with `fail_prefix` and recorded, and the caller continues to the next
+    race. Any other exception (a programming bug or a systematic outage) is left
+    to propagate so it surfaces as a crash rather than being silently recorded
+    once per race across the whole field.
     """
     from lemongrass.laps import backfill_race
     try:
@@ -188,7 +193,7 @@ def _backfill_one_race(client, race_id, opts, failures, fail_prefix):
         logging.error("%s failed for race %s", fail_prefix, race_id)
         failures.append(race_id)
         return False
-    except Exception as exc:
+    except RaceMonitorError as exc:
         # One-line reason (e.g. RaceMonitorHTTPError(429)) rather than a full
         # traceback per race, matching the old subprocess failure log.
         logging.error("%s failed for race %s: %s", fail_prefix, race_id, exc)

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -4015,3 +4015,38 @@ class TestMainFastPath:
                                 result = _mod.main()
         assert result == 0
         mock_rm.assert_called_once()
+
+
+class TestBackfillRace:
+    """The in-process backfill seam reused by race-backfill --upgrade-stored."""
+
+    def _details(self):
+        return {'Successful': True, 'Race': {
+            'Name': 'Test', 'StartDateEpoc': 0, 'EndDateEpoc': 0, 'Track': 'T'}}
+
+    def test_returns_1_for_live_race_without_car_number(self):
+        """The historical batch path passes car_number=None; a race that is
+        unexpectedly live must fail just that race (return 1), not sys.exit and
+        abort an entire --upgrade-stored run."""
+        client = MagicMock()
+        client.race.details.return_value = self._details()
+        client.race.is_live.return_value = {'Successful': True, 'IsLive': True}
+        opts = _mod.RaceOptions(network_mode=True)
+        with patch.object(_mod, '_resolve_race_metadata', return_value=None):
+            assert _mod.backfill_race('101', None, client, opts) == 1
+
+    def test_uses_injected_client_for_historical_backfill(self):
+        """A completed race is dispatched through _run_race using the caller's
+        client, and the function returns _run_race's status."""
+        client = MagicMock()
+        client.race.details.return_value = self._details()
+        client.race.is_live.return_value = {'Successful': True, 'IsLive': False}
+        opts = _mod.RaceOptions(network_mode=True)
+        with patch.object(_mod, '_resolve_race_metadata', return_value=None), \
+             patch.object(_mod._influx, 'connect') as mock_connect, \
+             patch.object(_mod, '_run_race', return_value=0) as mock_run_race:
+            mock_connect.return_value.__enter__.return_value = MagicMock()
+            result = _mod.backfill_race('101', None, client, opts)
+        assert result == 0
+        ctx = mock_run_race.call_args.args[0]
+        assert ctx.client is client

--- a/tests/test_race_backfill.py
+++ b/tests/test_race_backfill.py
@@ -1,6 +1,7 @@
 import importlib
 import os
 import sys
+from contextlib import contextmanager
 from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
@@ -79,22 +80,21 @@ class TestRunBackfill:
         ]
 
     def test_calls_laps_for_each_race(self):
-        with patch.object(_mod.subprocess, 'run') as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
+        with patch.object(_mod, 'RaceMonitorClient', return_value=MagicMock()), \
+             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
+             patch('lemongrass.laps._influx_only_skip', return_value=False), \
+             patch('lemongrass.laps.backfill_race', return_value=0) as mk_backfill:
             _mod.run_backfill(self._races())
-        assert mock_run.call_count == 2
+        assert mk_backfill.call_count == 2
 
-    def test_command_has_no_car_argument(self):
-        with patch.object(_mod.subprocess, 'run') as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
-            _mod.run_backfill(self._races()[:1])
-        cmd = mock_run.call_args.args[0]
-        assert cmd == ['lemongrass', 'laps', '-n', '--skip-if-complete', '101']
-
-    def test_dry_run_does_not_call_subprocess(self):
-        with patch.object(_mod.subprocess, 'run') as mock_run:
+    def test_dry_run_does_not_backfill(self):
+        with patch.object(_mod, 'RaceMonitorClient', return_value=MagicMock()) as mk_client, \
+             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
+             patch('lemongrass.laps._influx_only_skip', return_value=False), \
+             patch('lemongrass.laps.backfill_race', return_value=0) as mk_backfill:
             _mod.run_backfill(self._races(), dry_run=True)
-        mock_run.assert_not_called()
+        mk_backfill.assert_not_called()
+        mk_client.assert_not_called()
 
     def test_dry_run_logs_race_name(self, caplog):
         import logging
@@ -104,43 +104,114 @@ class TestRunBackfill:
 
     def test_failure_summary_logged_when_any_race_fails(self, caplog):
         import logging
-        with patch.object(_mod.subprocess, 'run') as mock_run:
-            mock_run.return_value = MagicMock(returncode=1)
+        with patch.object(_mod, 'RaceMonitorClient', return_value=MagicMock()), \
+             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
+             patch('lemongrass.laps._influx_only_skip', return_value=False), \
+             patch('lemongrass.laps.backfill_race', return_value=1):
             with caplog.at_level(logging.ERROR, logger='root'):
                 _mod.run_backfill(self._races())
         assert any('2 race(s) failed' in r.message for r in caplog.records)
 
     def test_no_failure_summary_when_all_succeed(self, caplog):
         import logging
-        with patch.object(_mod.subprocess, 'run') as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
+        with patch.object(_mod, 'RaceMonitorClient', return_value=MagicMock()), \
+             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
+             patch('lemongrass.laps._influx_only_skip', return_value=False), \
+             patch('lemongrass.laps.backfill_race', return_value=0):
             with caplog.at_level(logging.ERROR, logger='root'):
                 _mod.run_backfill(self._races())
         assert not any('failed' in r.message for r in caplog.records)
 
     def test_returns_failed_race_ids(self):
-        with patch.object(_mod.subprocess, 'run') as mock_run:
-            mock_run.side_effect = [MagicMock(returncode=0), MagicMock(returncode=1)]
+        with patch.object(_mod, 'RaceMonitorClient', return_value=MagicMock()), \
+             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
+             patch('lemongrass.laps._influx_only_skip', return_value=False), \
+             patch('lemongrass.laps.backfill_race', side_effect=[0, 1]):
             failures = _mod.run_backfill(self._races())
         assert failures == ['202']
 
     def test_returns_empty_list_when_all_succeed(self):
-        with patch.object(_mod.subprocess, 'run') as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
+        with patch.object(_mod, 'RaceMonitorClient', return_value=MagicMock()), \
+             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
+             patch('lemongrass.laps._influx_only_skip', return_value=False), \
+             patch('lemongrass.laps.backfill_race', return_value=0):
             failures = _mod.run_backfill(self._races())
         assert failures == []
 
     def test_passes_skip_if_complete_by_default(self):
-        with patch.object(_mod.subprocess, 'run') as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
+        with patch.object(_mod, 'RaceMonitorClient', return_value=MagicMock()), \
+             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
+             patch('lemongrass.laps._influx_only_skip', return_value=False) as mk_skip, \
+             patch('lemongrass.laps.backfill_race', return_value=0):
             _mod.run_backfill(self._races()[:1])
-        assert '--skip-if-complete' in mock_run.call_args.args[0]
+        mk_skip.assert_called()
 
-    def test_omits_skip_if_complete_when_forced(self):
-        with patch.object(_mod.subprocess, 'run') as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
+    # --- in-process backfill: one shared client/rate-limiter across all races ---
+
+    def test_reuses_single_client_across_races(self):
+        """One RaceMonitorClient (and its rate-limiter window) is shared across
+        every race, instead of a fresh subprocess/window per race."""
+        with patch.object(_mod, 'RaceMonitorClient', return_value=MagicMock()) as mk_client, \
+             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
+             patch('lemongrass.laps._influx_only_skip', return_value=False), \
+             patch('lemongrass.laps.backfill_race', return_value=0) as mk_backfill:
+            _mod.run_backfill(self._races())
+        assert mk_client.call_count == 1
+        assert mk_backfill.call_count == 2
+        clients = {c.args[2] for c in mk_backfill.call_args_list}
+        assert len(clients) == 1
+
+    def test_backfill_called_fieldwide_with_race_id(self):
+        with patch.object(_mod, 'RaceMonitorClient', return_value=MagicMock()), \
+             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
+             patch('lemongrass.laps._influx_only_skip', return_value=False), \
+             patch('lemongrass.laps.backfill_race', return_value=0) as mk_backfill:
+            _mod.run_backfill(self._races()[:1])
+        assert mk_backfill.call_args.args[0] == '101'  # race_id
+        assert mk_backfill.call_args.args[1] is None   # car_number (fieldwide)
+
+    def test_skip_if_complete_skips_without_client_or_racemonitor(self):
+        """A race already complete in Influx is skipped with no client created and
+        no backfill_race call — the whole point of --skip-if-complete."""
+        with patch.object(_mod, 'RaceMonitorClient') as mk_client, \
+             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
+             patch('lemongrass.laps._influx_only_skip', return_value=True), \
+             patch('lemongrass.laps.backfill_race') as mk_backfill:
+            _mod.run_backfill(self._races()[:1])
+        mk_backfill.assert_not_called()
+        mk_client.assert_not_called()
+
+    def test_force_bypasses_skip_check(self):
+        """force=True disables skip_if_complete, so _influx_only_skip is never
+        consulted and every race is backfilled."""
+        with patch.object(_mod, 'RaceMonitorClient', return_value=MagicMock()), \
+             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
+             patch('lemongrass.laps._influx_only_skip', return_value=True) as mk_skip, \
+             patch('lemongrass.laps.backfill_race', return_value=0) as mk_backfill:
             _mod.run_backfill(self._races()[:1], force=True)
-        assert '--skip-if-complete' not in mock_run.call_args.args[0]
+        mk_skip.assert_not_called()
+        assert mk_backfill.call_count == 1
+
+    def test_backfill_exception_records_failure_and_continues(self):
+        from race_monitor import RaceMonitorHTTPError
+        with patch.object(_mod, 'RaceMonitorClient', return_value=MagicMock()), \
+             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
+             patch('lemongrass.laps._influx_only_skip', return_value=False), \
+             patch('lemongrass.laps.backfill_race',
+                   side_effect=[RaceMonitorHTTPError(429, 'rate'), 0]) as mk_backfill:
+            failures = _mod.run_backfill(self._races())
+        assert mk_backfill.call_count == 2
+        assert failures == ['101']
+
+    def test_keyboard_interrupt_stops_backfill(self):
+        with patch.object(_mod, 'RaceMonitorClient', return_value=MagicMock()), \
+             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
+             patch('lemongrass.laps._influx_only_skip', return_value=False), \
+             patch('lemongrass.laps.backfill_race',
+                   side_effect=[KeyboardInterrupt(), 0]) as mk_backfill:
+            failures = _mod.run_backfill(self._races())
+        assert mk_backfill.call_count == 1
+        assert failures == []
 
 
 class TestValidateBackfill:
@@ -294,6 +365,16 @@ class TestRunUpgradeStored:
         api.query.side_effect = fake_query
         return api
 
+    @contextmanager
+    def _inprocess(self, **backfill_kwargs):
+        """Patch the in-process backfill seam (shared client + resolve_tokens +
+        laps.backfill_race), yielding the backfill_race mock."""
+        backfill_kwargs.setdefault('return_value', 0)
+        with patch.object(_mod, 'RaceMonitorClient', return_value=MagicMock()), \
+             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
+             patch('lemongrass.laps.backfill_race', **backfill_kwargs) as mk_backfill:
+            yield mk_backfill
+
     def test_skips_race_already_at_current_schema(self, caplog):
         import logging
         query_api = self._query_api(
@@ -303,10 +384,10 @@ class TestRunUpgradeStored:
             std_total_by_race={'101': 8},
             std_current_by_race={'101': 8},
         )
-        with patch.object(_mod.subprocess, 'run') as mock_run:
+        with self._inprocess() as mk_backfill:
             with caplog.at_level(logging.INFO):
                 _mod.run_upgrade_stored(query_api)
-        mock_run.assert_not_called()
+        mk_backfill.assert_not_called()
         assert any('skipping' in r.message and '101' in r.message for r in caplog.records)
 
     def test_rebackfills_when_laps_current_but_standings_stale(self):
@@ -317,11 +398,11 @@ class TestRunUpgradeStored:
             std_total_by_race={'101': 8},
             std_current_by_race={'101': 3},
         )
-        with patch.object(_mod.subprocess, 'run') as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
+        with self._inprocess() as mk_backfill:
             _mod.run_upgrade_stored(query_api)
-        assert mock_run.call_count == 1
-        assert mock_run.call_args.args[0] == ['lemongrass', 'laps', '-n', '101']
+        assert mk_backfill.call_count == 1
+        assert mk_backfill.call_args.args[0] == '101'
+        assert mk_backfill.call_args.args[1] is None
 
     def test_rebackfills_when_laps_current_but_standings_missing(self):
         query_api = self._query_api(
@@ -331,10 +412,9 @@ class TestRunUpgradeStored:
             std_total_by_race={'101': 0},
             std_current_by_race={'101': 0},
         )
-        with patch.object(_mod.subprocess, 'run') as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
+        with self._inprocess() as mk_backfill:
             _mod.run_upgrade_stored(query_api)
-        assert mock_run.call_count == 1
+        assert mk_backfill.call_count == 1
 
     def test_rebackfills_stale_race(self):
         query_api = self._query_api(
@@ -342,22 +422,21 @@ class TestRunUpgradeStored:
             total_by_race={'101': 10},
             current_by_race={'101': 5},
         )
-        with patch.object(_mod.subprocess, 'run') as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
+        with self._inprocess() as mk_backfill:
             _mod.run_upgrade_stored(query_api)
-        assert mock_run.call_count == 1
-        cmd = mock_run.call_args.args[0]
-        assert cmd == ['lemongrass', 'laps', '-n', '101']
+        assert mk_backfill.call_count == 1
+        assert mk_backfill.call_args.args[0] == '101'
+        assert mk_backfill.call_args.args[1] is None
 
-    def test_dry_run_does_not_call_subprocess(self):
+    def test_dry_run_does_not_backfill(self):
         query_api = self._query_api(
             stored_races={'101': 'Lemons 2024'},
             total_by_race={'101': 10},
             current_by_race={'101': 5},
         )
-        with patch.object(_mod.subprocess, 'run') as mock_run:
+        with self._inprocess() as mk_backfill:
             _mod.run_upgrade_stored(query_api, dry_run=True)
-        mock_run.assert_not_called()
+        mk_backfill.assert_not_called()
 
     def test_skips_race_with_no_stored_laps(self, caplog):
         import logging
@@ -366,10 +445,10 @@ class TestRunUpgradeStored:
             total_by_race={'101': 0},
             current_by_race={},
         )
-        with patch.object(_mod.subprocess, 'run') as mock_run:
+        with self._inprocess() as mk_backfill:
             with caplog.at_level(logging.INFO):
                 _mod.run_upgrade_stored(query_api)
-        mock_run.assert_not_called()
+        mk_backfill.assert_not_called()
 
     def test_returns_failed_race_ids(self):
         query_api = self._query_api(
@@ -377,8 +456,7 @@ class TestRunUpgradeStored:
             total_by_race={'101': 10},
             current_by_race={'101': 5},
         )
-        with patch.object(_mod.subprocess, 'run') as mock_run:
-            mock_run.return_value = MagicMock(returncode=1)
+        with self._inprocess(return_value=1):
             failures = _mod.run_upgrade_stored(query_api)
         assert failures == ['101']
 
@@ -388,8 +466,7 @@ class TestRunUpgradeStored:
             total_by_race={'101': 10},
             current_by_race={'101': 5},
         )
-        with patch.object(_mod.subprocess, 'run') as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
+        with self._inprocess(return_value=0):
             failures = _mod.run_upgrade_stored(query_api)
         assert failures == []
 
@@ -399,10 +476,9 @@ class TestRunUpgradeStored:
             total_by_race={'101': 5, '202': 5},
             current_by_race={'101': 0, '202': 0},
         )
-        with patch.object(_mod.subprocess, 'run') as mock_run:
-            mock_run.return_value = MagicMock(returncode=130)
+        with self._inprocess(side_effect=[SystemExit(130), 0]) as mk_backfill:
             _mod.run_upgrade_stored(query_api)
-        assert mock_run.call_count == 1
+        assert mk_backfill.call_count == 1
 
     def test_force_rebackfills_race_already_at_current_schema(self):
         query_api = self._query_api(
@@ -410,12 +486,11 @@ class TestRunUpgradeStored:
             total_by_race={'101': 10},
             current_by_race={'101': 10},  # already fully current
         )
-        with patch.object(_mod.subprocess, 'run') as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
+        with self._inprocess() as mk_backfill:
             _mod.run_upgrade_stored(query_api, force=True)
-        assert mock_run.call_count == 1
-        cmd = mock_run.call_args.args[0]
-        assert cmd == ['lemongrass', 'laps', '-n', '101']
+        assert mk_backfill.call_count == 1
+        assert mk_backfill.call_args.args[0] == '101'
+        assert mk_backfill.call_args.args[1] is None
 
     def test_force_logs_already_current_message(self, caplog):
         import logging
@@ -424,24 +499,23 @@ class TestRunUpgradeStored:
             total_by_race={'101': 10},
             current_by_race={'101': 10},  # already fully current
         )
-        with patch.object(_mod.subprocess, 'run') as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
+        with self._inprocess(return_value=0):
             with caplog.at_level(logging.INFO):
                 _mod.run_upgrade_stored(query_api, force=True)
         assert any('already current' in r.message and 'force re-backfilling' in r.message
                    for r in caplog.records)
 
-    def test_dry_run_force_does_not_call_subprocess(self, caplog):
+    def test_dry_run_force_does_not_backfill(self, caplog):
         import logging
         query_api = self._query_api(
             stored_races={'101': 'Lemons 2024'},
             total_by_race={'101': 10},
             current_by_race={'101': 10},  # already current; only --force would touch it
         )
-        with patch.object(_mod.subprocess, 'run') as mock_run:
+        with self._inprocess() as mk_backfill:
             with caplog.at_level(logging.INFO):
                 _mod.run_upgrade_stored(query_api, dry_run=True, force=True)
-        mock_run.assert_not_called()
+        mk_backfill.assert_not_called()
         assert any('would force re-backfill' in r.message for r in caplog.records)
 
     def test_force_still_skips_race_with_no_stored_laps(self):
@@ -450,9 +524,78 @@ class TestRunUpgradeStored:
             total_by_race={'101': 0},
             current_by_race={},
         )
-        with patch.object(_mod.subprocess, 'run') as mock_run:
+        with self._inprocess() as mk_backfill:
             _mod.run_upgrade_stored(query_api, force=True)
-        mock_run.assert_not_called()
+        mk_backfill.assert_not_called()
+
+
+    # --- in-process backfill: one shared client/rate-limiter across all races ---
+
+    def test_reuses_single_client_across_races(self):
+        """One RaceMonitorClient (and its rate-limiter window) is shared across
+        every race, instead of a fresh subprocess/window per race."""
+        query_api = self._query_api(
+            stored_races={'101': 'Race 1', '202': 'Race 2'},
+            total_by_race={'101': 10, '202': 10},
+            current_by_race={'101': 5, '202': 5},
+        )
+        fake_client = MagicMock()
+        with patch.object(_mod, 'RaceMonitorClient', return_value=fake_client) as mk_client, \
+             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
+             patch('lemongrass.laps.backfill_race', return_value=0) as mk_backfill:
+            _mod.run_upgrade_stored(query_api)
+        assert mk_client.call_count == 1
+        assert mk_backfill.call_count == 2
+        clients = {c.args[2] for c in mk_backfill.call_args_list}
+        assert clients == {fake_client}
+
+    def test_backfill_called_fieldwide_with_race_id(self):
+        """Each race is backfilled fieldwide: race_id passed, car_number None."""
+        query_api = self._query_api(
+            stored_races={'101': 'Race 1'},
+            total_by_race={'101': 10},
+            current_by_race={'101': 5},
+        )
+        with patch.object(_mod, 'RaceMonitorClient', return_value=MagicMock()), \
+             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
+             patch('lemongrass.laps.backfill_race', return_value=0) as mk_backfill:
+            _mod.run_upgrade_stored(query_api)
+        assert mk_backfill.call_count == 1
+        args = mk_backfill.call_args.args
+        assert args[0] == '101'   # race_id
+        assert args[1] is None    # car_number (fieldwide)
+
+    def test_backfill_exception_records_failure_and_continues(self):
+        """A per-race error (e.g. 429 exhaustion) is recorded and the run
+        continues to the next race, matching the old continue-on-failure model."""
+        from race_monitor import RaceMonitorHTTPError
+        query_api = self._query_api(
+            stored_races={'101': 'Race 1', '202': 'Race 2'},
+            total_by_race={'101': 10, '202': 10},
+            current_by_race={'101': 5, '202': 5},
+        )
+        with patch.object(_mod, 'RaceMonitorClient', return_value=MagicMock()), \
+             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
+             patch('lemongrass.laps.backfill_race',
+                   side_effect=[RaceMonitorHTTPError(429, 'rate'), 0]) as mk_backfill:
+            failures = _mod.run_upgrade_stored(query_api)
+        assert mk_backfill.call_count == 2
+        assert failures == ['101']
+
+    def test_keyboard_interrupt_stops_upgrade(self):
+        """Ctrl-C during a race stops the whole upgrade (no further races)."""
+        query_api = self._query_api(
+            stored_races={'101': 'Race 1', '202': 'Race 2'},
+            total_by_race={'101': 10, '202': 10},
+            current_by_race={'101': 5, '202': 5},
+        )
+        with patch.object(_mod, 'RaceMonitorClient', return_value=MagicMock()), \
+             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
+             patch('lemongrass.laps.backfill_race',
+                   side_effect=[KeyboardInterrupt(), 0]) as mk_backfill:
+            failures = _mod.run_upgrade_stored(query_api)
+        assert mk_backfill.call_count == 1
+        assert failures == []
 
 
 class TestUpgradeStoredArgParsing:

--- a/tests/test_race_backfill.py
+++ b/tests/test_race_backfill.py
@@ -213,6 +213,19 @@ class TestRunBackfill:
         assert mk_backfill.call_count == 1
         assert failures == []
 
+    def test_programming_bug_propagates_not_swallowed(self):
+        # A non-RaceMonitorError (e.g. a bug or systematic outage) must crash the
+        # run rather than be recorded per-race — otherwise a fault that breaks
+        # every race looks like a data problem instead of a bug.
+        with patch.object(_mod, 'RaceMonitorClient', return_value=MagicMock()), \
+             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
+             patch('lemongrass.laps._influx_only_skip', return_value=False), \
+             patch('lemongrass.laps.backfill_race',
+                   side_effect=[AttributeError('boom'), 0]) as mk_backfill:
+            with pytest.raises(AttributeError):
+                _mod.run_backfill(self._races())
+        assert mk_backfill.call_count == 1
+
 
 class TestValidateBackfill:
     def _make_query_api(self, race_name='My Race', lap_count=0,
@@ -596,6 +609,22 @@ class TestRunUpgradeStored:
             failures = _mod.run_upgrade_stored(query_api)
         assert mk_backfill.call_count == 1
         assert failures == []
+
+    def test_programming_bug_propagates_not_swallowed(self):
+        """A non-RaceMonitorError crashes the upgrade rather than being recorded
+        per-race, so a systematic fault surfaces as a bug instead of hiding."""
+        query_api = self._query_api(
+            stored_races={'101': 'Race 1', '202': 'Race 2'},
+            total_by_race={'101': 10, '202': 10},
+            current_by_race={'101': 5, '202': 5},
+        )
+        with patch.object(_mod, 'RaceMonitorClient', return_value=MagicMock()), \
+             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
+             patch('lemongrass.laps.backfill_race',
+                   side_effect=[AttributeError('boom'), 0]) as mk_backfill:
+            with pytest.raises(AttributeError):
+                _mod.run_upgrade_stored(query_api)
+        assert mk_backfill.call_count == 1
 
 
 class TestUpgradeStoredArgParsing:


### PR DESCRIPTION
## Problem

`races backfill` (and `--upgrade-stored`) ran each race as a separate `lemongrass laps` subprocess. The RaceMonitor client's rate limiter lives in a **process-global window**, so every subprocess started with an empty window and instantly burst several calls (`RaceDetails` → `CurrentRaces` + `PastRaces`, then `IsLive`) against a per-token budget the *previous* race had spent less than 60s earlier. The local throttle — the primary defence against 429s — was wiped at every subprocess boundary, leaving only reactive 429 retries, which with 2 tokens exhaust after ~30s of backoff (`max_retries=5` → 6 attempts → 3 sleep-rounds) against the server's ~60s recovery window:

```
Error: RaceMonitor rate limit exceeded (HTTP 429) — retries exhausted.
ERROR:root:Re-backfill failed for race 113450
```

## Fix

Back-fill each race **in-process** through a single shared `RaceMonitorClient`, so its rate-limiter window carries across every race and requests stay paced under the server's per-token budget — no fresh burst per race.

- **`laps.backfill_race(race_id, car_number, client, opts)`** — new seam extracted from `main()` that backfills one race with an injected client and returns a status (the one live/monitor guard now returns `1` instead of `sys.exit`-ing, so a batch loop isn't aborted). `main()` is a thin wrapper over it.
- **`_open_client()` / `_backfill_one_race(...)`** — shared helpers in `race_backfill` used by both `run_backfill` and `run_upgrade_stored`, so the two loops can't drift. One client is opened lazily and closed in a `finally`.
- **Failure handling** — a per-race **`RaceMonitorError`** (including 429 exhaustion) is logged as a one-line reason and recorded; the run continues to the next race. Any other exception — a programming bug or systematic outage — is left to propagate and crash the run, so a fault that would break every race surfaces as a crash rather than being silently recorded once per race. `KeyboardInterrupt` / `SystemExit(130)` stops the run.
- **`--skip-if-complete`** stays a caller-side guard: already-complete races skip via Influx with **no RaceMonitor fetch and no client construction**, and `skip_if_complete` still flows through to the deeper completeness check.

No `lemongrass laps` subprocess is spawned per race anywhere in `race-backfill` now.

## Tests

- New seam tests for `backfill_race` (injected client; return-vs-exit behaviour).
- New in-process contract tests for both `run_backfill` and `run_upgrade_stored`: single shared client across races, fieldwide dispatch, continue-on-`RaceMonitorError`, non-`RaceMonitorError`-propagates-and-stops, interrupt-stops, and (for `run_backfill`) Influx-skip without a client and force-bypasses-skip.
- Old subprocess-based tests converted to the in-process seam; redundant ones removed.
- **660 passed, ruff clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
