### PR TITLE
fix(race-backfill): show progress logs and sort upgrade-stored by numeric race id

### DIFF
--- a/src/lemongrass/race_backfill.py
+++ b/src/lemongrass/race_backfill.py
@@ -276,7 +276,10 @@ def run_upgrade_stored(query_api, dry_run=False, force=False):
     # every race, created lazily on the first re-backfill and closed in finally.
     client = None
     try:
-        for race_id, race_name in sorted(stored_races.items()):
+        # race_id keys are Influx tag strings; sort numerically so the run is a
+        # predictable ascending sweep rather than a lexicographic one where a
+        # shorter id (e.g. "9793") lands amid the longer six-digit ids.
+        for race_id, race_name in sorted(stored_races.items(), key=lambda kv: int(kv[0])):
             total_tables = query_api.query(
                 f'from(bucket: "{_influx.BUCKET_LAPS}")\n'
                 f'  |> range(start: {EPOCH_START})\n'

--- a/src/lemongrass/race_backfill.py
+++ b/src/lemongrass/race_backfill.py
@@ -360,6 +360,13 @@ def run_upgrade_stored(query_api, dry_run=False, force=False):
 
 def main():
     """Entry point: parse args, discover races, then backfill or validate."""
+    # The `lemongrass` console script dispatches here by import (cli.main ->
+    # races.main -> race_backfill.main), so the __main__ guard's basicConfig never
+    # runs. Configure logging here or every progress logging.info() line is
+    # dropped at the root logger's default WARNING level.
+    logging.basicConfig(
+        level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
     args = _build_parser().parse_args()
 
     if args.upgrade_stored:
@@ -403,6 +410,4 @@ def main():
 
 
 if __name__ == '__main__':
-    logging.basicConfig(
-        level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
     main()

--- a/tests/test_race_backfill.py
+++ b/tests/test_race_backfill.py
@@ -732,6 +732,27 @@ class TestMainTokenResolution:
         assert any('MY_POOL' in r.message for r in caplog.records)
 
 
+class TestMainConfiguresLogging:
+    def test_main_configures_info_logging(self):
+        # race-backfill runs under the `lemongrass` console script, whose dispatch
+        # path (cli.main -> races.main -> race_backfill.main) never configures
+        # logging — the basicConfig in the __main__ guard doesn't run on import.
+        # main() must configure INFO itself, or every progress logging.info() line
+        # (SKIP / re-backfilling / summary) is silently dropped at the default
+        # WARNING level.
+        import logging
+        with patch.dict(os.environ, {'RACEMONITOR_TOKENS': 'T'}, clear=True):
+            with patch.object(sys, 'argv', ['race-backfill']):
+                with patch('lemongrass.race_backfill.RaceMonitorClient') as mock_rm_cls:
+                    mock_rm_cls.return_value.__enter__.return_value = MagicMock()
+                    with patch.object(_mod, 'find_matching_races', return_value=[]):
+                        with patch.object(_mod, 'run_backfill', return_value=[]):
+                            with patch.object(_mod.logging, 'basicConfig') as mock_bc:
+                                _mod.main()
+        mock_bc.assert_called_once()
+        assert mock_bc.call_args.kwargs.get('level') == logging.INFO
+
+
 class TestValidateWindowPadding:
     def test_lap_query_padded_one_day_each_side(self):
         import lemongrass.race_backfill as rb

--- a/tests/test_race_backfill.py
+++ b/tests/test_race_backfill.py
@@ -463,6 +463,20 @@ class TestRunUpgradeStored:
                 _mod.run_upgrade_stored(query_api)
         mk_backfill.assert_not_called()
 
+    def test_processes_races_in_ascending_numeric_order(self):
+        # race_id keys are Influx tag strings; a plain sorted() orders them
+        # lexicographically, so a shorter id sorts into the middle of longer ones.
+        # Sort numerically so the run is a predictable ascending sweep.
+        query_api = self._query_api(
+            stored_races={'113450': 'C', '9793': 'A', '100247': 'B'},
+            total_by_race={'113450': 5, '9793': 5, '100247': 5},
+            current_by_race={'113450': 0, '9793': 0, '100247': 0},
+        )
+        with self._inprocess(return_value=0) as mk_backfill:
+            _mod.run_upgrade_stored(query_api, force=True)
+        called_ids = [c.args[0] for c in mk_backfill.call_args_list]
+        assert called_ids == ['9793', '100247', '113450']
+
     def test_returns_failed_race_ids(self):
         query_api = self._query_api(
             stored_races={'101': 'Lemons 2024'},


### PR DESCRIPTION
Two observability/ordering fixes for `lemongrass races backfill`, both surfaced while running `--upgrade-stored`.

## 1. Progress logs never appeared

Running `lemongrass races backfill` printed the standings tables but none of the progress logs — no `SKIP`, `re-backfilling race X`, `already at schema v4`, or the failure summary. The only survivor was a lone `WARNING:root:unparseable TotalTime…`, in the bare default format rather than the intended timestamped one.

The `lemongrass` console script dispatches to `race_backfill.main()` by import (`cli.main` → `races.main` → `race_backfill.main`), so the `logging.basicConfig()` in the `if __name__ == '__main__':` guard never runs. The root logger stayed at its default WARNING level, dropping every `logging.info()` line.

This regressed in #197: the pre-#197 loop shelled out to `lemongrass laps` subprocesses whose `laps.main()` calls `basicConfig`, so each child's INFO logs printed. Moving backfill in-process removed that side effect.

**Fix:** configure INFO logging at the top of `race_backfill.main()` (covers both `lemongrass race-backfill` and `lemongrass races backfill`) and drop the now-redundant `basicConfig` from the `__main__` guard.

## 2. `--upgrade-stored` processed races in lexicographic, not numeric, order

`run_upgrade_stored` sorted `stored_races.items()` by key, but `race_id` keys are Influx tag strings — so the sort was lexicographic. It's deterministic, but a shorter id like `9793` sorts into the middle of the six-digit ids, which reads as random.

**Fix:** sort by `int(race_id)` so the run is a predictable ascending sweep.

Both fixes have regression tests. Full backfill suite + ruff pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)