### PR TITLE
docs: fix inaccurate docstrings and a broken README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Open source car telemetry for 24 Hours of Lemons.
 
 ## Raspberry Pi Services
 
-The services on the pi are managed via [docker-compose.yml](docker-compose.yml).
+The services on the pi are defined by a `docker-compose.yml` managed in the deployment (IaC) repository, not in this repo.
 
 | Service | Description |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -10,15 +10,16 @@ Open source car telemetry for 24 Hours of Lemons.
 - An InfluxDB instance running v2.x
 - Grafana to visualize the data
 
-## Raspberry Pi Services
+## Services
 
-The services on the pi are defined by a `docker-compose.yml` managed in the deployment (IaC) repository, not in this repo.
+This repo provides two long-running services that run on the pi:
 
 | Service | Description |
 | --- | --- |
 | telem | Monitors car data via OBD-II USB adapter |
 | pisugar-monitor | Monitors PiSugar 3 UPS |
-| telegraf | Monitors Raspberry Pi OS |
+
+Deployment and orchestration (docker-compose, telegraf for OS metrics, etc.) are managed in the deployment (IaC) repository, not here.
 
 ## Lap Data
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This repo provides two long-running services that run on the pi:
 | telem | Monitors car data via OBD-II USB adapter |
 | pisugar-monitor | Monitors PiSugar 3 UPS |
 
-Deployment and orchestration (docker-compose, telegraf for OS metrics, etc.) are managed in the deployment (IaC) repository, not here.
+Deployment and orchestration (docker-compose, telegraf for OS metrics, etc.) should be managed in a separate IaC repository, not here.
 
 ## Lap Data
 

--- a/src/lemongrass/_env.py
+++ b/src/lemongrass/_env.py
@@ -17,8 +17,9 @@ def _legacy_applies(pool_var: str) -> bool:
 
 
 def resolve_tokens() -> str | list[str]:
-    """Return tokens from the configured pool var (comma-separated) or fall back
-    to the legacy singular RACEMONITOR_TOKEN."""
+    """Return tokens from the configured pool var (comma-separated) or, when the
+    default pool var is in use, fall back to the legacy singular
+    RACEMONITOR_TOKEN. A deployment naming its own pool var gets '' instead."""
     pool_var = _pool_var()
     multi = os.environ.get(pool_var)
     if multi:

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -645,7 +645,7 @@ def old_race(ctx, opts):
 
 
 def print_rankings(sorted_competitors, _race_live, selected_class, categories):
-    """Take a dict of sorted competitors and print them in a nice table."""
+    """Take a list of sorted competitor dicts and print them in a nice table."""
     print(UNDERLINE)
     list_of_names = []
 
@@ -726,6 +726,8 @@ def monitor_routine(ctx, laps, opts, competitor_name=None, car_info=None, _stop_
 
     Returns MonitorStatus.RACE_ENDED when the race ends naturally, or
     MonitorStatus.INTERRUPTED on KeyboardInterrupt (caller should exit 130).
+    Returns None when the loop exits because _stop_event was set before the race
+    ended (the test-injection path).
     _stop_event may be injected for testing; defaults to a new threading.Event.
     session_id is tracked across polls and tags each written lap point; a new
     session push fires whenever the live session ID changes.

--- a/src/lemongrass/race_backfill.py
+++ b/src/lemongrass/race_backfill.py
@@ -173,12 +173,14 @@ def _open_client():
 def _backfill_one_race(client, race_id, opts, failures, fail_prefix):
     """Backfill one race in-process with the shared client, recording failures.
 
-    Returns True if the loop should stop (an interrupt propagated). An
-    operational RaceMonitor error — including rate-limit exhaustion (429) — is
-    logged with `fail_prefix` and recorded, and the caller continues to the next
-    race. Any other exception (a programming bug or a systematic outage) is left
-    to propagate so it surfaces as a crash rather than being silently recorded
-    once per race across the whole field.
+    Returns True if the loop should stop: a KeyboardInterrupt or a
+    SystemExit(130) is treated as an interrupt and halts the field. An
+    operational RaceMonitor error — including rate-limit exhaustion (429) — or a
+    non-130 SystemExit is logged with `fail_prefix` and recorded as a failure,
+    and the caller continues to the next race. Any other exception (a
+    programming bug or a systematic outage) is left to propagate so it surfaces
+    as a crash rather than being silently recorded once per race across the
+    whole field.
     """
     from lemongrass.laps import backfill_race
     try:

--- a/src/lemongrass/telem.py
+++ b/src/lemongrass/telem.py
@@ -295,7 +295,13 @@ def _route_command(command):
 
 
 def new_status(r):
-    """Queue MIL and DTC count for batch write to InfluxDB."""
+    """Queue MIL and DTC count for batch write to InfluxDB.
+
+    For the primary STATUS command, a rising DTC count also triggers an
+    on-demand forced GET_DTC read via _fetch_and_store_dtcs() (queuing an
+    extra -Get-DTCs point), tracking _last_dtc_count / _dtc_fetch_failures with
+    a give-up threshold on repeated failures.
+    """
     global _last_dtc_count, _dtc_fetch_failures
 
     if r.value is None:


### PR DESCRIPTION
Audited every module/class/function docstring across the source tree, plus the READMEs, against the current implementation and corrected the factual mismatches found.

## Docstring fixes

- **`race_backfill._backfill_one_race`** — documented that `KeyboardInterrupt` and `SystemExit(130)` halt the field, and a non-130 `SystemExit` is recorded as a failure like a `RaceMonitorError` rather than propagating as a crash.
- **`laps.print_rankings`** — `sorted_competitors` is a list of competitor dicts, not a dict.
- **`laps.monitor_routine`** — noted the `None` return when `_stop_event` is set before the race ends (test-injection path).
- **`_env.resolve_tokens`** — the legacy `RACEMONITOR_TOKEN` fallback is gated to when the default pool var is in use; a custom pool var gets `''`.
- **`telem.new_status`** — noted the on-demand forced `GET_DTC` read triggered on a rising DTC count.

## README fix

- **`README.md`** — the "Raspberry Pi Services" section was written when the compose orchestration lived here and linked a `docker-compose.yml` that has since moved to the external IaC repo (dead link). Reframed the section around the two services this repo actually provides (`telem`, `pisugar-monitor`) and pointed to the IaC repo for deployment/orchestration (compose, telegraf).

Docs-only changes; no behavior is modified. `ruff check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)