### PR TITLE
test: rebalance suite — cut redundancy, cover runtime loops, fix print_rankings

### DIFF
--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -651,7 +651,7 @@ def print_rankings(sorted_competitors, _race_live, selected_class, categories):
 
     for competitor in sorted_competitors:
         for item in competitor:
-            if (item == "FirstName" and item != '') or (item == "LastName" and item != ''):
+            if item in ("FirstName", "LastName") and competitor[item] != '':
                 list_of_names.append(competitor[item])
 
     for competitor in sorted_competitors:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,14 +41,12 @@ class TestDispatcher:
                 cli.main()
         assert "OBD_PORT" in capsys.readouterr().err
 
-    def test_no_args_exits_nonzero(self):
-        with patch.object(sys, 'argv', ['lemongrass']):
-            with pytest.raises(SystemExit) as exc:
-                cli.main()
-        assert exc.value.code != 0
-
-    def test_unknown_command_exits_nonzero(self):
-        with patch.object(sys, 'argv', ['lemongrass', 'notacommand']):
+    @pytest.mark.parametrize("argv", [
+        ['lemongrass'],                    # no command
+        ['lemongrass', 'notacommand'],     # unknown command
+    ])
+    def test_missing_or_unknown_command_exits_nonzero(self, argv):
+        with patch.object(sys, 'argv', argv):
             with pytest.raises(SystemExit) as exc:
                 cli.main()
         assert exc.value.code != 0
@@ -213,11 +211,13 @@ class TestRaceMonitorErrors:
         assert 'rate limit' in err.lower()
         assert '429' in err
 
-    def test_other_http_error_exits_1_with_status(self, capsys):
+    def test_other_http_error_exits_1_with_status_and_body(self, capsys):
+        """A non-429 HTTP error prints the status line and, below it, the
+        response body so the operator sees the server's reason."""
         from race_monitor import RaceMonitorHTTPError
 
         def raise_500():
-            raise RaceMonitorHTTPError(500, "boom")
+            raise RaceMonitorHTTPError(500, "upstream database unavailable")
 
         with patch.object(sys, 'argv', ['lemongrass', 'races', 'list']):
             with patch('lemongrass.races.main', raise_500):
@@ -227,6 +227,7 @@ class TestRaceMonitorErrors:
         err = capsys.readouterr().err
         assert '500' in err
         assert 'rate limit' not in err.lower()
+        assert 'upstream database unavailable' in err
 
     def test_base_error_exits_1_without_traceback(self, capsys):
         from race_monitor import RaceMonitorError

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -133,6 +133,17 @@ class TestValidation:
         with pytest.raises(_config.ConfigError, match=f"{section}.*must be a table"):
             _config.load_config()
 
+    @pytest.mark.parametrize("body,match", [
+        ("[telem.obd]\nbaudrate = \"fast\"", "baudrate must be an integer"),
+        ("[telem.obd]\ndebug = 5", "debug must be a boolean"),
+        ("[races.backfill]\nsearch_terms = [1, 2]",
+         "search_terms must be a list of strings"),
+    ])
+    def test_typed_wrong_type_raises(self, tmp_path, monkeypatch, body, match):
+        _write_cfg(tmp_path, monkeypatch, body)
+        with pytest.raises(_config.ConfigError, match=match):
+            _config.load_config()
+
     def test_bad_max_size_raises(self, tmp_path, monkeypatch):
         _write_cfg(tmp_path, monkeypatch, """
             [telem.spool]
@@ -170,15 +181,12 @@ class TestSecretsOnlyEnv:
         ]:
             monkeypatch.setenv(var, val)
         c = _config.load_config()
-        assert c.influx.url == "http://from-file:8086"   # file wins
-        assert c.influx.org == "focism"                  # default kept; env ignored
-        assert c.telem.obd.port == "/dev/obd"
-        assert c.telem.obd.baudrate == 0
-        assert c.telem.obd.debug is False
-        assert c.telem.vin == ""
-        assert c.telem.spool.dir == "/data/telem-spool"
-        assert c.telem.spool.max_size == 1073741824
-        assert c.pisugar.host == ""
+        # Prove env is ignored across sections; the full default matrix is
+        # already asserted by test_defaults_match_todays_literals.
+        assert c.influx.url == "http://from-file:8086"   # file wins over env
+        assert c.influx.org == "focism"                  # env ignored, default kept
+        assert c.telem.obd.port == "/dev/obd"            # env ignored
+        assert c.pisugar.host == ""                      # env ignored
 
     def test_buckets_have_no_env_override(self, monkeypatch):
         monkeypatch.delenv("LEMONGRASS_CONFIG", raising=False)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -14,6 +14,14 @@ def test_single_token_returns_str(monkeypatch):
     assert _env.resolve_tokens() == "solo"
 
 
+def test_single_item_pool_returns_str(monkeypatch):
+    """A pool var holding one token collapses to the bare string, not a
+    one-element list — distinct from the legacy-var path above."""
+    monkeypatch.delenv("LEMONGRASS_CONFIG", raising=False)
+    monkeypatch.setenv("RACEMONITOR_TOKENS", "only")
+    assert _env.resolve_tokens() == "only"
+
+
 def test_pool_var_name_is_configurable(monkeypatch, tmp_path):
     cfg = tmp_path / "c.toml"
     cfg.write_text('[racemonitor]\ntokens_env = "MY_POOL"\n')

--- a/tests/test_influx.py
+++ b/tests/test_influx.py
@@ -7,39 +7,39 @@ from urllib3 import Retry
 import lemongrass._influx as influx_mod
 
 
-def test_defaults_match_prod(monkeypatch):
-    monkeypatch.delenv('INFLUX_URL', raising=False)
-    monkeypatch.delenv('INFLUX_ORG', raising=False)
-    reloaded = importlib.reload(influx_mod)
-    assert reloaded.INFLUX_URL == 'https://influxdb.focism.com'
-    assert reloaded.INFLUX_ORG == 'focism'
+@pytest.fixture
+def reload_influx(monkeypatch):
+    """Reload _influx (which snapshots the config at import time) and restore the
+    default module state on teardown, so an env-mutating reload can't leak into
+    later tests regardless of ordering. Yields a callable that performs the reload
+    and returns the reloaded module."""
+    yield lambda: importlib.reload(influx_mod)
+    for var in ("LEMONGRASS_CONFIG", "INFLUX_URL", "INFLUX_ORG"):
+        monkeypatch.delenv(var, raising=False)
+    importlib.reload(influx_mod)
 
 
-def test_env_does_not_override_influx_constants(monkeypatch):
+def test_env_does_not_override_influx_constants(monkeypatch, reload_influx):
     monkeypatch.delenv('LEMONGRASS_CONFIG', raising=False)
     monkeypatch.setenv('INFLUX_URL', 'http://localhost:8086')
     monkeypatch.setenv('INFLUX_ORG', 'lemongrass')
-    reloaded = importlib.reload(influx_mod)
+    reloaded = reload_influx()
     assert reloaded.INFLUX_URL == 'https://influxdb.focism.com'
     assert reloaded.INFLUX_ORG == 'focism'
-    monkeypatch.delenv('INFLUX_URL', raising=False)
-    monkeypatch.delenv('INFLUX_ORG', raising=False)
-    importlib.reload(influx_mod)  # restore default module state for later tests
 
 
-def test_bucket_names():
-    assert influx_mod.BUCKET_LAPS == 'laps'
-    assert influx_mod.BUCKET_RACES == 'races'
-    assert influx_mod.BUCKET_SESSIONS == 'race_sessions'
-
-
-def test_retry_policy_shape():
-    assert isinstance(influx_mod.INFLUX_RETRIES, Retry)
-    assert influx_mod.INFLUX_RETRIES.total == 3
-    assert 530 in influx_mod.INFLUX_RETRIES.status_forcelist
-    assert influx_mod.INFLUX_RETRIES.respect_retry_after_header is False
-    assert influx_mod.INFLUX_RETRIES.allowed_methods is None
-    assert influx_mod.INFLUX_RETRIES.backoff_max == 10
+@pytest.mark.parametrize("retries,total", [
+    (influx_mod.INFLUX_RETRIES, 3),      # the shared module-level default
+    (influx_mod.build_retries(1), 1),    # a trimmed budget shares the same policy
+])
+def test_build_retries_shares_transient_policy(retries, total):
+    assert isinstance(retries, Retry)
+    assert retries.total == total
+    assert retries.status_forcelist == [429, 502, 503, 504, 530]
+    assert 530 in retries.status_forcelist
+    assert retries.respect_retry_after_header is False
+    assert retries.allowed_methods is None
+    assert retries.backoff_max == 10
 
 
 def test_connect_exits_when_token_missing(monkeypatch, caplog):
@@ -86,40 +86,23 @@ def test_connect_forwards_timeout_and_retries(monkeypatch):
     )
 
 
-def test_build_retries_shares_transient_policy_with_fewer_attempts():
-    trimmed = influx_mod.build_retries(1)
-    assert isinstance(trimmed, Retry)
-    assert trimmed.total == 1
-    # Same transient-error semantics as the shared default, only fewer attempts.
-    assert trimmed.status_forcelist == influx_mod.INFLUX_RETRIES.status_forcelist
-    assert trimmed.respect_retry_after_header is False
-    assert trimmed.allowed_methods is None
-    assert trimmed.backoff_max == 10
-
-
-def test_connect_reads_token_from_configured_env_var(monkeypatch, tmp_path):
+def test_connect_reads_token_from_configured_env_var(monkeypatch, tmp_path, reload_influx):
     cfg = tmp_path / "c.toml"
     cfg.write_text('[influx]\ntoken_env = "MY_TOKEN"\n')
     monkeypatch.setenv('LEMONGRASS_CONFIG', str(cfg))
     monkeypatch.delenv('INFLUX_TELEMETRY_TOKEN', raising=False)
     monkeypatch.setenv('MY_TOKEN', 'via-directive')
-    reloaded = importlib.reload(influx_mod)
+    reloaded = reload_influx()
     with mock.patch('influxdb_client.InfluxDBClient') as client_cls:
         reloaded.connect()
     assert client_cls.call_args.kwargs['token'] == 'via-directive'
-    monkeypatch.delenv('LEMONGRASS_CONFIG', raising=False)
-    importlib.reload(influx_mod)  # restore default module state for later tests
 
 
 class TestInvalidFluxIds:
-    def test_clean_ids_pass(self):
-        from lemongrass import _influx
-        assert _influx.invalid_flux_ids(['144185', 'car_25-2']) == []
-
-    def test_metacharacters_rejected(self):
-        from lemongrass import _influx
-        assert _influx.invalid_flux_ids(['ok', 'bad"id', 'a b']) == ['bad"id', 'a b']
-
-    def test_non_strings_coerced(self):
-        from lemongrass import _influx
-        assert _influx.invalid_flux_ids([144185]) == []
+    @pytest.mark.parametrize("values,expected", [
+        (['144185', 'car_25-2'], []),                     # clean ids pass
+        (['ok', 'bad"id', 'a b'], ['bad"id', 'a b']),     # metacharacters rejected
+        ([144185], []),                                   # non-strings coerced
+    ])
+    def test_invalid_flux_ids(self, values, expected):
+        assert influx_mod.invalid_flux_ids(values) == expected

--- a/tests/test_influx.py
+++ b/tests/test_influx.py
@@ -36,7 +36,6 @@ def test_build_retries_shares_transient_policy(retries, total):
     assert isinstance(retries, Retry)
     assert retries.total == total
     assert retries.status_forcelist == [429, 502, 503, 504, 530]
-    assert 530 in retries.status_forcelist
     assert retries.respect_retry_after_header is False
     assert retries.allowed_methods is None
     assert retries.backoff_max == 10

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -11,6 +11,44 @@ import lemongrass._env as _env_mod
 import lemongrass.laps as _mod
 
 
+def _single_car_session_details(car_number='42', category='1', category_name='A',
+                                session_id=1, race_id=999, session_name='S1',
+                                start_epoc=0):
+    """Standard single-competitor session-details payload shared by old_race tests.
+
+    Carries the full ~20-key competitor dict (a superset of what any old_race path
+    reads) so callers can delegate here instead of re-declaring it. Override the
+    keyword args for the few fields individual tests vary.
+    """
+    return {
+        'Successful': True,
+        'Session': {
+            'ID': session_id, 'RaceID': race_id, 'Name': session_name,
+            'SessionStartDateEpoc': start_epoc,
+            'Categories': {category: {'ID': category, 'Name': category_name}},
+            'SortedCompetitors': [{
+                'Number': car_number, 'Category': category, 'ID': 1,
+                'SessionID': session_id, 'RaceID': race_id,
+                'FirstName': 'Jane', 'LastName': 'Doe',
+                'Position': '1', 'Laps': '1', 'LastLapTime': '',
+                'BestPosition': '1', 'BestLap': '1',
+                'BestLapTime': '0:01:30.000', 'TotalTime': '0:01:30.000',
+                'Transponder': '', 'Nationality': '', 'AdditionalData': '',
+                'LapTimes': [
+                    {'Lap': '1', 'LapTime': '0:01:30.000', 'Position': '1',
+                     'FlagStatus': 0, 'TotalTime': '0:01:30.000'},
+                ],
+            }],
+        },
+    }
+
+
+@pytest.fixture
+def single_car_session():
+    """Fixture exposing the shared single-competitor session-details factory."""
+    return _single_car_session_details
+
+
 class TestResolveTokens:
     def test_multi_tokens_returns_list(self):
         with patch.dict(os.environ, {'RACEMONITOR_TOKENS': 'TOKEN1,TOKEN2'}, clear=True):
@@ -49,30 +87,12 @@ class TestResolveTokens:
             result = _env_mod.resolve_tokens()
         assert result == ''
 
-    def test_whitespace_only_racemonitor_tokens_falls_back_to_single_token(self):
+    @pytest.mark.parametrize("tokens_value", ['  ,  , ', '  ', '', ','])
+    def test_empty_ish_racemonitor_tokens_falls_back_to_single_token(self, tokens_value):
+        # Whatever the empty-ish shape (all-whitespace slots, no commas, empty,
+        # bare comma), an empty RACEMONITOR_TOKENS falls back to RACEMONITOR_TOKEN.
         with patch.dict(os.environ,
-                        {'RACEMONITOR_TOKENS': '  ,  , ', 'RACEMONITOR_TOKEN': 'FALLBACK'},
-                        clear=True):
-            result = _env_mod.resolve_tokens()
-        assert result == 'FALLBACK'
-
-    def test_whitespace_only_no_commas_falls_back_to_single_token(self):
-        with patch.dict(os.environ,
-                        {'RACEMONITOR_TOKENS': '  ', 'RACEMONITOR_TOKEN': 'FALLBACK'},
-                        clear=True):
-            result = _env_mod.resolve_tokens()
-        assert result == 'FALLBACK'
-
-    def test_empty_string_racemonitor_tokens_falls_back_to_single_token(self):
-        with patch.dict(os.environ,
-                        {'RACEMONITOR_TOKENS': '', 'RACEMONITOR_TOKEN': 'FALLBACK'},
-                        clear=True):
-            result = _env_mod.resolve_tokens()
-        assert result == 'FALLBACK'
-
-    def test_bare_comma_falls_back_to_single_token(self):
-        with patch.dict(os.environ,
-                        {'RACEMONITOR_TOKENS': ',', 'RACEMONITOR_TOKEN': 'FALLBACK'},
+                        {'RACEMONITOR_TOKENS': tokens_value, 'RACEMONITOR_TOKEN': 'FALLBACK'},
                         clear=True):
             result = _env_mod.resolve_tokens()
         assert result == 'FALLBACK'
@@ -81,16 +101,6 @@ class TestResolveTokens:
         with patch.dict(os.environ, {'RACEMONITOR_TOKENS': 'TOKEN1,,TOKEN2'}, clear=True):
             result = _env_mod.resolve_tokens()
         assert result == ['TOKEN1', 'TOKEN2']
-
-
-class TestIntervalArg:
-    def test_default_interval_is_30(self):
-        args = _mod._build_parser().parse_args(['12345', '42'])
-        assert args.interval == 30
-
-    def test_custom_interval(self):
-        args = _mod._build_parser().parse_args(['12345', '42', '--interval', '60'])
-        assert args.interval == 60
 
 
 class TestMonitorRoutine:
@@ -110,10 +120,6 @@ class TestMonitorRoutine:
         opts = _mod.RaceOptions(network_mode=False, interval=30)
         with patch.object(_mod, 'refresh_competitor', return_value=[{'Lap': 1}]):
             _mod.monitor_routine(ctx, [{'Lap': 1}], opts, _stop_event=stop)
-
-    def test_monitor_status_values_exist(self):
-        assert _mod.MonitorStatus.RACE_ENDED is not None
-        assert _mod.MonitorStatus.INTERRUPTED is not None
 
     def test_refresh_competitor_empty_response_returns_empty_list(self):
         ctx = _mod.RaceContext('123', '42', MagicMock(), None, 0)
@@ -286,14 +292,16 @@ class TestMonitorRoutine:
         ctx = _mod.RaceContext('123', '42', MagicMock(), MagicMock(), 0)
         opts = _mod.RaceOptions(network_mode=True, interval=0)
 
+        session_resp = {'Successful': True, 'Session': {
+            'ID': 'sess-1', 'Name': 'S', 'Competitors': {}, 'Classes': {}}}
+
         call_count = 0
         def fake_get_session(race_id):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
                 stop.set()
-            return {'Successful': True, 'Session': {
-                'ID': 'sess-1', 'Name': 'S', 'Competitors': {}, 'Classes': {}}}
+            return session_resp
 
         ctx.client.live.get_session.side_effect = fake_get_session
 
@@ -302,7 +310,9 @@ class TestMonitorRoutine:
                 with patch.object(_mod, 'push_influx'):
                     _mod.monitor_routine(ctx, [], opts, _stop_event=stop)
 
-        mock_standings.assert_called_once_with(ctx, mock_standings.call_args[0][1], 'sess-1', {})
+        # prev_standings starts as {} on the first poll; the real session_response
+        # (not the mock's own recorded arg) is the expected second argument.
+        mock_standings.assert_called_once_with(ctx, session_resp, 'sess-1', {})
 
     def test_standings_not_written_when_not_network_mode(self):
         stop = threading.Event()
@@ -415,6 +425,51 @@ class TestMonitorRoutine:
                     _mod.monitor_routine(ctx, [], opts, _stop_event=stop)
         # no exception raised is the assertion
 
+    def test_get_session_exception_does_not_kill_monitor(self):
+        """A get_session network error mid-poll is swallowed; the poll continues."""
+        stop = threading.Event()
+        ctx = _mod.RaceContext('123', '42', MagicMock(), None, 0)
+        opts = _mod.RaceOptions(network_mode=False, interval=0)
+        ctx.client.live.get_session.side_effect = ConnectionError("wifi blip")
+
+        calls = 0
+
+        def fake_refresh(c):
+            nonlocal calls
+            calls += 1
+            stop.set()
+            return []
+
+        with patch.object(_mod, 'refresh_competitor', side_effect=fake_refresh):
+            result = _mod.monitor_routine(ctx, [], opts, _stop_event=stop)
+        assert calls == 1  # reached refresh despite get_session raising
+        assert result is None
+
+    def test_is_live_exception_does_not_kill_monitor(self):
+        """An is_live network error on the periodic liveness check is swallowed;
+        the loop keeps polling rather than crashing or ending the race."""
+        ctx = _mod.RaceContext('123', '42', MagicMock(), None, 0)
+        opts = _mod.RaceOptions(network_mode=False, interval=30)
+
+        n = _mod._LIVE_CHECK_INTERVAL
+        poll_count = 0
+
+        def fake_wait(timeout):
+            nonlocal poll_count
+            poll_count += 1
+            return poll_count > n  # stop after one full liveness interval
+
+        stop = MagicMock()
+        stop.wait.side_effect = fake_wait
+        ctx.client.live.get_session.return_value = {'Successful': False}
+        ctx.client.race.is_live.side_effect = ConnectionError("wifi blip")
+
+        with patch.object(_mod, 'refresh_competitor', return_value=[]):
+            with patch.object(_mod.threading, 'Event', return_value=stop):
+                result = _mod.monitor_routine(ctx, [], opts)
+        assert ctx.client.race.is_live.called  # the check fired and raised
+        assert result is None  # loop exited via stop, not a crash or RACE_ENDED
+
 
 class TestWriteCSV:
     def test_opens_file_with_correct_name(self):
@@ -468,22 +523,12 @@ class TestResolveClassHistorical:
             },
         }
 
-    def test_returns_class_name(self):
+    @pytest.mark.parametrize("name", ['A', 'Super Street', 'GT3,Pro=Am'])
+    def test_class_name_preserved(self, name):
         sd = self._session('42', '1')
+        sd['Session']['Categories']['1']['Name'] = name
         class_name, _ = _mod._resolve_class_historical('42', sd)
-        assert class_name == 'A'
-
-    def test_class_name_spaces_preserved(self):
-        sd = self._session('42', '1')
-        sd['Session']['Categories']['1']['Name'] = 'Super Street'
-        class_name, _ = _mod._resolve_class_historical('42', sd)
-        assert class_name == 'Super Street'
-
-    def test_class_name_special_chars_preserved(self):
-        sd = self._session('42', '1')
-        sd['Session']['Categories']['1']['Name'] = 'GT3,Pro=Am'
-        class_name, _ = _mod._resolve_class_historical('42', sd)
-        assert class_name == 'GT3,Pro=Am'
+        assert class_name == name
 
     def test_only_car_in_class_is_always_position_1(self):
         sd = self._session('42', '1')
@@ -566,11 +611,21 @@ class TestResolveClassLive:
             },
         }
 
-    def test_returns_class_name(self):
+    @pytest.mark.parametrize("name", ['A', 'GT3,Pro=Am'])
+    def test_class_name_preserved(self, name):
         session = self._make_session('42', 'classA', 3)
-        session['Session']['Classes']['classA']['Description'] = 'A'
+        session['Session']['Classes']['classA']['Description'] = name
         class_name, _ = _mod._resolve_class_live(session, '42')
+        assert class_name == name
+
+    def test_non_integer_tracked_position_returns_class_name_and_none(self):
+        # tracked car's Position is unparseable (e.g. DNF) — class name still
+        # resolves but the class position cannot be computed.
+        session = self._make_session('42', 'classA', 3)
+        session['Session']['Competitors']['r1']['Position'] = 'DNF'
+        class_name, class_pos = _mod._resolve_class_live(session, '42')
         assert class_name == 'A'
+        assert class_pos is None
 
     def test_only_car_in_class_is_position_1(self):
         session = self._make_session('42', 'classA', 3)
@@ -602,12 +657,6 @@ class TestResolveClassLive:
         class_name, class_pos = _mod._resolve_class_live({'Successful': False}, '42')
         assert class_name is None
         assert class_pos is None
-
-    def test_class_name_special_chars_preserved(self):
-        session = self._make_session('42', 'classA', 1)
-        session['Session']['Classes']['classA']['Description'] = 'GT3,Pro=Am'
-        class_name, _ = _mod._resolve_class_live(session, '42')
-        assert class_name == 'GT3,Pro=Am'
 
 
 class TestTimeToMs:
@@ -697,31 +746,24 @@ class TestPushInfluxClassInfo:
         assert isinstance(record, list)
         assert len(record) == 2
 
-    def test_includes_class_tag_when_provided(self):
+    @pytest.mark.parametrize("kwargs,substr,present", [
+        # class tag: included when class_name given, omitted otherwise
+        ({'class_name': 'A', 'class_positions': {1: 2}}, 'class=A', True),
+        ({}, 'class=', False),
+        # class_position field: included when class_positions maps the lap
+        ({'class_name': 'A', 'class_positions': {1: 2}}, 'class_position=2i', True),
+        ({}, 'class_position', False),
+        # competitor_name field
+        ({'competitor_name': 'Jane Doe'}, 'competitor_name="Jane Doe"', True),
+        ({}, 'competitor_name', False),
+        # car_info field
+        ({'car_info': '2005/Toy/Celica'}, 'car_info="2005/Toy/Celica"', True),
+        ({}, 'car_info', False),
+    ])
+    def test_optional_field_inclusion(self, kwargs, substr, present):
         ctx, write_api = self._ctx()
-        _mod.push_influx(ctx, self._laps(), False, class_name='A', class_positions={1: 2})
-        assert 'class=A' in self._record(write_api)
-
-    def test_car_number_tag_before_class_tag(self):
-        ctx, write_api = self._ctx()
-        _mod.push_influx(ctx, self._laps(), False, class_name='A', class_positions={1: 1})
-        record = self._record(write_api)
-        assert record.index('car_number=') < record.index('class=')
-
-    def test_includes_class_position_field_when_provided(self):
-        ctx, write_api = self._ctx()
-        _mod.push_influx(ctx, self._laps(), False, class_name='A', class_positions={1: 2})
-        assert 'class_position=2i' in self._record(write_api)
-
-    def test_omits_class_tag_when_not_provided(self):
-        ctx, write_api = self._ctx()
-        _mod.push_influx(ctx, self._laps(), False)
-        assert 'class=' not in self._record(write_api)
-
-    def test_omits_class_position_when_not_provided(self):
-        ctx, write_api = self._ctx()
-        _mod.push_influx(ctx, self._laps(), False)
-        assert 'class_position' not in self._record(write_api)
+        _mod.push_influx(ctx, self._laps(), False, **kwargs)
+        assert (substr in self._record(write_api)) is present
 
     def test_ctx_start_epoc_used_when_no_override(self):
         ctx, write_api = self._ctx()  # ctx.start_epoc = 0
@@ -744,26 +786,6 @@ class TestPushInfluxClassInfo:
             _mod.push_influx(ctx, self._laps(), False)
         assert any('epoch' in r.message.lower() and r.levelno == logging.WARNING
                    for r in caplog.records)
-
-    def test_includes_competitor_name_field_when_provided(self):
-        ctx, write_api = self._ctx()
-        _mod.push_influx(ctx, self._laps(), False, competitor_name='Jane Doe')
-        assert 'competitor_name="Jane Doe"' in self._record(write_api)
-
-    def test_omits_competitor_name_field_when_none(self):
-        ctx, write_api = self._ctx()
-        _mod.push_influx(ctx, self._laps(), False)
-        assert 'competitor_name' not in self._record(write_api)
-
-    def test_includes_car_info_field_when_provided(self):
-        ctx, write_api = self._ctx()
-        _mod.push_influx(ctx, self._laps(), False, car_info='2005/Toy/Celica')
-        assert 'car_info="2005/Toy/Celica"' in self._record(write_api)
-
-    def test_omits_car_info_field_when_none(self):
-        ctx, write_api = self._ctx()
-        _mod.push_influx(ctx, self._laps(), False)
-        assert 'car_info' not in self._record(write_api)
 
     def test_measurement_is_lap(self):
         ctx, write_api = self._ctx()
@@ -838,43 +860,14 @@ class TestPushInfluxClassInfo:
         assert 'car_number=42' not in record
 
     def test_passes_session_id_to_build_lap_points(self):
-        ctx, _write_api = self._ctx()
-        with patch.object(_mod, '_build_lap_points', return_value=[]) as mock_build:
-            _mod.push_influx(ctx, self._laps(), False, session_id=77)
-        assert mock_build.call_args.args[8] == 77
-
-
-class TestSkipIfCompleteArg:
-    def test_default_is_false(self):
-        args = _mod._build_parser().parse_args(['12345', '42'])
-        assert args.skip_if_complete is False
-
-    def test_flag_sets_true(self):
-        args = _mod._build_parser().parse_args(['12345', '42', '--skip-if-complete'])
-        assert args.skip_if_complete is True
+        ctx, write_api = self._ctx()
+        _mod.push_influx(ctx, self._laps(), False, session_id=77)
+        assert 'session_id=77' in self._record(write_api)
 
 
 class TestOldRaceSkip:
     def _session_details(self):
-        return {
-            'Successful': True,
-            'Session': {
-                'ID': 1, 'RaceID': 999, 'Name': 'S1', 'SessionStartDateEpoc': 0,
-                'Categories': {'1': {'ID': '1', 'Name': 'A'}},
-                'SortedCompetitors': [{
-                    'Number': '42', 'Category': '1', 'ID': 1, 'SessionID': 1,
-                    'RaceID': 999, 'FirstName': 'Jane', 'LastName': 'Doe',
-                    'Position': '1', 'Laps': '1', 'LastLapTime': '',
-                    'BestPosition': '1', 'BestLap': '1',
-                    'BestLapTime': '0:01:30.000', 'TotalTime': '0:01:30.000',
-                    'Transponder': '', 'Nationality': '', 'AdditionalData': '',
-                    'LapTimes': [
-                        {'Lap': '1', 'LapTime': '0:01:30.000', 'Position': '1',
-                         'FlagStatus': 0, 'TotalTime': '0:01:30.000'},
-                    ],
-                }],
-            },
-        }
+        return _single_car_session_details()
 
     def _ctx(self):
         ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
@@ -1032,12 +1025,10 @@ class TestExistingLapCounts:
 
 class TestArgParserCarNumber:
     def test_car_number_optional(self):
+        # nargs='?' makes the positional car_number optional (defaults to None);
+        # this is custom parser wiring main() depends on, not a stdlib default.
         args = _mod._build_parser().parse_args(['12345'])
         assert args.car_number is None
-
-    def test_car_number_accepted_when_provided(self):
-        args = _mod._build_parser().parse_args(['12345', '42'])
-        assert args.car_number == 42
 
 
 class TestExistingLapCountsFieldwide:
@@ -1116,25 +1107,7 @@ class TestExistingStandingsCountsFieldwide:
 
 class TestOldRaceFieldwide:
     def _session_details(self, car_number='42'):
-        return {
-            'Successful': True,
-            'Session': {
-                'ID': 1, 'RaceID': 999, 'Name': 'S1', 'SessionStartDateEpoc': 0,
-                'Categories': {'1': {'ID': '1', 'Name': 'A'}},
-                'SortedCompetitors': [{
-                    'Number': car_number, 'Category': '1', 'ID': 1, 'SessionID': 1,
-                    'RaceID': 999, 'FirstName': 'Jane', 'LastName': 'Doe',
-                    'Position': '1', 'Laps': '1', 'LastLapTime': '',
-                    'BestPosition': '1', 'BestLap': '1',
-                    'BestLapTime': '0:01:30.000', 'TotalTime': '0:01:30.000',
-                    'Transponder': '', 'Nationality': '', 'AdditionalData': '',
-                    'LapTimes': [
-                        {'Lap': '1', 'LapTime': '0:01:30.000', 'Position': '1',
-                         'FlagStatus': 0, 'TotalTime': '0:01:30.000'},
-                    ],
-                }],
-            },
-        }
+        return _single_car_session_details(car_number=car_number)
 
     def test_proceeds_even_when_tracked_car_absent(self):
         """With no competitor_missing gate, old_race writes even when ctx.car_number absent."""
@@ -1169,28 +1142,6 @@ class TestOldRaceFieldwide:
         mock_del.assert_not_called()
         assert any('No competitors' in r.message for r in caplog.records)
 
-
-class TestOldRacePrintsClass:
-    def _session_details(self):
-        return {
-            'Successful': True,
-            'Session': {
-                'ID': 1, 'RaceID': 999, 'Name': 'S1', 'SessionStartDateEpoc': 0,
-                'Categories': {'1': {'ID': '1', 'Name': 'B-Class'}},
-                'SortedCompetitors': [{
-                    'Number': '42', 'Category': '1', 'ID': 1, 'SessionID': 1,
-                    'RaceID': 999, 'FirstName': 'Jane', 'LastName': 'Doe',
-                    'Position': '1', 'Laps': '1', 'LastLapTime': '',
-                    'BestPosition': '1', 'BestLap': '1',
-                    'BestLapTime': '0:01:30.000', 'TotalTime': '0:01:30.000',
-                    'Transponder': 'T123', 'Nationality': '', 'AdditionalData': '',
-                    'LapTimes': [
-                        {'Lap': '1', 'LapTime': '0:01:30.000', 'Position': '1',
-                         'FlagStatus': 0, 'TotalTime': '0:01:30.000'},
-                    ],
-                }],
-            },
-        }
 
 class TestLiveRace:
     def _session_response(self, class_desc='A'):
@@ -1249,6 +1200,17 @@ class TestLiveRace:
                 with patch.object(_mod, 'push_influx_race'):
                     _mod.live_race(ctx, opts)
         assert ctx.client.live.get_session.call_count == 1
+
+    def test_save_file_writes_csv_with_name_and_race_id(self):
+        # opts.save_file routes to write_csv with a "<competitor name>-<race_id>"
+        # filename built from the live racer detail.
+        ctx = self._ctx()
+        opts = _mod.RaceOptions(network_mode=False, save_file=True)
+        with patch.object(_mod, 'print_rankings'):
+            with patch.object(_mod, 'write_csv') as mock_csv:
+                _mod.live_race(ctx, opts)
+        mock_csv.assert_called_once()
+        assert mock_csv.call_args.args[0] == 'Jane Doe-999'
 
 
 class TestLiveRaceStandingsWrite:
@@ -1402,28 +1364,21 @@ class TestLiveRaceMetadataFailure:
 
 class TestOldRaceClassWiring:
     def _session_details(self, car_number='42', cat_id='1', cat_name='A'):
-        return {
-            'Successful': True,
-            'Session': {
-                'ID': 1, 'RaceID': 999, 'Name': 'S1', 'SessionDate': '',
-                'SessionTime': '', 'SortMode': '', 'CategoryString': '',
-                'ResultsProcessorVersion': 1, 'SessionStartDateEpoc': 0,
-                'Categories': {cat_id: {'ID': cat_id, 'Name': cat_name}},
-                'SortedCompetitors': [{
-                    'Number': car_number, 'Category': cat_id,
-                    'ID': 1, 'SessionID': 1, 'RaceID': 999,
-                    'FirstName': 'Jane', 'LastName': 'Doe',
-                    'Position': '1', 'Laps': '1', 'LastLapTime': '',
-                    'BestPosition': '1', 'BestLap': '1',
-                    'BestLapTime': '0:01:30.000', 'TotalTime': '0:01:30.000',
-                    'Transponder': '', 'Nationality': '', 'AdditionalData': '',
-                    'LapTimes': [
-                        {'Lap': '1', 'LapTime': '0:01:30.000', 'Position': '1',
-                         'FlagStatus': 0, 'TotalTime': '0:01:30.000'},
-                    ],
-                }],
-            },
-        }
+        return _single_car_session_details(
+            car_number=car_number, category=cat_id, category_name=cat_name)
+
+    @staticmethod
+    def _capture_points():
+        """Return (captured_list, patch_cm) so _build_lap_points runs for real and
+        the emitted lap Point objects are captured from _write_points_chunked
+        (standings points written in the same pass are filtered out)."""
+        captured = []
+
+        def _cap(_api, points):
+            captured.extend(p for p in points if p.to_line_protocol().startswith('lap,'))
+
+        cm = patch.object(_mod, '_write_points_chunked', side_effect=_cap)
+        return captured, cm
 
     def test_calls_resolve_class_historical_per_session(self):
         ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
@@ -1445,41 +1400,47 @@ class TestOldRaceClassWiring:
         opts = _mod.RaceOptions(network_mode=True)
         ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
         ctx.client.results.session_details.return_value = self._session_details()
+        captured, cm = self._capture_points()
         with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
-            with patch.object(_mod, '_build_lap_points', return_value=[]) as mock_build:
+            with cm:
                 with patch.object(_mod, 'push_influx_race'):
                     with patch.object(_mod, 'print_rankings'):
                         _mod.old_race(ctx, opts)
-        assert mock_build.call_args.args[4] == 'A'
+        assert 'class=A' in captured[0].to_line_protocol()
 
     def test_passes_session_start_epoc_to_build_lap_points(self):
-        # ctx.start_epoc=9999 is intentionally different from SessionStartDateEpoc=5555
+        # ctx.start_epoc=9999 is intentionally different from SessionStartDateEpoc=5555;
+        # the emitted timestamp must anchor on the session epoch (5555*1000 + 90000ms).
         ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 9999)
         opts = _mod.RaceOptions(network_mode=True)
         session = self._session_details()
         session['Session']['SessionStartDateEpoc'] = 5555
         ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
         ctx.client.results.session_details.return_value = session
+        captured, cm = self._capture_points()
         with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
-            with patch.object(_mod, '_build_lap_points', return_value=[]) as mock_build:
+            with cm:
                 with patch.object(_mod, 'push_influx_race'):
                     with patch.object(_mod, 'print_rankings'):
                         _mod.old_race(ctx, opts)
-        assert mock_build.call_args.args[6] == 5555
+        assert captured[0].to_line_protocol().endswith(str(5555 * 1000 + 90000))
 
     def test_handles_missing_session_start_epoc_key(self):
-        ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
+        # Missing SessionStartDateEpoc -> None passed through -> _build_lap_points
+        # falls back to ctx.start_epoc (7000 here), anchoring at 7000*1000 + 90000ms.
+        ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 7000)
         opts = _mod.RaceOptions(network_mode=True)
         session = self._session_details()
         del session['Session']['SessionStartDateEpoc']
         ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
         ctx.client.results.session_details.return_value = session
+        captured, cm = self._capture_points()
         with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
-            with patch.object(_mod, '_build_lap_points', return_value=[]) as mock_build:
+            with cm:
                 with patch.object(_mod, 'push_influx_race'):
                     with patch.object(_mod, 'print_rankings'):
                         _mod.old_race(ctx, opts)
-        assert mock_build.call_args.args[6] is None
+        assert captured[0].to_line_protocol().endswith(str(7000 * 1000 + 90000))
 
     def test_no_network_mode_skips_resolve(self):
         ctx = _mod.RaceContext('999', '42', MagicMock(), None, 0)
@@ -1496,12 +1457,13 @@ class TestOldRaceClassWiring:
         opts = _mod.RaceOptions(network_mode=True)
         ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
         ctx.client.results.session_details.return_value = self._session_details()
+        captured, cm = self._capture_points()
         with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
-            with patch.object(_mod, '_build_lap_points', return_value=[]) as mock_build:
+            with cm:
                 with patch.object(_mod, 'push_influx_race'):
                     with patch.object(_mod, 'print_rankings'):
                         _mod.old_race(ctx, opts)
-        assert mock_build.call_args.args[2] == 'Jane Doe'
+        assert 'competitor_name="Jane Doe"' in captured[0].to_line_protocol()
 
     def test_passes_car_info_to_build_lap_points(self):
         ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
@@ -1510,12 +1472,13 @@ class TestOldRaceClassWiring:
         session['Session']['SortedCompetitors'][0]['AdditionalData'] = '2005/Toy/Celica'
         ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
         ctx.client.results.session_details.return_value = session
+        captured, cm = self._capture_points()
         with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
-            with patch.object(_mod, '_build_lap_points', return_value=[]) as mock_build:
+            with cm:
                 with patch.object(_mod, 'push_influx_race'):
                     with patch.object(_mod, 'print_rankings'):
                         _mod.old_race(ctx, opts)
-        assert mock_build.call_args.args[3] == '2005/Toy/Celica'
+        assert 'car_info="2005/Toy/Celica"' in captured[0].to_line_protocol()
 
     def test_competitor_name_none_when_both_name_fields_empty(self):
         ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
@@ -1525,12 +1488,13 @@ class TestOldRaceClassWiring:
         session['Session']['SortedCompetitors'][0]['LastName'] = ''
         ctx.client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 1}]}
         ctx.client.results.session_details.return_value = session
+        captured, cm = self._capture_points()
         with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
-            with patch.object(_mod, '_build_lap_points', return_value=[]) as mock_build:
+            with cm:
                 with patch.object(_mod, 'push_influx_race'):
                     with patch.object(_mod, 'print_rankings'):
                         _mod.old_race(ctx, opts)
-        assert mock_build.call_args.args[2] is None
+        assert 'competitor_name' not in captured[0].to_line_protocol()
 
     def test_old_race_calls_push_influx_race_once_across_multiple_sessions(self):
         ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 1000)
@@ -2270,20 +2234,15 @@ class TestPushInfluxRace:
         _mod.push_influx_race(ctx, 5000000)
         assert self._record(write_api).startswith('race,')
 
-    def test_race_id_tag(self):
+    @pytest.mark.parametrize("expected", [
+        'race_id=999',
+        'track_name=Road\\ America',
+        'end_time_epoc=1749132000i',
+    ])
+    def test_line_protocol_contains(self, expected):
         ctx, write_api, _delete_api = self._ctx()
         _mod.push_influx_race(ctx, 5000000)
-        assert 'race_id=999' in self._record(write_api)
-
-    def test_track_name_tag(self):
-        ctx, write_api, _delete_api = self._ctx()
-        _mod.push_influx_race(ctx, 5000000)
-        assert 'track_name=Road\\ America' in self._record(write_api)
-
-    def test_end_time_epoc_field(self):
-        ctx, write_api, _delete_api = self._ctx()
-        _mod.push_influx_race(ctx, 5000000)
-        assert 'end_time_epoc=1749132000i' in self._record(write_api)
+        assert expected in self._record(write_api)
 
     def test_uses_provided_timestamp(self):
         ctx, write_api, _delete_api = self._ctx()
@@ -2307,10 +2266,10 @@ class TestPushInfluxRace:
         _mod.push_influx_race(ctx, 1000)
         assert 'series_name=' not in self._record(write_api)
 
-    def test_metadata_none_skips_delete_and_write(self):
+    def test_metadata_none_returns_false_and_skips_delete_and_write(self):
         ctx, write_api, delete_api = self._ctx()
         ctx.metadata = None
-        _mod.push_influx_race(ctx, 1000)
+        assert _mod.push_influx_race(ctx, 1000) is False
         delete_api.delete.assert_not_called()
         write_api.write.assert_not_called()
 
@@ -2329,11 +2288,6 @@ class TestPushInfluxRace:
         ctx, write_api, _delete_api = self._ctx()
         write_api.write.side_effect = Exception("network error")
         assert _mod.push_influx_race(ctx, 5000000) is False
-
-    def test_returns_false_when_metadata_none(self):
-        ctx, _write_api, _delete_api = self._ctx()
-        ctx.metadata = None
-        assert _mod.push_influx_race(ctx, 1000) is False
 
 
 class TestPushInfluxRaceFields:
@@ -2366,22 +2320,7 @@ class TestPushInfluxRaceFields:
 
 class TestOldRaceMetadataFailure:
     def _session_details(self):
-        return {
-            'Successful': True,
-            'Session': {
-                'ID': 1, 'Name': 'S1', 'SessionStartDateEpoc': 1000,
-                'Categories': {'1': {'ID': '1', 'Name': 'A'}},
-                'SortedCompetitors': [{
-                    'Number': '42', 'Category': '1', 'FirstName': 'Jane',
-                    'LastName': 'Doe', 'Position': '1', 'Laps': '1',
-                    'BestLapTime': '', 'LastLapTime': '', 'Transponder': '',
-                    'AdditionalData': '',
-                    'LapTimes': [{'Lap': '1', 'LapTime': '0:01:30.000',
-                                  'Position': '1', 'FlagStatus': 0,
-                                  'TotalTime': '0:01:30.000'}],
-                }],
-            },
-        }
+        return _single_car_session_details(start_epoc=1000)
 
     def _ctx(self):
         ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
@@ -2493,25 +2432,16 @@ class TestPushInfluxSession:
         _mod.push_influx_session(ctx, 42, 'Day 1', 1700000000)
         assert self._record(write_api).startswith('session,')
 
-    def test_race_id_tag(self):
+    @pytest.mark.parametrize("expected", [
+        'race_id=999',
+        'session_id=42',
+        'session_name="Day 1"',
+        'start_epoc=1700000000i',
+    ])
+    def test_line_protocol_contains(self, expected):
         ctx, write_api, _delete_api = self._ctx()
         _mod.push_influx_session(ctx, 42, 'Day 1', 1700000000)
-        assert 'race_id=999' in self._record(write_api)
-
-    def test_session_id_tag(self):
-        ctx, write_api, _delete_api = self._ctx()
-        _mod.push_influx_session(ctx, 42, 'Day 1', 1700000000)
-        assert 'session_id=42' in self._record(write_api)
-
-    def test_session_name_field(self):
-        ctx, write_api, _delete_api = self._ctx()
-        _mod.push_influx_session(ctx, 42, 'Day 1', 1700000000)
-        assert 'session_name="Day 1"' in self._record(write_api)
-
-    def test_start_epoc_field(self):
-        ctx, write_api, _delete_api = self._ctx()
-        _mod.push_influx_session(ctx, 42, 'Day 1', 1700000000)
-        assert 'start_epoc=1700000000i' in self._record(write_api)
+        assert expected in self._record(write_api)
 
     def test_timestamp_uses_start_epoc_ms(self):
         ctx, write_api, _delete_api = self._ctx()
@@ -2632,18 +2562,32 @@ class TestOldRaceFullField:
         ctx.client.results.session_details.return_value = session_details
         return ctx
 
+    @staticmethod
+    def _capture_points():
+        captured = []
+
+        def _cap(_api, points):
+            captured.extend(p for p in points if p.to_line_protocol().startswith('lap,'))
+
+        cm = patch.object(_mod, '_write_points_chunked', side_effect=_cap)
+        return captured, cm
+
+    @staticmethod
+    def _car_number(point):
+        return point.to_line_protocol().split('car_number=', 1)[1].split(',', 1)[0]
+
     def test_writes_all_competitors_not_just_tracked(self):
         ctx = self._ctx(self._session_details_two_cars())
         opts = _mod.RaceOptions(network_mode=True)
+        captured, cm = self._capture_points()
         with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
-            with patch.object(_mod, '_build_lap_points', return_value=[]) as mock_build:
+            with cm:
                 with patch.object(_mod, 'push_influx_race'):
                     with patch.object(_mod, 'delete_existing_laps'):
                         with patch.object(_mod, 'print_rankings'):
                             _mod.old_race(ctx, opts)
-        assert mock_build.call_count == 2
-        built_car_numbers = {c.args[7] for c in mock_build.call_args_list}
-        assert built_car_numbers == {'42', '99'}
+        assert len(captured) == 2
+        assert {self._car_number(p) for p in captured} == {'42', '99'}
 
     def test_resolve_class_called_per_competitor(self):
         ctx = self._ctx(self._session_details_two_cars())
@@ -2661,14 +2605,16 @@ class TestOldRaceFullField:
     def test_build_lap_points_receives_explicit_car_number(self):
         ctx = self._ctx(self._session_details_two_cars())
         opts = _mod.RaceOptions(network_mode=True)
+        captured, cm = self._capture_points()
         with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
-            with patch.object(_mod, '_build_lap_points', return_value=[]) as mock_build:
+            with cm:
                 with patch.object(_mod, 'push_influx_race'):
                     with patch.object(_mod, 'delete_existing_laps'):
                         with patch.object(_mod, 'print_rankings'):
                             _mod.old_race(ctx, opts)
-        for c in mock_build.call_args_list:
-            assert c.args[7] is not None
+        # every emitted point carries an explicit per-competitor car_number tag
+        for point in captured:
+            assert 'car_number=' in point.to_line_protocol()
 
     def test_race_not_stamped_when_write_fails(self):
         ctx = self._ctx(self._session_details_two_cars())
@@ -2697,13 +2643,14 @@ class TestOldRaceFullField:
         }
         ctx = self._ctx(session)
         opts = _mod.RaceOptions(network_mode=True)
+        captured, cm = self._capture_points()
         with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
-            with patch.object(_mod, '_build_lap_points', return_value=[]) as mock_build:
+            with cm:
                 with patch.object(_mod, 'push_influx_race'):
                     with patch.object(_mod, 'delete_existing_laps'):
                         with patch.object(_mod, 'print_rankings'):
                             _mod.old_race(ctx, opts)
-        built_car_numbers = {c.args[7] for c in mock_build.call_args_list}
+        built_car_numbers = {self._car_number(p) for p in captured}
         assert 'SC' not in built_car_numbers
         assert '42' in built_car_numbers
 
@@ -2767,14 +2714,16 @@ class TestOldRaceFullField:
     def test_build_lap_points_receives_session_id(self):
         ctx = self._ctx(self._session_details_two_cars())
         opts = _mod.RaceOptions(network_mode=True)
+        captured, cm = self._capture_points()
         with patch.object(_mod, '_resolve_class_historical', return_value=('A', {1: 1})):
-            with patch.object(_mod, '_build_lap_points', return_value=[]) as mock_build:
+            with cm:
                 with patch.object(_mod, 'push_influx_race'):
                     with patch.object(_mod, 'delete_existing_laps'):
                         with patch.object(_mod, 'print_rankings'):
                             _mod.old_race(ctx, opts)
-        for c in mock_build.call_args_list:
-            assert c.args[8] == 1  # session_id from session details ID=1
+        # session_id tag comes from the session details ID=1
+        for point in captured:
+            assert 'session_id=1' in point.to_line_protocol()
 
 
 class TestBuildLapPointsSessionId:
@@ -2788,14 +2737,13 @@ class TestBuildLapPointsSessionId:
             ctx, self._laps(), 'Jane Doe', None, 'A', None, 0, '42', session_id)
         return points[0].to_line_protocol()
 
-    def test_session_id_tag_integer(self):
-        assert 'session_id=7' in self._build(7)
-
-    def test_session_id_tag_string(self):
-        assert 'session_id=99' in self._build('99')
-
-    def test_session_id_tag_absent_when_none(self):
-        assert 'session_id' not in self._build(None)
+    @pytest.mark.parametrize("session_id,substr,present", [
+        (7, 'session_id=7', True),       # integer
+        ('99', 'session_id=99', True),   # string
+        (None, 'session_id', False),     # omitted
+    ])
+    def test_session_id_tag(self, session_id, substr, present):
+        assert (substr in self._build(session_id)) is present
 
 
 class TestBuildLapPointsNonNumericPosition:
@@ -2871,6 +2819,32 @@ class TestPrintRankingsSortOrder:
         _mod.print_rankings(competitors, False, None, self._categories())
         out = capsys.readouterr().out
         assert out.index('42') < out.index('99')
+
+
+class TestPrintRankingsNames:
+    """print_rankings collects and returns the non-empty competitor names.
+
+    Regression: the name loop guarded on `item != ''` where `item` is the dict
+    KEY (always 'FirstName'/'LastName', never ''), so empty name VALUES were
+    collected anyway. The guard must test the value, so blank names are dropped.
+    """
+
+    def _categories(self):
+        return {'1': {'ID': '1', 'Name': 'Gold'}}
+
+    def _competitor(self, first, last):
+        return {'Position': '1', 'Number': '42', 'FirstName': first, 'LastName': last,
+                'Laps': '5', 'Category': '1', 'Transponder': 'T1'}
+
+    def test_empty_name_values_excluded_from_returned_names(self):
+        competitors = [
+            self._competitor('Jane', 'Doe'),   # both present
+            self._competitor('', 'Solo'),      # blank first name -> only 'Solo'
+            self._competitor('Mono', ''),      # blank last name -> only 'Mono'
+        ]
+        names = _mod.print_rankings(competitors, False, None, self._categories())
+        assert names == ['Jane', 'Doe', 'Solo', 'Mono']
+        assert '' not in names
 
 
 class TestWritePointsChunked:
@@ -2958,6 +2932,29 @@ class TestDryRun:
         assert result == 1
         mock_live.assert_not_called()
         assert any('dry-run' in r.message.lower() for r in caplog.records)
+
+
+class TestRunRaceDispatch:
+    def _ctx(self):
+        return _mod.RaceContext('999', '42', MagicMock(), None, 0)
+
+    def test_monitor_mode_returns_0_when_race_not_live(self):
+        # -m against a completed race disables monitoring and exits cleanly
+        # without falling through to the historical old_race backfill.
+        ctx = self._ctx()
+        opts = _mod.RaceOptions(monitor_mode=True)
+        with patch.object(_mod, 'old_race') as mock_old:
+            result = _mod._run_race(ctx, opts, {'Successful': True, 'IsLive': False})
+        assert result == 0
+        mock_old.assert_not_called()
+
+    def test_returns_1_on_write_failed(self):
+        ctx = self._ctx()
+        opts = _mod.RaceOptions()
+        with patch.object(_mod, 'live_race',
+                          return_value=_mod.MonitorStatus.WRITE_FAILED):
+            result = _mod._run_race(ctx, opts, {'Successful': True, 'IsLive': True})
+        assert result == 1
 
 
 class TestComputeClassPositionsLive:
@@ -3635,22 +3632,8 @@ class TestLiveRaceNoData:
 
 class TestOldRaceSessionFetching:
     def _session_details(self, sid=1):
-        return {
-            'Successful': True,
-            'Session': {
-                'ID': sid, 'Name': f'S{sid}', 'SessionStartDateEpoc': 1000,
-                'Categories': {'1': {'ID': '1', 'Name': 'A'}},
-                'SortedCompetitors': [{
-                    'Number': '42', 'Category': '1', 'FirstName': 'Jane',
-                    'LastName': 'Doe', 'Position': '1', 'Laps': '1',
-                    'BestLapTime': '', 'LastLapTime': '', 'Transponder': '',
-                    'AdditionalData': '',
-                    'LapTimes': [{'Lap': '1', 'LapTime': '0:01:30.000',
-                                  'Position': '1', 'FlagStatus': 0,
-                                  'TotalTime': '0:01:30.000'}],
-                }],
-            },
-        }
+        return _single_car_session_details(
+            session_id=sid, session_name=f'S{sid}', start_epoc=1000)
 
     def test_zero_sessions_returns_cleanly(self, caplog):
         """A race with no posted sessions must log and return, not UnboundLocalError."""
@@ -3781,6 +3764,24 @@ class TestClassIndex:
         index = _mod._build_class_index(details)
         assert _mod._resolve_class_historical('99', details, index) == (None, {})
 
+    def test_malformed_laps_skipped_in_index(self):
+        # A lap with an unparseable Lap number and one missing Position must be
+        # skipped without aborting the rest of the car's index.
+        details = {
+            'Session': {
+                'Categories': {'1': {'Name': 'A'}},
+                'SortedCompetitors': [
+                    {'Number': '10', 'Category': '1', 'LapTimes': [
+                        {'Lap': '1', 'Position': '1'},
+                        {'Lap': '$J', 'Position': '2'},  # unparseable Lap -> skipped
+                        {'Lap': '3'},                    # missing Position -> skipped
+                    ]},
+                ],
+            },
+        }
+        _, _, laps_by_car, _ = _mod._build_class_index(details)
+        assert laps_by_car['10'] == {1: 1}
+
     def test_old_race_builds_index_once_per_session(self):
         session = {
             'Successful': True,
@@ -3860,21 +3861,17 @@ class TestStoredEndSettled:
     def _stored(self, end_epoc):
         return _mod.StoredRace(schema_version=4, expected_lap_count=1, end_time_epoc=end_epoc)
 
-    def test_zero_epoch_is_not_settled(self):
-        assert _mod.stored_end_settled(self._stored(0)) is False
-
-    def test_none_epoch_is_not_settled(self):
-        assert _mod.stored_end_settled(self._stored(None)) is False
-
-    def test_future_epoch_is_not_settled(self):
+    @pytest.mark.parametrize("end_epoc", [
+        0,                # unknown end
+        None,             # missing end
+        _NOW + 5000,      # future end
+        _NOW - 3600,      # ended an hour ago, still well within the settle buffer
+    ])
+    def test_unknown_future_or_recent_end_is_not_settled(self, end_epoc):
+        # None of these are settled well behind us; a later session under the same
+        # race_id could still be live, so each must fall through to the is_live check.
         with patch.object(_mod.time, 'time', return_value=self._NOW):
-            assert _mod.stored_end_settled(self._stored(self._NOW + 5000)) is False
-
-    def test_recent_past_within_buffer_is_not_settled(self):
-        # Ended an hour ago — a later session under the same race_id could still be
-        # live, so this must fall through to the authoritative is_live check.
-        with patch.object(_mod.time, 'time', return_value=self._NOW):
-            assert _mod.stored_end_settled(self._stored(self._NOW - 3600)) is False
+            assert _mod.stored_end_settled(self._stored(end_epoc)) is False
 
     def test_end_exactly_at_buffer_is_not_settled(self):
         with patch.object(_mod.time, 'time', return_value=self._NOW):

--- a/tests/test_laps.py
+++ b/tests/test_laps.py
@@ -49,6 +49,19 @@ def single_car_session():
     return _single_car_session_details
 
 
+def _capture_lap_points():
+    """Return (captured_list, patch_cm) so _build_lap_points runs for real and
+    the emitted lap Point objects are captured from _write_points_chunked
+    (standings points written in the same pass are filtered out)."""
+    captured = []
+
+    def _cap(_api, points):
+        captured.extend(p for p in points if p.to_line_protocol().startswith('lap,'))
+
+    cm = patch.object(_mod, '_write_points_chunked', side_effect=_cap)
+    return captured, cm
+
+
 class TestResolveTokens:
     def test_multi_tokens_returns_list(self):
         with patch.dict(os.environ, {'RACEMONITOR_TOKENS': 'TOKEN1,TOKEN2'}, clear=True):
@@ -1367,18 +1380,7 @@ class TestOldRaceClassWiring:
         return _single_car_session_details(
             car_number=car_number, category=cat_id, category_name=cat_name)
 
-    @staticmethod
-    def _capture_points():
-        """Return (captured_list, patch_cm) so _build_lap_points runs for real and
-        the emitted lap Point objects are captured from _write_points_chunked
-        (standings points written in the same pass are filtered out)."""
-        captured = []
-
-        def _cap(_api, points):
-            captured.extend(p for p in points if p.to_line_protocol().startswith('lap,'))
-
-        cm = patch.object(_mod, '_write_points_chunked', side_effect=_cap)
-        return captured, cm
+    _capture_points = staticmethod(_capture_lap_points)
 
     def test_calls_resolve_class_historical_per_session(self):
         ctx = _mod.RaceContext('999', '42', MagicMock(), MagicMock(), 0)
@@ -2562,15 +2564,7 @@ class TestOldRaceFullField:
         ctx.client.results.session_details.return_value = session_details
         return ctx
 
-    @staticmethod
-    def _capture_points():
-        captured = []
-
-        def _cap(_api, points):
-            captured.extend(p for p in points if p.to_line_protocol().startswith('lap,'))
-
-        cm = patch.object(_mod, '_write_points_chunked', side_effect=_cap)
-        return captured, cm
+    _capture_points = staticmethod(_capture_lap_points)
 
     @staticmethod
     def _car_number(point):

--- a/tests/test_pisugar_monitor.py
+++ b/tests/test_pisugar_monitor.py
@@ -1,7 +1,9 @@
 import base64
 import json
-from unittest.mock import MagicMock, call, mock_open, patch
-from urllib.error import URLError
+import logging
+from contextlib import ExitStack
+from unittest.mock import MagicMock, mock_open, patch
+from urllib.error import HTTPError, URLError
 
 import pytest
 
@@ -31,10 +33,10 @@ class TestTokenExpiry:
     def test_empty_string_returns_none(self):
         assert token_expiry("") is None
 
-    def test_padding_handled(self):
-        for extra in ["", "x", "xy"]:
-            payload = {"exp": 9999, "pad": extra}
-            assert token_expiry(_make_jwt(payload)) == 9999
+    @pytest.mark.parametrize("extra", ["", "x", "xy"])
+    def test_padding_handled(self, extra):
+        payload = {"exp": 9999, "pad": extra}
+        assert token_expiry(_make_jwt(payload)) == 9999
 
     def test_base64url_payload_decoded(self):
         """JWT payloads are base64url; b64decode silently drops '-'/'_' and
@@ -80,19 +82,6 @@ class TestHttpTimeouts:
 
 
 class TestMain:
-    def test_missing_influx_token_exits_before_pisugar_login(self):
-        """A missing INFLUX_TELEMETRY_TOKEN must fail fast: exit before attempting
-        a pisugar login (a network call)."""
-        login = MagicMock()
-        with patch.dict('os.environ', {}, clear=True):
-            with patch.object(_mod, 'login', login):
-                with patch.object(_mod, 'read_credentials',
-                                  return_value=('admin', 'secret')):
-                    with pytest.raises(SystemExit) as exc:
-                        _mod.main()
-        assert exc.value.code == 1
-        login.assert_not_called()
-
     def test_honors_configured_token_env_var(self, monkeypatch, tmp_path):
         cfg = tmp_path / "c.toml"
         cfg.write_text('[influx]\ntoken_env = "MY_INFLUX_TOKEN"\n')
@@ -122,27 +111,30 @@ class TestExecCommandCoercion:
                 b"battery: 84.5"
             assert _mod.exec_command("get battery") == 84.5
 
+    @pytest.mark.parametrize("raw,expected", [
+        (b"battery_charging: true", True),
+        (b"battery_power_plugged: false", False),
+    ])
+    def test_coerces_booleans(self, raw, expected):
+        with patch.object(_mod.urllib.request, "urlopen") as mock_open:
+            mock_open.return_value.__enter__.return_value.read.return_value = raw
+            assert _mod.exec_command("get battery_charging") is expected
+
 
 class TestStartupConnect:
     def test_retries_until_server_reachable(self):
         """The monitor often boots before pisugar-server binds :8421; it must
         retry instead of dying with a traceback."""
         with patch.object(_mod, "login", side_effect=[URLError("refused"), "tok"]) as mock_login:
-            with patch.object(_mod, "exec_command", return_value="PiSugar 3") as mock_exec:
+            with patch.object(_mod, "exec_command", return_value="PiSugar 3"):
                 with patch.object(_mod, "sleep") as mock_sleep:
                     token, tags = _mod._startup_connect("u", "p")
         assert token == "tok"
         assert mock_login.call_count == 2
         mock_sleep.assert_called_once_with(_mod.STARTUP_RETRY_DELAY_S)
+        # Device tags read raw (coerce=False) so "PiSugar 3" isn't numerically mangled.
         assert tags == {"server_version": "PiSugar 3", "model": "PiSugar 3",
                         "firmware_version": "PiSugar 3"}
-        # Device tags must be read raw; coerce=False keeps "PiSugar 3" from being
-        # numerically mangled.
-        assert mock_exec.call_args_list == [
-            call("get version", "tok", coerce=False),
-            call("get model", "tok", coerce=False),
-            call("get firmware_version", "tok", coerce=False),
-        ]
 
     def test_no_credentials_skips_login(self):
         with patch.object(_mod, "login") as mock_login:
@@ -175,3 +167,95 @@ class TestWritePointsBucket:
         point = _mod.build_point("pisugar-battery-level", 80, {"host": "pi-1"})
         assert point._tags == {"host": "pi-1"}
         assert "vin" not in point._tags
+
+    def test_write_failure_is_logged_and_swallowed(self, caplog):
+        """A rejected batch (e.g. a malformed reading) must be logged and
+        swallowed, not propagated -- the next 0.5s tick re-reads fresh values."""
+        caplog.set_level(logging.INFO)
+        write_api = MagicMock()
+        write_api.write.side_effect = RuntimeError("bucket rejected the write")
+        _mod.write_points(write_api, [_mod.build_point("pisugar-temperature", 42.0)])
+        assert "Failed to write" in caplog.text
+
+
+class _StopLoopError(Exception):
+    """Sentinel raised from a patched sleep() to break main()'s `while True`
+    after exactly one tick."""
+
+
+class TestMainLoop:
+    def _drive_one_tick(self, monkeypatch, exec_command, *, credentials=(None, None),
+                        token_expiry_ret=None, startup_token=None, login=None):
+        """Run main() through a single loop iteration, then break via _StopLoopError.
+
+        `exec_command` is passed straight to the mock's side_effect: a list feeds
+        one value per read, an exception instance raises on the read path.
+        """
+        monkeypatch.setenv("INFLUX_TELEMETRY_TOKEN", "influx-tok")
+        monkeypatch.delenv("LEMONGRASS_CONFIG", raising=False)
+        connect_cm = MagicMock()
+        write_api = connect_cm.__enter__.return_value.write_api.return_value
+        login = login or MagicMock(return_value="new-token")
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch.object(_mod, "read_credentials", return_value=credentials))
+            stack.enter_context(
+                patch.object(_mod, "_startup_connect",
+                             return_value=(startup_token, {"model": "PiSugar 3"})))
+            stack.enter_context(patch.object(_mod, "_resolve_host", return_value="pi-1"))
+            stack.enter_context(
+                patch.object(_mod, "token_expiry", return_value=token_expiry_ret))
+            stack.enter_context(patch.object(_mod, "login", login))
+            stack.enter_context(patch.object(_mod._influx, "connect",
+                                             return_value=connect_cm))
+            ec = stack.enter_context(
+                patch.object(_mod, "exec_command", side_effect=exec_command))
+            stack.enter_context(patch.object(_mod, "sleep", side_effect=_StopLoopError))
+            with pytest.raises(_StopLoopError):
+                _mod.main()
+        return {"write_api": write_api, "login": login, "exec_command": ec}
+
+    def test_one_tick_reads_six_and_writes(self, monkeypatch):
+        r = self._drive_one_tick(
+            monkeypatch,
+            exec_command=[True, 0.1, 80.0, True, 4.2, 25.0],
+        )
+        assert r["exec_command"].call_count == 6
+        assert r["write_api"].write.call_count == 1
+        assert len(r["write_api"].write.call_args.kwargs["record"]) == 6
+
+    def test_401_read_triggers_reauthentication(self, monkeypatch, caplog):
+        caplog.set_level(logging.INFO)
+        login = MagicMock(return_value="fresh-token")
+        self._drive_one_tick(
+            monkeypatch,
+            exec_command=HTTPError("http://pi", 401, "unauthorized", {}, None),
+            credentials=("admin", "secret"),
+            startup_token="old-token",
+            token_expiry_ret=None,  # skip proactive refresh; exercise the 401 path
+            login=login,
+        )
+        login.assert_called_once_with("admin", "secret")
+        assert "re-authenticating" in caplog.text
+
+    def test_proactive_refresh_near_expiry(self, monkeypatch, caplog):
+        caplog.set_level(logging.INFO)
+        login = MagicMock(return_value="fresh-token")
+        self._drive_one_tick(
+            monkeypatch,
+            exec_command=[True, 0.1, 80.0, True, 4.2, 25.0],
+            credentials=("admin", "secret"),
+            startup_token="old-token",
+            token_expiry_ret=1,  # exp far in the past -> now() past the refresh margin
+            login=login,
+        )
+        login.assert_called_once_with("admin", "secret")
+        assert "nearing expiry" in caplog.text
+
+    def test_generic_read_error_is_logged_and_swallowed(self, monkeypatch, caplog):
+        caplog.set_level(logging.INFO)
+        self._drive_one_tick(
+            monkeypatch,
+            exec_command=ValueError("garbled pisugar response"),
+        )
+        assert "Error reading from PiSugar" in caplog.text

--- a/tests/test_race_backfill.py
+++ b/tests/test_race_backfill.py
@@ -1,8 +1,10 @@
 import importlib
+import logging
 import os
 import sys
 from contextlib import contextmanager
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -19,6 +21,40 @@ EPOC_2020 = 1577836800
 EPOC_2021 = 1609459200
 EPOC_2022 = 1640995200
 EPOC_2023 = 1672531200
+
+
+@contextmanager
+def _inprocess_backfill(results=None):
+    """Patch the in-process backfill seam (shared RaceMonitorClient +
+    resolve_tokens + laps.backfill_race), yielding the backfill_race mock.
+
+    The mock carries a `.calls` list recording each invocation as
+    SimpleNamespace(race_id, car_number, client, opts), so tests assert on named
+    arguments and an observable client identity rather than brittle positional
+    call_args indices. It also exposes `.client_cls`, the patched
+    RaceMonitorClient, for asserting how many clients were created. `results`,
+    when given, is the per-call outcome list — an int is returned as the exit
+    code, a BaseException instance is raised; the default is 0 for every call.
+    """
+    calls = []
+    outcomes = iter(results) if results is not None else None
+
+    def record(race_id, car_number, client, opts):
+        calls.append(SimpleNamespace(race_id=race_id, car_number=car_number,
+                                     client=client, opts=opts))
+        if outcomes is None:
+            return 0
+        outcome = next(outcomes)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+    with patch.object(_mod, 'RaceMonitorClient', return_value=MagicMock()) as mk_client, \
+         patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
+         patch('lemongrass.laps.backfill_race', side_effect=record) as mk_backfill:
+        mk_backfill.calls = calls
+        mk_backfill.client_cls = mk_client
+        yield mk_backfill
 
 
 class TestFindMatchingRaces:
@@ -97,13 +133,11 @@ class TestRunBackfill:
         mk_client.assert_not_called()
 
     def test_dry_run_logs_race_name(self, caplog):
-        import logging
         with caplog.at_level(logging.INFO, logger='root'):
             _mod.run_backfill(self._races(), dry_run=True)
         assert any('Real Hoopties 2022' in r.message for r in caplog.records)
 
     def test_failure_summary_logged_when_any_race_fails(self, caplog):
-        import logging
         with patch.object(_mod, 'RaceMonitorClient', return_value=MagicMock()), \
              patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
              patch('lemongrass.laps._influx_only_skip', return_value=False), \
@@ -113,7 +147,6 @@ class TestRunBackfill:
         assert any('2 race(s) failed' in r.message for r in caplog.records)
 
     def test_no_failure_summary_when_all_succeed(self, caplog):
-        import logging
         with patch.object(_mod, 'RaceMonitorClient', return_value=MagicMock()), \
              patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
              patch('lemongrass.laps._influx_only_skip', return_value=False), \
@@ -151,24 +184,20 @@ class TestRunBackfill:
     def test_reuses_single_client_across_races(self):
         """One RaceMonitorClient (and its rate-limiter window) is shared across
         every race, instead of a fresh subprocess/window per race."""
-        with patch.object(_mod, 'RaceMonitorClient', return_value=MagicMock()) as mk_client, \
-             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
-             patch('lemongrass.laps._influx_only_skip', return_value=False), \
-             patch('lemongrass.laps.backfill_race', return_value=0) as mk_backfill:
+        with _inprocess_backfill() as mk_backfill, \
+             patch('lemongrass.laps._influx_only_skip', return_value=False):
             _mod.run_backfill(self._races())
-        assert mk_client.call_count == 1
+        assert mk_backfill.client_cls.call_count == 1
         assert mk_backfill.call_count == 2
-        clients = {c.args[2] for c in mk_backfill.call_args_list}
+        clients = {c.client for c in mk_backfill.calls}
         assert len(clients) == 1
 
     def test_backfill_called_fieldwide_with_race_id(self):
-        with patch.object(_mod, 'RaceMonitorClient', return_value=MagicMock()), \
-             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
-             patch('lemongrass.laps._influx_only_skip', return_value=False), \
-             patch('lemongrass.laps.backfill_race', return_value=0) as mk_backfill:
+        with _inprocess_backfill() as mk_backfill, \
+             patch('lemongrass.laps._influx_only_skip', return_value=False):
             _mod.run_backfill(self._races()[:1])
-        assert mk_backfill.call_args.args[0] == '101'  # race_id
-        assert mk_backfill.call_args.args[1] is None   # car_number (fieldwide)
+        assert mk_backfill.calls[0].race_id == '101'
+        assert mk_backfill.calls[0].car_number is None
 
     def test_skip_if_complete_skips_without_client_or_racemonitor(self):
         """A race already complete in Influx is skipped with no client created and
@@ -192,39 +221,54 @@ class TestRunBackfill:
         mk_skip.assert_not_called()
         assert mk_backfill.call_count == 1
 
-    def test_backfill_exception_records_failure_and_continues(self):
+
+class TestBackfillOneRace:
+    """Direct coverage of the per-race exception/interrupt/return contract that
+    both run_backfill and run_upgrade_stored delegate to."""
+
+    def _call(self, **backfill_kwargs):
+        failures = []
+        with patch('lemongrass.laps.backfill_race', **backfill_kwargs):
+            stop = _mod._backfill_one_race(MagicMock(), '101', MagicMock(),
+                                           failures, 'Backfill')
+        return stop, failures
+
+    def test_racemonitor_error_recorded_and_continues(self):
         from race_monitor import RaceMonitorHTTPError
-        with patch.object(_mod, 'RaceMonitorClient', return_value=MagicMock()), \
-             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
-             patch('lemongrass.laps._influx_only_skip', return_value=False), \
-             patch('lemongrass.laps.backfill_race',
-                   side_effect=[RaceMonitorHTTPError(429, 'rate'), 0]) as mk_backfill:
-            failures = _mod.run_backfill(self._races())
-        assert mk_backfill.call_count == 2
+        stop, failures = self._call(side_effect=RaceMonitorHTTPError(429, 'rate'))
+        assert stop is False
         assert failures == ['101']
 
-    def test_keyboard_interrupt_stops_backfill(self):
-        with patch.object(_mod, 'RaceMonitorClient', return_value=MagicMock()), \
-             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
-             patch('lemongrass.laps._influx_only_skip', return_value=False), \
-             patch('lemongrass.laps.backfill_race',
-                   side_effect=[KeyboardInterrupt(), 0]) as mk_backfill:
-            failures = _mod.run_backfill(self._races())
-        assert mk_backfill.call_count == 1
+    def test_keyboard_interrupt_signals_stop(self):
+        stop, failures = self._call(side_effect=KeyboardInterrupt())
+        assert stop is True
         assert failures == []
 
-    def test_programming_bug_propagates_not_swallowed(self):
-        # A non-RaceMonitorError (e.g. a bug or systematic outage) must crash the
-        # run rather than be recorded per-race — otherwise a fault that breaks
-        # every race looks like a data problem instead of a bug.
-        with patch.object(_mod, 'RaceMonitorClient', return_value=MagicMock()), \
-             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
-             patch('lemongrass.laps._influx_only_skip', return_value=False), \
-             patch('lemongrass.laps.backfill_race',
-                   side_effect=[AttributeError('boom'), 0]) as mk_backfill:
-            with pytest.raises(AttributeError):
-                _mod.run_backfill(self._races())
-        assert mk_backfill.call_count == 1
+    def test_systemexit_130_signals_stop(self):
+        stop, failures = self._call(side_effect=SystemExit(130))
+        assert stop is True
+        assert failures == []
+
+    def test_systemexit_non_130_recorded_and_continues(self):
+        stop, failures = self._call(side_effect=SystemExit(2))
+        assert stop is False
+        assert failures == ['101']
+
+    def test_programming_bug_propagates(self):
+        # A non-RaceMonitorError (bug or systematic outage) must crash rather than
+        # be recorded per-race, so it surfaces as a bug not a data problem.
+        with pytest.raises(AttributeError):
+            self._call(side_effect=AttributeError('boom'))
+
+    def test_nonzero_return_recorded_as_failure(self):
+        stop, failures = self._call(return_value=1)
+        assert stop is False
+        assert failures == ['101']
+
+    def test_zero_return_no_failure(self):
+        stop, failures = self._call(return_value=0)
+        assert stop is False
+        assert failures == []
 
 
 class TestValidateBackfill:
@@ -257,52 +301,27 @@ class TestValidateBackfill:
         api.query.side_effect = fake_query
         return api
 
-    def test_returns_true_when_race_has_laps(self):
-        query_api = self._make_query_api(lap_count=15)
-        assert _mod.validate_backfill(['101'], query_api) is True
+    def test_returns_true_and_logs_ok_when_race_has_laps(self, caplog):
+        query_api = self._make_query_api(race_name='Lemons 2026', lap_count=15)
+        with caplog.at_level(logging.INFO, logger='root'):
+            assert _mod.validate_backfill(['101'], query_api) is True
+        assert any('OK' in r.message and '15' in r.message and 'Lemons 2026' in r.message
+                   for r in caplog.records)
 
-    def test_returns_false_when_race_has_no_laps(self):
+    def test_returns_false_and_warns_when_race_has_no_laps(self, caplog):
         query_api = self._make_query_api(lap_count=0)
-        assert _mod.validate_backfill(['101'], query_api) is False
+        with caplog.at_level(logging.WARNING, logger='root'):
+            assert _mod.validate_backfill(['101'], query_api) is False
+        assert any('NO laps' in r.message for r in caplog.records)
 
     def test_returns_false_when_race_metadata_missing(self):
         query_api = self._make_query_api(race_name=None, lap_count=15)
         assert _mod.validate_backfill(['101'], query_api) is False
 
-    def test_logs_race_name_in_output(self, caplog):
-        import logging
-        query_api = self._make_query_api(race_name='Lemons 2026', lap_count=15)
-        with caplog.at_level(logging.INFO, logger='root'):
-            _mod.validate_backfill(['101'], query_api)
-        assert any('Lemons 2026' in r.message for r in caplog.records)
-
-    def test_logs_ok_with_lap_count(self, caplog):
-        import logging
-        query_api = self._make_query_api(lap_count=15)
-        with caplog.at_level(logging.INFO, logger='root'):
-            _mod.validate_backfill(['101'], query_api)
-        assert any('OK' in r.message and '15' in r.message for r in caplog.records)
-
-    def test_logs_warning_when_no_laps(self, caplog):
-        import logging
-        query_api = self._make_query_api(lap_count=0)
-        with caplog.at_level(logging.WARNING, logger='root'):
-            _mod.validate_backfill(['101'], query_api)
-        assert any('NO laps' in r.message for r in caplog.records)
-
     def test_laps_not_queried_when_race_metadata_missing(self):
         query_api = self._make_query_api(race_name=None)
         _mod.validate_backfill(['101'], query_api)
         assert query_api.query.call_count == 1
-
-    def test_laps_query_scoped_to_race_time_bounds(self):
-        race_start = datetime(2022, 6, 1, tzinfo=UTC)
-        query_api = self._make_query_api(lap_count=10, race_start=race_start,
-                                         race_end_epoc=1672531200)
-        _mod.validate_backfill(['101'], query_api)
-        laps_flux = query_api.query.call_args_list[1].args[0]
-        assert '1970-01-01' not in laps_flux
-        assert '2022-05-31' in laps_flux  # race_start (2022-06-01) padded back one day
 
     def test_races_query_filters_by_end_time_epoc_field(self):
         query_api = self._make_query_api(lap_count=10)
@@ -311,7 +330,6 @@ class TestValidateBackfill:
         assert '_field == "end_time_epoc"' in races_flux
 
     def test_logs_warning_when_end_time_epoc_zero(self, caplog):
-        import logging
         query_api = self._make_query_api(lap_count=10, race_end_epoc=0)
         with caplog.at_level(logging.WARNING, logger='root'):
             _mod.validate_backfill(['101'], query_api)
@@ -355,9 +373,6 @@ class TestRunUpgradeStored:
             elif '_measurement == "standings"' in flux:
                 # standings query — current (schema_version == SCHEMA_VERSION) vs total (position)
                 if 'r._field == "schema_version"' in flux:
-                    # the freshness contract requires filtering on the current value,
-                    # not merely the presence of a schema_version field
-                    assert f'r._value == {SCHEMA_VERSION}' in flux
                     source = std_current_by_race
                 else:
                     source = std_total_by_race
@@ -379,17 +394,13 @@ class TestRunUpgradeStored:
         return api
 
     @contextmanager
-    def _inprocess(self, **backfill_kwargs):
-        """Patch the in-process backfill seam (shared client + resolve_tokens +
-        laps.backfill_race), yielding the backfill_race mock."""
-        backfill_kwargs.setdefault('return_value', 0)
-        with patch.object(_mod, 'RaceMonitorClient', return_value=MagicMock()), \
-             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
-             patch('lemongrass.laps.backfill_race', **backfill_kwargs) as mk_backfill:
+    def _inprocess(self, results=None):
+        """Patch the in-process backfill seam, yielding the backfill_race mock
+        (see module-level _inprocess_backfill)."""
+        with _inprocess_backfill(results) as mk_backfill:
             yield mk_backfill
 
     def test_skips_race_already_at_current_schema(self, caplog):
-        import logging
         query_api = self._query_api(
             stored_races={'101': 'Lemons 2024'},
             total_by_race={'101': 10},
@@ -403,6 +414,26 @@ class TestRunUpgradeStored:
         mk_backfill.assert_not_called()
         assert any('skipping' in r.message and '101' in r.message for r in caplog.records)
 
+    def test_standings_freshness_filters_on_current_schema_value(self):
+        # The freshness contract requires filtering standings on the current
+        # schema value, not merely the presence of a schema_version field.
+        query_api = self._query_api(
+            stored_races={'101': 'Lemons 2024'},
+            total_by_race={'101': 10},
+            current_by_race={'101': 10},
+            std_total_by_race={'101': 8},
+            std_current_by_race={'101': 8},
+        )
+        with self._inprocess():
+            _mod.run_upgrade_stored(query_api)
+        std_current_queries = [
+            c.args[0] for c in query_api.query.call_args_list
+            if '_measurement == "standings"' in c.args[0]
+            and 'r._field == "schema_version"' in c.args[0]
+        ]
+        assert std_current_queries
+        assert all(f'r._value == {SCHEMA_VERSION}' in q for q in std_current_queries)
+
     def test_rebackfills_when_laps_current_but_standings_stale(self):
         query_api = self._query_api(
             stored_races={'101': 'Lemons 2024'},
@@ -414,8 +445,8 @@ class TestRunUpgradeStored:
         with self._inprocess() as mk_backfill:
             _mod.run_upgrade_stored(query_api)
         assert mk_backfill.call_count == 1
-        assert mk_backfill.call_args.args[0] == '101'
-        assert mk_backfill.call_args.args[1] is None
+        assert mk_backfill.calls[0].race_id == '101'
+        assert mk_backfill.calls[0].car_number is None
 
     def test_rebackfills_when_laps_current_but_standings_missing(self):
         query_api = self._query_api(
@@ -438,8 +469,8 @@ class TestRunUpgradeStored:
         with self._inprocess() as mk_backfill:
             _mod.run_upgrade_stored(query_api)
         assert mk_backfill.call_count == 1
-        assert mk_backfill.call_args.args[0] == '101'
-        assert mk_backfill.call_args.args[1] is None
+        assert mk_backfill.calls[0].race_id == '101'
+        assert mk_backfill.calls[0].car_number is None
 
     def test_dry_run_does_not_backfill(self):
         query_api = self._query_api(
@@ -452,7 +483,6 @@ class TestRunUpgradeStored:
         mk_backfill.assert_not_called()
 
     def test_skips_race_with_no_stored_laps(self, caplog):
-        import logging
         query_api = self._query_api(
             stored_races={'101': 'Lemons 2024'},
             total_by_race={'101': 0},
@@ -472,9 +502,9 @@ class TestRunUpgradeStored:
             total_by_race={'113450': 5, '9793': 5, '100247': 5},
             current_by_race={'113450': 0, '9793': 0, '100247': 0},
         )
-        with self._inprocess(return_value=0) as mk_backfill:
+        with self._inprocess() as mk_backfill:
             _mod.run_upgrade_stored(query_api, force=True)
-        called_ids = [c.args[0] for c in mk_backfill.call_args_list]
+        called_ids = [c.race_id for c in mk_backfill.calls]
         assert called_ids == ['9793', '100247', '113450']
 
     def test_returns_failed_race_ids(self):
@@ -483,7 +513,7 @@ class TestRunUpgradeStored:
             total_by_race={'101': 10},
             current_by_race={'101': 5},
         )
-        with self._inprocess(return_value=1):
+        with self._inprocess(results=[1]):
             failures = _mod.run_upgrade_stored(query_api)
         assert failures == ['101']
 
@@ -493,7 +523,7 @@ class TestRunUpgradeStored:
             total_by_race={'101': 10},
             current_by_race={'101': 5},
         )
-        with self._inprocess(return_value=0):
+        with self._inprocess():
             failures = _mod.run_upgrade_stored(query_api)
         assert failures == []
 
@@ -503,37 +533,26 @@ class TestRunUpgradeStored:
             total_by_race={'101': 5, '202': 5},
             current_by_race={'101': 0, '202': 0},
         )
-        with self._inprocess(side_effect=[SystemExit(130), 0]) as mk_backfill:
+        with self._inprocess(results=[SystemExit(130), 0]) as mk_backfill:
             _mod.run_upgrade_stored(query_api)
         assert mk_backfill.call_count == 1
 
-    def test_force_rebackfills_race_already_at_current_schema(self):
+    def test_force_rebackfills_race_already_at_current_schema(self, caplog):
         query_api = self._query_api(
             stored_races={'101': 'Lemons 2024'},
             total_by_race={'101': 10},
             current_by_race={'101': 10},  # already fully current
         )
         with self._inprocess() as mk_backfill:
-            _mod.run_upgrade_stored(query_api, force=True)
-        assert mk_backfill.call_count == 1
-        assert mk_backfill.call_args.args[0] == '101'
-        assert mk_backfill.call_args.args[1] is None
-
-    def test_force_logs_already_current_message(self, caplog):
-        import logging
-        query_api = self._query_api(
-            stored_races={'101': 'Lemons 2024'},
-            total_by_race={'101': 10},
-            current_by_race={'101': 10},  # already fully current
-        )
-        with self._inprocess(return_value=0):
             with caplog.at_level(logging.INFO):
                 _mod.run_upgrade_stored(query_api, force=True)
+        assert mk_backfill.call_count == 1
+        assert mk_backfill.calls[0].race_id == '101'
+        assert mk_backfill.calls[0].car_number is None
         assert any('already current' in r.message and 'force re-backfilling' in r.message
                    for r in caplog.records)
 
     def test_dry_run_force_does_not_backfill(self, caplog):
-        import logging
         query_api = self._query_api(
             stored_races={'101': 'Lemons 2024'},
             total_by_race={'101': 10},
@@ -555,7 +574,6 @@ class TestRunUpgradeStored:
             _mod.run_upgrade_stored(query_api, force=True)
         mk_backfill.assert_not_called()
 
-
     # --- in-process backfill: one shared client/rate-limiter across all races ---
 
     def test_reuses_single_client_across_races(self):
@@ -566,15 +584,12 @@ class TestRunUpgradeStored:
             total_by_race={'101': 10, '202': 10},
             current_by_race={'101': 5, '202': 5},
         )
-        fake_client = MagicMock()
-        with patch.object(_mod, 'RaceMonitorClient', return_value=fake_client) as mk_client, \
-             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
-             patch('lemongrass.laps.backfill_race', return_value=0) as mk_backfill:
+        with self._inprocess() as mk_backfill:
             _mod.run_upgrade_stored(query_api)
-        assert mk_client.call_count == 1
+        assert mk_backfill.client_cls.call_count == 1
         assert mk_backfill.call_count == 2
-        clients = {c.args[2] for c in mk_backfill.call_args_list}
-        assert clients == {fake_client}
+        clients = {c.client for c in mk_backfill.calls}
+        assert len(clients) == 1
 
     def test_backfill_called_fieldwide_with_race_id(self):
         """Each race is backfilled fieldwide: race_id passed, car_number None."""
@@ -583,78 +598,11 @@ class TestRunUpgradeStored:
             total_by_race={'101': 10},
             current_by_race={'101': 5},
         )
-        with patch.object(_mod, 'RaceMonitorClient', return_value=MagicMock()), \
-             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
-             patch('lemongrass.laps.backfill_race', return_value=0) as mk_backfill:
+        with self._inprocess() as mk_backfill:
             _mod.run_upgrade_stored(query_api)
         assert mk_backfill.call_count == 1
-        args = mk_backfill.call_args.args
-        assert args[0] == '101'   # race_id
-        assert args[1] is None    # car_number (fieldwide)
-
-    def test_backfill_exception_records_failure_and_continues(self):
-        """A per-race error (e.g. 429 exhaustion) is recorded and the run
-        continues to the next race, matching the old continue-on-failure model."""
-        from race_monitor import RaceMonitorHTTPError
-        query_api = self._query_api(
-            stored_races={'101': 'Race 1', '202': 'Race 2'},
-            total_by_race={'101': 10, '202': 10},
-            current_by_race={'101': 5, '202': 5},
-        )
-        with patch.object(_mod, 'RaceMonitorClient', return_value=MagicMock()), \
-             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
-             patch('lemongrass.laps.backfill_race',
-                   side_effect=[RaceMonitorHTTPError(429, 'rate'), 0]) as mk_backfill:
-            failures = _mod.run_upgrade_stored(query_api)
-        assert mk_backfill.call_count == 2
-        assert failures == ['101']
-
-    def test_keyboard_interrupt_stops_upgrade(self):
-        """Ctrl-C during a race stops the whole upgrade (no further races)."""
-        query_api = self._query_api(
-            stored_races={'101': 'Race 1', '202': 'Race 2'},
-            total_by_race={'101': 10, '202': 10},
-            current_by_race={'101': 5, '202': 5},
-        )
-        with patch.object(_mod, 'RaceMonitorClient', return_value=MagicMock()), \
-             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
-             patch('lemongrass.laps.backfill_race',
-                   side_effect=[KeyboardInterrupt(), 0]) as mk_backfill:
-            failures = _mod.run_upgrade_stored(query_api)
-        assert mk_backfill.call_count == 1
-        assert failures == []
-
-    def test_programming_bug_propagates_not_swallowed(self):
-        """A non-RaceMonitorError crashes the upgrade rather than being recorded
-        per-race, so a systematic fault surfaces as a bug instead of hiding."""
-        query_api = self._query_api(
-            stored_races={'101': 'Race 1', '202': 'Race 2'},
-            total_by_race={'101': 10, '202': 10},
-            current_by_race={'101': 5, '202': 5},
-        )
-        with patch.object(_mod, 'RaceMonitorClient', return_value=MagicMock()), \
-             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
-             patch('lemongrass.laps.backfill_race',
-                   side_effect=[AttributeError('boom'), 0]) as mk_backfill:
-            with pytest.raises(AttributeError):
-                _mod.run_upgrade_stored(query_api)
-        assert mk_backfill.call_count == 1
-
-
-class TestUpgradeStoredArgParsing:
-    def test_upgrade_stored_flag_accepted(self):
-        args = _mod._build_parser().parse_args(['--upgrade-stored'])
-        assert args.upgrade_stored is True
-
-    def test_upgrade_stored_default_false(self):
-        args = _mod._build_parser().parse_args([])
-        assert args.upgrade_stored is False
-
-    def test_upgrade_stored_and_force_accepted_together(self):
-        # Previously mutually exclusive — must now parse without error
-        args = _mod._build_parser().parse_args(['--upgrade-stored', '--force'])
-        assert args.upgrade_stored is True
-        assert args.force is True
+        assert mk_backfill.calls[0].race_id == '101'
+        assert mk_backfill.calls[0].car_number is None
 
 
 class TestParseStartDate:
@@ -666,84 +614,145 @@ class TestParseStartDate:
             _mod._parse_start_date('01/01/2021')
         assert exc.value.code == 1
 
-    def test_start_date_arg_default_from_config(self):
-        args = _mod._build_parser().parse_args([])
-        assert args.start_date == _mod.DEFAULT_START_DATE
-
-    def test_start_date_arg_override(self):
-        args = _mod._build_parser().parse_args(['--start-date', '2023-06-01'])
-        assert args.start_date == '2023-06-01'
-
 
 class TestArgParsing:
-    def test_dry_run_flag(self):
-        args = _mod._build_parser().parse_args(['--dry-run'])
-        assert args.dry_run is True
+    @pytest.mark.parametrize('argv, attr, expected', [
+        (['--dry-run'], 'dry_run', True),
+        (['--validate'], 'validate', True),
+        (['--force'], 'force', True),
+        (['--upgrade-stored'], 'upgrade_stored', True),
+        (['--start-date', '2023-06-01'], 'start_date', '2023-06-01'),
+    ])
+    def test_flag_sets_attribute(self, argv, attr, expected):
+        args = _mod._build_parser().parse_args(argv)
+        assert getattr(args, attr) == expected
 
-    def test_dry_run_default(self):
-        args = _mod._build_parser().parse_args([])
-        assert args.dry_run is False
-
-    def test_validate_flag_accepted(self):
-        args = _mod._build_parser().parse_args(['--validate'])
-        assert args.validate is True
-
-    def test_validate_defaults_to_false(self):
-        args = _mod._build_parser().parse_args([])
-        assert args.validate is False
-
-    def test_force_flag_accepted(self):
-        args = _mod._build_parser().parse_args(['--force'])
+    def test_upgrade_stored_and_force_not_mutually_exclusive(self):
+        # Previously mutually exclusive — must now parse together without error.
+        args = _mod._build_parser().parse_args(['--upgrade-stored', '--force'])
+        assert args.upgrade_stored is True
         assert args.force is True
 
-    def test_force_defaults_to_false(self):
-        args = _mod._build_parser().parse_args([])
-        assert args.force is False
+
+class TestOpenClient:
+    def test_exits_when_no_token(self):
+        with patch.object(_mod, 'resolve_tokens', return_value=[]):
+            with pytest.raises(SystemExit) as exc:
+                _mod._open_client()
+        assert exc.value.code == 1
+
+    def test_returns_client_built_from_resolved_tokens(self):
+        with patch.object(_mod, 'resolve_tokens', return_value=['tok']):
+            with patch.object(_mod, 'RaceMonitorClient', return_value='CLIENT') as mk:
+                client = _mod._open_client()
+        assert client == 'CLIENT'
+        mk.assert_called_once_with(api_token=['tok'])
 
 
 class TestMainTokenResolution:
-    def _run_main(self, env):
-        mock_client = MagicMock()
-        with patch.dict(os.environ, env, clear=True):
+    def test_main_wires_resolve_tokens_through(self):
+        """Smoke test: main() resolves tokens and passes them to the client.
+        Thorough token-resolution coverage lives in test_race_diagnose.py."""
+        with patch.dict(os.environ, {'RACEMONITOR_TOKENS': 'TOKEN1,TOKEN2'}, clear=True):
             with patch.object(sys, 'argv', ['race-backfill']):
                 with patch('lemongrass.race_backfill.RaceMonitorClient') as mock_rm_cls:
-                    mock_rm_cls.return_value.__enter__.return_value = mock_client
+                    mock_rm_cls.return_value.__enter__.return_value = MagicMock()
                     with patch.object(_mod, 'find_matching_races', return_value=[]):
                         with patch.object(_mod, 'run_backfill', return_value=[]):
                             _mod.main()
-        return mock_rm_cls
-
-    def test_uses_racemonitor_tokens_when_set(self):
-        mock_rm_cls = self._run_main({'RACEMONITOR_TOKENS': 'TOKEN1'})
-        mock_rm_cls.assert_called_once_with(api_token='TOKEN1')
-
-    def test_uses_multi_token_list_when_multiple_tokens_set(self):
-        mock_rm_cls = self._run_main({'RACEMONITOR_TOKENS': 'TOKEN1,TOKEN2'})
         mock_rm_cls.assert_called_once_with(api_token=['TOKEN1', 'TOKEN2'])
 
-    def test_falls_back_to_racemonitor_token(self):
-        mock_rm_cls = self._run_main({'RACEMONITOR_TOKEN': 'FALLBACK'})
-        mock_rm_cls.assert_called_once_with(api_token='FALLBACK')
 
-    def test_exits_when_no_token_set(self):
+class TestMain:
+    """main() control flow: dispatch, exit codes, and interrupt handling."""
+
+    def test_upgrade_stored_with_start_date_exits_1(self):
+        with patch.object(sys, 'argv',
+                          ['race-backfill', '--upgrade-stored', '--start-date', '1999-01-01']):
+            with pytest.raises(SystemExit) as exc:
+                _mod.main()
+        assert exc.value.code == 1
+
+    def test_upgrade_stored_with_validate_exits_1(self):
+        with patch.object(sys, 'argv', ['race-backfill', '--upgrade-stored', '--validate']):
+            with pytest.raises(SystemExit) as exc:
+                _mod.main()
+        assert exc.value.code == 1
+
+    def _run_upgrade_main(self, run_kwargs):
+        with patch.object(sys, 'argv', ['race-backfill', '--upgrade-stored']):
+            with patch('lemongrass._influx.connect') as mk_connect:
+                mk_connect.return_value.__enter__.return_value = MagicMock()
+                with patch.object(_mod, 'run_upgrade_stored', **run_kwargs) as mk_run:
+                    with pytest.raises(SystemExit) as exc:
+                        _mod.main()
+        return exc, mk_run
+
+    def test_upgrade_stored_dispatches_and_exits_0_on_success(self):
+        exc, mk_run = self._run_upgrade_main({'return_value': []})
+        mk_run.assert_called_once()
+        assert exc.value.code == 0
+
+    def test_upgrade_stored_exits_1_on_failures(self):
+        exc, _ = self._run_upgrade_main({'return_value': ['101']})
+        assert exc.value.code == 1
+
+    def test_upgrade_stored_keyboard_interrupt_exits_130(self):
+        exc, _ = self._run_upgrade_main({'side_effect': KeyboardInterrupt()})
+        assert exc.value.code == 130
+
+    def _run_validate_main(self, ok):
+        with patch.dict(os.environ, {'RACEMONITOR_TOKENS': 'T'}, clear=True):
+            with patch.object(sys, 'argv', ['race-backfill', '--validate']):
+                with patch('lemongrass.race_backfill.RaceMonitorClient') as mk_rm:
+                    mk_rm.return_value.__enter__.return_value = MagicMock()
+                    with patch.object(_mod, 'find_matching_races',
+                                      return_value=[_make_race(101, 'R', EPOC_2022)]):
+                        with patch('lemongrass._influx.connect') as mk_connect:
+                            mk_connect.return_value.__enter__.return_value = MagicMock()
+                            with patch.object(_mod, 'validate_backfill',
+                                              return_value=ok) as mk_val:
+                                with pytest.raises(SystemExit) as exc:
+                                    _mod.main()
+        return exc, mk_val
+
+    def test_validate_dispatches_and_exits_0_when_ok(self):
+        exc, mk_val = self._run_validate_main(ok=True)
+        mk_val.assert_called_once()
+        assert exc.value.code == 0
+
+    def test_validate_exits_1_when_not_ok(self):
+        exc, _ = self._run_validate_main(ok=False)
+        assert exc.value.code == 1
+
+    def test_backfill_failures_exit_1(self):
+        with patch.dict(os.environ, {'RACEMONITOR_TOKENS': 'T'}, clear=True):
+            with patch.object(sys, 'argv', ['race-backfill']):
+                with patch('lemongrass.race_backfill.RaceMonitorClient') as mk_rm:
+                    mk_rm.return_value.__enter__.return_value = MagicMock()
+                    with patch.object(_mod, 'find_matching_races', return_value=[]):
+                        with patch.object(_mod, 'run_backfill', return_value=['101']):
+                            with pytest.raises(SystemExit) as exc:
+                                _mod.main()
+        assert exc.value.code == 1
+
+    def test_backfill_keyboard_interrupt_exits_130(self):
+        with patch.dict(os.environ, {'RACEMONITOR_TOKENS': 'T'}, clear=True):
+            with patch.object(sys, 'argv', ['race-backfill']):
+                with patch('lemongrass.race_backfill.RaceMonitorClient') as mk_rm:
+                    mk_rm.return_value.__enter__.return_value = MagicMock()
+                    with patch.object(_mod, 'find_matching_races',
+                                      side_effect=KeyboardInterrupt()):
+                        with pytest.raises(SystemExit) as exc:
+                            _mod.main()
+        assert exc.value.code == 130
+
+    def test_no_token_exits_1(self):
         with patch.dict(os.environ, {}, clear=True):
             with patch.object(sys, 'argv', ['race-backfill']):
-                with pytest.raises(SystemExit) as exc_info:
+                with pytest.raises(SystemExit) as exc:
                     _mod.main()
-        assert exc_info.value.code == 1
-
-    def test_no_token_error_honors_configured_pool_var(self, caplog, tmp_path):
-        import logging
-        cfg = tmp_path / "c.toml"
-        cfg.write_text('[racemonitor]\ntokens_env = "MY_POOL"\n')
-        env = {'RACEMONITOR_TOKEN': 'stale-legacy', 'LEMONGRASS_CONFIG': str(cfg)}
-        with patch.dict(os.environ, env, clear=True):
-            with patch.object(sys, 'argv', ['race-backfill']):
-                with caplog.at_level(logging.ERROR):
-                    with pytest.raises(SystemExit) as exc_info:
-                        _mod.main()
-        assert exc_info.value.code == 1
-        assert any('MY_POOL' in r.message for r in caplog.records)
+        assert exc.value.code == 1
 
 
 class TestMainConfiguresLogging:
@@ -753,23 +762,29 @@ class TestMainConfiguresLogging:
         # logging — the basicConfig in the __main__ guard doesn't run on import.
         # main() must configure INFO itself, or every progress logging.info() line
         # (SKIP / re-backfilling / summary) is silently dropped at the default
-        # WARNING level.
-        import logging
-        with patch.dict(os.environ, {'RACEMONITOR_TOKENS': 'T'}, clear=True):
-            with patch.object(sys, 'argv', ['race-backfill']):
-                with patch('lemongrass.race_backfill.RaceMonitorClient') as mock_rm_cls:
-                    mock_rm_cls.return_value.__enter__.return_value = MagicMock()
-                    with patch.object(_mod, 'find_matching_races', return_value=[]):
-                        with patch.object(_mod, 'run_backfill', return_value=[]):
-                            with patch.object(_mod.logging, 'basicConfig') as mock_bc:
+        # WARNING level. Observe the effect (root level set to INFO) rather than
+        # that basicConfig was called, by simulating the unconfigured console-script
+        # environment where the root logger has no handlers.
+        root = logging.getLogger()
+        saved_handlers = root.handlers[:]
+        saved_level = root.level
+        root.handlers = []
+        try:
+            with patch.dict(os.environ, {'RACEMONITOR_TOKENS': 'T'}, clear=True):
+                with patch.object(sys, 'argv', ['race-backfill']):
+                    with patch('lemongrass.race_backfill.RaceMonitorClient') as mock_rm_cls:
+                        mock_rm_cls.return_value.__enter__.return_value = MagicMock()
+                        with patch.object(_mod, 'find_matching_races', return_value=[]):
+                            with patch.object(_mod, 'run_backfill', return_value=[]):
                                 _mod.main()
-        mock_bc.assert_called_once()
-        assert mock_bc.call_args.kwargs.get('level') == logging.INFO
+            assert root.level == logging.INFO
+        finally:
+            root.handlers = saved_handlers
+            root.setLevel(saved_level)
 
 
 class TestValidateWindowPadding:
     def test_lap_query_padded_one_day_each_side(self):
-        import lemongrass.race_backfill as rb
         query_api = MagicMock()
 
         race_record = MagicMock()
@@ -784,7 +799,7 @@ class TestValidateWindowPadding:
         lap_table.records = []
         query_api.query.side_effect = [[race_table], [lap_table]]
 
-        rb.validate_backfill(['999'], query_api)
+        _mod.validate_backfill(['999'], query_api)
         lap_flux = query_api.query.call_args_list[1].args[0]
         assert 'start: 2020-01-01T00:00:00Z' in lap_flux
         assert 'stop: 2020-01-05T00:00:00Z' in lap_flux
@@ -806,4 +821,3 @@ def test_backfill_defaults_come_from_config(monkeypatch, tmp_path):
     finally:
         monkeypatch.delenv("LEMONGRASS_CONFIG", raising=False)
         importlib.reload(race_backfill)  # restore default module state
-

--- a/tests/test_race_diagnose.py
+++ b/tests/test_race_diagnose.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -24,26 +25,14 @@ class TestMainTokenResolution:
                         _mod.main()
         return mock_rm_cls
 
-    def test_uses_racemonitor_tokens_when_set(self):
-        mock_rm_cls = self._run_main({
-            'RACEMONITOR_TOKENS': 'TOKEN1',
-            'INFLUX_TELEMETRY_TOKEN': 'ITOKEN',
-        })
-        mock_rm_cls.assert_called_once_with(api_token='TOKEN1')
-
-    def test_uses_multi_token_list_when_multiple_tokens_set(self):
-        mock_rm_cls = self._run_main({
-            'RACEMONITOR_TOKENS': 'TOKEN1,TOKEN2',
-            'INFLUX_TELEMETRY_TOKEN': 'ITOKEN',
-        })
-        mock_rm_cls.assert_called_once_with(api_token=['TOKEN1', 'TOKEN2'])
-
-    def test_falls_back_to_racemonitor_token(self):
-        mock_rm_cls = self._run_main({
-            'RACEMONITOR_TOKEN': 'FALLBACK',
-            'INFLUX_TELEMETRY_TOKEN': 'ITOKEN',
-        })
-        mock_rm_cls.assert_called_once_with(api_token='FALLBACK')
+    @pytest.mark.parametrize('token_env, expected', [
+        ({'RACEMONITOR_TOKENS': 'TOKEN1'}, 'TOKEN1'),
+        ({'RACEMONITOR_TOKENS': 'TOKEN1,TOKEN2'}, ['TOKEN1', 'TOKEN2']),
+        ({'RACEMONITOR_TOKEN': 'FALLBACK'}, 'FALLBACK'),
+    ])
+    def test_resolves_tokens_for_client(self, token_env, expected):
+        mock_rm_cls = self._run_main({**token_env, 'INFLUX_TELEMETRY_TOKEN': 'ITOKEN'})
+        mock_rm_cls.assert_called_once_with(api_token=expected)
 
     def test_exits_when_no_token_set(self):
         with patch.dict(os.environ, {'INFLUX_TELEMETRY_TOKEN': 'ITOKEN'}, clear=True):
@@ -116,3 +105,89 @@ class TestWindowPadding:
         flux = query_api.query.call_args.args[0]
         assert 'start: 1970-01-10T00:00:00Z' in flux
         assert 'stop: 1970-01-13T00:00:00Z' in flux
+
+
+class TestEpocToStr:
+    def test_zero_returns_sentinel(self):
+        assert _mod.epoc_to_str(0) == '0 (zero/null)'
+
+    def test_none_returns_sentinel(self):
+        assert _mod.epoc_to_str(None) == 'None (zero/null)'
+
+    def test_normal_epoch_formats_utc(self):
+        epoc = 1600000000
+        expected = datetime.fromtimestamp(epoc, tz=UTC).strftime('%Y-%m-%d %H:%M:%S UTC')
+        assert _mod.epoc_to_str(epoc) == expected
+        assert _mod.epoc_to_str(epoc).endswith('UTC')
+
+
+class TestDiagnoseApi:
+    def test_happy_path_counts_matching_car_laps(self, capsys):
+        client = MagicMock()
+        client.race.details.return_value = {
+            'Successful': True,
+            'Race': {'Name': 'Lemons 2026', 'StartDateEpoc': 1600000000,
+                     'EndDateEpoc': 1600100000},
+        }
+        client.results.sessions_for_race.return_value = {'Sessions': [{'ID': 'S1'}]}
+        client.results.session_details.return_value = {
+            'Session': {
+                'SessionStartDateEpoc': 1600000500,
+                'SortedCompetitors': [
+                    {'Number': '99', 'LapTimes': [1, 2]},
+                    {'Number': '42', 'LapTimes': [10, 20, 30]},
+                ],
+            }
+        }
+        start_epoc, end_epoc = _mod.diagnose_api(client, '144185', '42')
+        out = capsys.readouterr().out
+        assert (start_epoc, end_epoc) == (1600000000, 1600100000)
+        assert 'Lemons 2026' in out
+        assert 'Session S1' in out
+        assert 'car 42 laps=3' in out
+        assert 'Total laps for car 42 across all sessions: 3' in out
+
+
+class TestDiagnoseInflux:
+    def _query_api(self, records):
+        api = MagicMock()
+        table = MagicMock()
+        table.records = records
+        api.query.return_value = [table]
+        return api
+
+    def _record(self, lap_no, time):
+        rec = MagicMock()
+        rec.get_value.return_value = lap_no
+        rec.get_time.return_value = time
+        return rec
+
+    def test_prints_stored_laps_when_records_present(self, capsys):
+        t1 = datetime(2020, 1, 1, tzinfo=UTC)
+        t2 = datetime(2020, 1, 1, 1, tzinfo=UTC)
+        api = self._query_api([self._record(1, t1), self._record(2, t2)])
+        _mod.diagnose_influx(api, '999', '42', start_epoc=1600000000, end_epoc=1600100000)
+        out = capsys.readouterr().out
+        assert 'Stored laps: 2' in out
+        assert 'Lap numbers stored: [1, 2]' in out
+
+    def test_prints_no_laps_when_empty(self, capsys):
+        api = self._query_api([])
+        _mod.diagnose_influx(api, '999', '42', start_epoc=1600000000, end_epoc=1600100000)
+        assert 'No laps found in InfluxDB.' in capsys.readouterr().out
+
+    def test_zero_start_epoc_uses_epoch_start(self):
+        api = self._query_api([])
+        _mod.diagnose_influx(api, '999', '42', start_epoc=0, end_epoc=1600100000)
+        flux = api.query.call_args.args[0]
+        assert f'start: {_mod.EPOCH_START}' in flux
+
+    def test_zero_end_epoc_warns_and_uses_now(self, capsys):
+        api = self._query_api([])
+        now = datetime.now(UTC)
+        _mod.diagnose_influx(api, '999', '42', start_epoc=1600000000, end_epoc=0)
+        out = capsys.readouterr().out
+        assert 'end_time_epoc not set' in out
+        flux = api.query.call_args.args[0]
+        # stop falls back to now(), not a fixed epoch derived from end_epoc
+        assert f'stop: {now.strftime("%Y")}' in flux

--- a/tests/test_races.py
+++ b/tests/test_races.py
@@ -241,6 +241,21 @@ class TestHandlePrune:
         assert buckets.count('races') == 2
         assert buckets.count('race_sessions') == 2
 
+    def test_prune_partial_failure_exits_1(self, capsys):
+        # A delete that raises for a race is recorded in the failed list, and the
+        # command exits 1 so a partial prune is not mistaken for success.
+        with patch.object(sys, 'argv', ['lemongrass-races-prune', '12345', '--yes']):
+            fake_client = self._make_influx_client()
+            fake_client.delete_api.return_value.delete.side_effect = RuntimeError('boom')
+            with patch('lemongrass._influx.connect', return_value=fake_client):
+                with patch.dict('os.environ', {'INFLUX_TELEMETRY_TOKEN': 'tok'}):
+                    with pytest.raises(SystemExit) as exc:
+                        _mod._handle_prune()
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert 'failed to prune' in err
+        assert '12345' in err
+
 
 class TestHandleBackfill:
     def test_delegates_to_race_backfill_main(self):
@@ -387,6 +402,32 @@ class TestHandleList:
             with pytest.raises(SystemExit) as exc:
                 _mod._handle_list()
         assert exc.value.code != 0
+
+    def test_missing_race_date_shows_question_mark(self, capsys):
+        # A race whose metadata record has no timestamp renders '?' in the DATE
+        # column rather than crashing on None.strftime.
+        def fake_query(flux):
+            if 'bucket: "races"' in flux:
+                table = MagicMock()
+                rec = MagicMock()
+                rec.values = {'race_id': 'R1', 'race_name': 'Dateless Race'}
+                rec.get_time.return_value = None
+                table.records = [rec]
+                return [table]
+            return []
+
+        client = MagicMock()
+        query_api = MagicMock()
+        query_api.query.side_effect = fake_query
+        client.query_api.return_value = query_api
+        client.__enter__ = lambda s: client
+        client.__exit__ = MagicMock(return_value=False)
+        with patch('lemongrass._influx.connect', return_value=client):
+            with patch.dict('os.environ', {'INFLUX_TELEMETRY_TOKEN': 'tok'}):
+                _mod._handle_list()
+        out = capsys.readouterr().out
+        assert 'Dateless Race' in out
+        assert '?' in out
 
 
 class TestHandleDiagnose:

--- a/tests/test_spool.py
+++ b/tests/test_spool.py
@@ -1,7 +1,9 @@
 import logging
+import os
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
 from influxdb_client import Point
 from influxdb_client.rest import ApiException
 
@@ -108,23 +110,72 @@ class TestAppend:
         names = sorted(p.name for p in s.dir.glob("*.lp"))
         assert names == ["000000000006.lp"]
 
-    def test_new_file_triggers_dir_fsync(self, tmp_path, monkeypatch):
+    @pytest.mark.parametrize(
+        "rotate_bytes, second_append_fsyncs",
+        [
+            (1, 1),        # tiny rotate: second append opens a NEW file -> dir fsync
+            (10_000, 0),   # large rotate: second append REUSES the file -> no fsync
+        ],
+    )
+    def test_dir_fsync_only_on_new_file(
+        self, tmp_path, monkeypatch, rotate_bytes, second_append_fsyncs
+    ):
         # A newly-created (rotated) spool file needs its directory entry fsync'd
-        # so the file survives a hard fault before dir metadata is flushed.
-        s = Spool(tmp_path / "spool", rotate_bytes=1)  # every append rotates
+        # so the file survives a hard fault before dir metadata is flushed; a
+        # reused file does not.
+        s = Spool(tmp_path / "spool", rotate_bytes=rotate_bytes)
         calls = []
         monkeypatch.setattr(s, "_fsync_dir", lambda: calls.append(1), raising=False)
-        s.append([_pt("RPM", 1)])                        # new file -> dir fsync
-        s.append([_pt("RPM", 2)])                        # new file -> dir fsync
-        assert len(calls) == 2
-
-    def test_append_to_existing_file_skips_dir_fsync(self, tmp_path, monkeypatch):
-        s = Spool(tmp_path / "spool", rotate_bytes=10_000)  # reuse one file
-        calls = []
-        monkeypatch.setattr(s, "_fsync_dir", lambda: calls.append(1), raising=False)
-        s.append([_pt("RPM", 1)])                        # new file -> 1 dir fsync
-        s.append([_pt("RPM", 2)])                        # reuse -> no dir fsync
+        s.append([_pt("RPM", 1)])   # first file is always new -> 1 dir fsync
         assert len(calls) == 1
+        s.append([_pt("RPM", 2)])   # new-file or reuse depending on rotate size
+        assert len(calls) == 1 + second_append_fsyncs
+
+    def test_append_returns_false_on_write_oserror(self, tmp_path, monkeypatch, caplog):
+        # A disk error mid-write must not raise into the callback; append reports
+        # False so flush_points falls back to the in-memory backlog.
+        s = Spool(tmp_path / "spool")
+
+        def boom(fd):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(os, "fsync", boom)  # data fsync fails inside the write
+        with caplog.at_level(logging.ERROR):
+            result = s.append([_pt("RPM", 1)])
+        assert result is False
+        assert any("Spool append to" in r.message for r in caplog.records)
+
+    def test_enforce_cap_eviction_unlink_oserror_is_warned(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        # Eviction failing to unlink an over-cap file is non-fatal: warn, don't
+        # crash the append that triggered enforcement.
+        s = Spool(tmp_path / "spool", max_bytes=1, rotate_bytes=1)
+        s.append([_pt("RPM", 1)])  # 000000000001.lp
+
+        def failing_unlink(self, missing_ok=False):
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(Path, "unlink", failing_unlink)
+        with caplog.at_level(logging.WARNING):
+            result = s.append([_pt("RPM", 2)])  # triggers _enforce_cap eviction
+        assert result is True
+        assert any("Could not evict spool file" in r.message for r in caplog.records)
+
+
+class TestFsyncDir:
+    def test_real_body_runs_without_error(self, tmp_path):
+        # Exercise the real os.open/os.fsync/os.close body (normally monkeypatched
+        # out) against a genuine directory.
+        s = Spool(tmp_path / "spool")
+        s._fsync_dir()  # must not raise
+
+    def test_oserror_is_warned_not_raised(self, tmp_path, caplog):
+        s = Spool(tmp_path / "spool")
+        s.dir = tmp_path / "does-not-exist"  # os.open raises OSError
+        with caplog.at_level(logging.WARNING):
+            s._fsync_dir()  # must not raise
+        assert any("Could not fsync spool dir" in r.message for r in caplog.records)
 
 
 class TestDegradation:
@@ -265,6 +316,73 @@ class TestReplay:
         assert result is True
         # Warning should be logged about the unlink failure
         assert any("Could not remove replayed spool file" in r.message for r in caplog.records)
+
+    def test_unreadable_quarantine_rename_oserror_is_warned(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        # Unreadable oldest file that also cannot be renamed to .bad: warn and
+        # still report progress rather than looping forever on it.
+        s = Spool(tmp_path / "spool")
+        s.append([_pt("RPM", 1)])
+        write_api = MagicMock()
+
+        def failing_read_text(self, *args, **kwargs):
+            raise OSError("I/O error")
+
+        def failing_rename(self, target):
+            raise OSError("cross-device link")
+
+        monkeypatch.setattr(Path, "read_text", failing_read_text)
+        monkeypatch.setattr(Path, "rename", failing_rename)
+        with caplog.at_level(logging.WARNING):
+            result = s.replay_oldest(write_api, BUCKET)
+        assert result is True
+        assert any(
+            "Could not quarantine unreadable spool file" in r.message
+            for r in caplog.records
+        )
+        write_api.write.assert_not_called()
+
+    def test_salvage_unlink_oserror_is_warned(self, tmp_path, monkeypatch, caplog):
+        # 4xx on the full file, salvage (drop torn last line) succeeds, but the
+        # post-salvage unlink fails: warn, still report progress.
+        s = Spool(tmp_path / "spool")
+        s.append([_pt("RPM", 1), _pt("RPM", 2)])  # 2 lines -> salvageable
+        write_api = MagicMock()
+        write_api.write.side_effect = [ApiException(status=400, reason="bad"), None]
+
+        def failing_unlink(self, missing_ok=False):
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(Path, "unlink", failing_unlink)
+        with caplog.at_level(logging.WARNING):
+            result = s.replay_oldest(write_api, BUCKET)
+        assert result is True
+        assert any(
+            "Could not remove salvaged spool file" in r.message
+            for r in caplog.records
+        )
+
+    def test_corrupt_quarantine_rename_oserror_is_warned(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        # Single-line 4xx-rejected file is unsalvageable -> quarantine; the .bad
+        # rename fails: warn, still report progress.
+        s = Spool(tmp_path / "spool")
+        s.append([_pt("RPM", 1)])  # single line -> unsalvageable
+        write_api = MagicMock()
+        write_api.write.side_effect = ApiException(status=400, reason="bad")
+
+        def failing_rename(self, target):
+            raise OSError("cross-device link")
+
+        monkeypatch.setattr(Path, "rename", failing_rename)
+        with caplog.at_level(logging.WARNING):
+            result = s.replay_oldest(write_api, BUCKET)
+        assert result is True
+        assert any(
+            "Could not quarantine spool file" in r.message for r in caplog.records
+        )
 
 
 class TestRoundTrip:

--- a/tests/test_telem.py
+++ b/tests/test_telem.py
@@ -42,24 +42,26 @@ class TestConnect:
             _mod.connect()
         mock_async.assert_called_once_with(portstr="/dev/ttyUSB0")
 
-    def test_passes_baudrate_when_set(self, monkeypatch, tmp_path):
+    @pytest.mark.parametrize(
+        "baudrate_line, expected_baudrate",
+        [
+            ("baudrate = 38400\n", 38400),  # nonzero -> pinned
+            ("baudrate = 0\n", None),        # 0 = auto-detect -> omitted
+        ],
+    )
+    def test_baudrate_passed_only_when_nonzero(
+        self, monkeypatch, tmp_path, baudrate_line, expected_baudrate
+    ):
         cfg = tmp_path / "c.toml"
-        cfg.write_text('[telem.obd]\nport = "socket://elm327:35000"\nbaudrate = 38400\n')
-        monkeypatch.setenv("LEMONGRASS_CONFIG", str(cfg))
-        with patch.object(_mod.obd, "Async") as mock_async:
-            _mod.connect()
-        mock_async.assert_called_once_with(
-            portstr="socket://elm327:35000", baudrate=38400
-        )
-
-    def test_omits_baudrate_when_zero(self, monkeypatch, tmp_path):
-        cfg = tmp_path / "c.toml"
-        cfg.write_text('[telem.obd]\nport = "/dev/obd"\nbaudrate = 0\n')
+        cfg.write_text('[telem.obd]\nport = "/dev/obd"\n' + baudrate_line)
         monkeypatch.setenv("LEMONGRASS_CONFIG", str(cfg))
         with patch.object(_mod.obd, "Async") as mock_async:
             _mod.connect()
         _, kwargs = mock_async.call_args
-        assert "baudrate" not in kwargs
+        if expected_baudrate is None:
+            assert "baudrate" not in kwargs
+        else:
+            assert kwargs["baudrate"] == expected_baudrate
 
 
 class TestNewValue:
@@ -95,32 +97,46 @@ class TestNewValue:
             _mod.new_value(r)
         assert len(_mod.pending_points) == 0
 
-    def test_measurement_name_has_spaces_replaced(self):
+
+class TestMeasurementName:
+    @pytest.mark.parametrize(
+        "command_str, expected",
+        [
+            ("ENGINE RPM: rpm", "-rpm"),
+            ("b'0103': Fuel System Status", "-Fuel-System-Status"),
+            ("b'0112': Secondary Air Status", "-Secondary-Air-Status"),
+            ("b'0151': Fuel Type", "-Fuel-Type"),
+            ("b'0141': Monitor status this drive cycle",
+             "-Monitor-status-this-drive-cycle"),
+            ("no colon here", None),  # no ':' -> IndexError -> None
+        ],
+    )
+    def test_derives_name_from_command(self, command_str, expected):
         r = MagicMock()
-        r.command = _Cmd("ENGINE RPM: rpm")
-        r.value.magnitude = 3000.0
-        captured_name = []
-        original_point = _mod.Point
-
-        def capture_point(name):
-            captured_name.append(name)
-            return original_point(name)
-
-        with patch.object(_mod, 'Point', side_effect=capture_point):
-            _mod.new_value(r)
-        assert captured_name[0] == "-rpm"
+        r.command = command_str
+        assert _mod._measurement_name(r) == expected
 
 
 class TestNewFuelStatus:
     def setup_method(self):
         _reset()
 
-    def test_appends_known_status(self):
+    @pytest.mark.parametrize(
+        "status_text, expected",
+        [
+            # known status maps via FUEL_STATUS_MAP...
+            ("Closed loop, using oxygen sensor feedback to determine fuel mix", 1),
+            # ...unknown status falls back to the 255 sentinel
+            ("Unknown mode that maps to nothing", 255),
+        ],
+    )
+    def test_appends_mapped_or_unknown_status(self, status_text, expected):
         r = MagicMock()
         r.command = _Cmd("b'0103': Fuel System Status")
-        r.value = ["Closed loop, using oxygen sensor feedback to determine fuel mix"]
+        r.value = [status_text]
         _mod.new_fuel_status(r)
         assert len(_mod.pending_points) == 1
+        assert f"value={expected}i" in _mod.pending_points[0].to_line_protocol()
 
     def test_skips_falsy_first_element(self):
         r = MagicMock()
@@ -129,34 +145,12 @@ class TestNewFuelStatus:
         _mod.new_fuel_status(r)
         assert len(_mod.pending_points) == 0
 
-    def test_appends_for_unknown_status(self):
-        r = MagicMock()
-        r.command = _Cmd("b'0103': Fuel System Status")
-        r.value = ["Unknown mode that maps to nothing"]
-        _mod.new_fuel_status(r)
-        assert len(_mod.pending_points) == 1
-
     def test_returns_early_on_malformed_command(self):
         r = MagicMock()
         r.command = _Cmd("no colon here")
         r.value = ["Closed loop, using oxygen sensor feedback to determine fuel mix"]
         _mod.new_fuel_status(r)
         assert len(_mod.pending_points) == 0
-
-    def test_measurement_name_uses_description(self):
-        r = MagicMock()
-        r.command = _Cmd("b'0103': Fuel System Status")
-        r.value = ["Closed loop, using oxygen sensor feedback to determine fuel mix"]
-        captured_name = []
-        original_point = _mod.Point
-
-        def capture_point(name):
-            captured_name.append(name)
-            return original_point(name)
-
-        with patch.object(_mod, "Point", side_effect=capture_point):
-            _mod.new_fuel_status(r)
-        assert captured_name[0] == "-Fuel-System-Status"
 
     def test_uses_system_1_status_when_systems_differ(self):
         """Dual-bank ECU: system 1 in failure mode must not be masked by
@@ -168,7 +162,7 @@ class TestNewFuelStatus:
             "Closed loop, using oxygen sensor feedback to determine fuel mix",
         ]
         _mod.new_fuel_status(r)
-        assert _mod.pending_points[0]._fields == {"value": 3}
+        assert "value=3i" in _mod.pending_points[0].to_line_protocol()
 
 
 class TestConfigureObdLogging:
@@ -191,13 +185,20 @@ class TestNewAirStatus:
     def setup_method(self):
         _reset()
 
-    def test_appends_known_status(self):
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            ("Upstream", 0),                             # known -> AIR_STATUS_MAP
+            ("Some new status ELM327 hasn't seen", 255),  # unknown -> sentinel
+        ],
+    )
+    def test_appends_mapped_or_unknown_status(self, value, expected):
         r = MagicMock()
         r.command = _Cmd("b'0112': Secondary Air Status")
-        r.value = "Upstream"
+        r.value = value
         _mod.new_air_status(r)
         assert len(_mod.pending_points) == 1
-        assert _mod.pending_points[0]._fields == {"value": 0}
+        assert f"value={expected}i" in _mod.pending_points[0].to_line_protocol()
 
     def test_skips_falsy_value(self):
         r = MagicMock()
@@ -206,35 +207,12 @@ class TestNewAirStatus:
         _mod.new_air_status(r)
         assert len(_mod.pending_points) == 0
 
-    def test_appends_for_unknown_status(self):
-        r = MagicMock()
-        r.command = _Cmd("b'0112': Secondary Air Status")
-        r.value = "Some new status ELM327 hasn't seen"
-        _mod.new_air_status(r)
-        assert len(_mod.pending_points) == 1
-        assert _mod.pending_points[0]._fields == {"value": 255}
-
     def test_returns_early_on_malformed_command(self):
         r = MagicMock()
         r.command = _Cmd("no colon here")
         r.value = "Upstream"
         _mod.new_air_status(r)
         assert len(_mod.pending_points) == 0
-
-    def test_measurement_name_uses_description(self):
-        r = MagicMock()
-        r.command = _Cmd("b'0112': Secondary Air Status")
-        r.value = "Upstream"
-        captured_name = []
-        original_point = _mod.Point
-
-        def capture_point(name):
-            captured_name.append(name)
-            return original_point(name)
-
-        with patch.object(_mod, "Point", side_effect=capture_point):
-            _mod.new_air_status(r)
-        assert captured_name[0] == "-Secondary-Air-Status"
 
 
 class TestQueryFuelTypeOnce:
@@ -261,7 +239,7 @@ class TestQueryFuelTypeOnce:
             connection, _mod.obd.commands.FUEL_TYPE, force=True
         )
         assert len(_mod.pending_points) == 1
-        assert _mod.pending_points[0]._fields == {"value": "Gasoline"}
+        assert 'value="Gasoline"' in _mod.pending_points[0].to_line_protocol()
 
     def test_skips_on_falsy_value(self):
         connection = MagicMock()
@@ -273,23 +251,14 @@ class TestQueryFuelTypeOnce:
             _mod._query_fuel_type_once(connection)
         assert len(_mod.pending_points) == 0
 
-    def test_measurement_name_uses_description(self):
+    def test_logs_and_returns_on_query_exception(self, caplog):
         connection = MagicMock()
         connection.supports.return_value = True
-        r = MagicMock()
-        r.command = _Cmd("b'0151': Fuel Type")
-        r.value = "Gasoline"
-        captured_name = []
-        original_point = _mod.Point
-
-        def capture_point(name):
-            captured_name.append(name)
-            return original_point(name)
-
-        with patch.object(_mod.obd.OBD, "query", return_value=r), \
-                patch.object(_mod, "Point", side_effect=capture_point):
+        with patch.object(_mod.obd.OBD, "query", side_effect=Exception("boom")), \
+                caplog.at_level(logging.ERROR):
             _mod._query_fuel_type_once(connection)
-        assert captured_name[0] == "-Fuel-Type"
+        assert len(_mod.pending_points) == 0
+        assert any("Fuel-type query failed" in r.message for r in caplog.records)
 
 
 class TestResolveVin:
@@ -394,8 +363,8 @@ class TestNewStatus:
         r.value.DTC_count = 0
         _mod.new_status(r)
         assert len(_mod.pending_points) == 2
-        assert _mod.pending_points[0]._fields == {"value": 1}
-        assert _mod.pending_points[1]._fields == {"value": 0}
+        assert "value=1i" in _mod.pending_points[0].to_line_protocol()
+        assert "value=0i" in _mod.pending_points[1].to_line_protocol()
 
     def test_returns_early_on_malformed_command(self):
         r = MagicMock()
@@ -412,19 +381,11 @@ class TestNewStatus:
         )
         r.value.MIL = True
         r.value.DTC_count = 2
-        captured_names = []
-        original_point = _mod.Point
-
-        def capture_point(name):
-            captured_names.append(name)
-            return original_point(name)
-
-        with patch.object(_mod, "Point", side_effect=capture_point):
-            _mod.new_status(r)
-        assert captured_names == [
-            "-Monitor-status-this-drive-cycle-MIL",
-            "-Monitor-status-this-drive-cycle-DTC-Count",
-        ]
+        _mod.new_status(r)
+        mil_lp = _mod.pending_points[0].to_line_protocol()
+        dtc_lp = _mod.pending_points[1].to_line_protocol()
+        assert mil_lp.startswith("-Monitor-status-this-drive-cycle-MIL")
+        assert dtc_lp.startswith("-Monitor-status-this-drive-cycle-DTC-Count")
 
 
 class TestFetchAndStoreDtcs:
@@ -458,7 +419,7 @@ class TestFetchAndStoreDtcs:
             result = _mod._fetch_and_store_dtcs()
         assert result is True
         assert len(_mod.pending_points) == 1
-        assert _mod.pending_points[0]._fields == {"value": ""}
+        assert 'value=""' in _mod.pending_points[0].to_line_protocol()
 
     def test_writes_joined_codes(self):
         _mod._connection = MagicMock()
@@ -471,7 +432,16 @@ class TestFetchAndStoreDtcs:
             result = _mod._fetch_and_store_dtcs()
         assert result is True
         assert len(_mod.pending_points) == 1
-        assert _mod.pending_points[0]._fields == {"value": "P0104,B0003"}
+        assert 'value="P0104,B0003"' in _mod.pending_points[0].to_line_protocol()
+
+    def test_returns_false_on_query_exception(self, caplog):
+        _mod._connection = MagicMock()
+        with patch.object(_mod.obd.OBD, "query", side_effect=Exception("boom")), \
+                caplog.at_level(logging.ERROR):
+            result = _mod._fetch_and_store_dtcs()
+        assert result is False
+        assert len(_mod.pending_points) == 0
+        assert any("GET_DTC query failed" in r.message for r in caplog.records)
 
 
 class TestNewStatusDtcTrigger:
@@ -612,6 +582,20 @@ class TestFlushPoints:
         write_api.write.side_effect = Exception("network error")
         assert _mod.flush_points(write_api) is False
         assert _mod.pending_points == ["p1", "p2"]
+
+    def test_ram_fallback_drops_oldest_overflow_with_warning(self, caplog):
+        """The RAM fallback (no spool) re-queues the unwritten batch but stays
+        bounded: overflow past MAX_PENDING_POINTS is dropped oldest-first with a
+        warning, so a downed Influx can't OOM the Pi."""
+        _mod._spool = None
+        _mod.pending_points.extend(["p1", "p2", "p3"])
+        write_api = MagicMock()
+        write_api.write.side_effect = Exception("network error")
+        with patch.object(_mod, "MAX_PENDING_POINTS", 2), \
+                caplog.at_level(logging.WARNING):
+            assert _mod.flush_points(write_api) is False
+        assert len(_mod.pending_points) == 2
+        assert any("dropped" in r.message.lower() for r in caplog.records)
 
 
 class TestLoggingConfig:
@@ -759,18 +743,18 @@ class TestRouteCommand:
         ]:
             assert _mod._route_command(_Cmd(name)) is _mod.new_value
 
-    def test_routes_status_commands(self):
-        assert _mod._route_command(_Cmd("STATUS")) is _mod.new_status
-        assert _mod._route_command(_Cmd("STATUS_DRIVE_CYCLE")) is _mod.new_status
-
-    def test_routes_air_status(self):
-        assert _mod._route_command(_Cmd("AIR_STATUS")) is _mod.new_air_status
-
-    def test_routes_fuel_status(self):
-        assert _mod._route_command(_Cmd("FUEL_STATUS")) is _mod.new_fuel_status
-
-    def test_routes_generic_numeric_to_new_value(self):
-        assert _mod._route_command(_Cmd("RPM")) is _mod.new_value
+    @pytest.mark.parametrize(
+        "name, expected_callback",
+        [
+            ("STATUS", _mod.new_status),
+            ("STATUS_DRIVE_CYCLE", _mod.new_status),
+            ("AIR_STATUS", _mod.new_air_status),
+            ("FUEL_STATUS", _mod.new_fuel_status),
+            ("RPM", _mod.new_value),  # generic numeric PID
+        ],
+    )
+    def test_routes_to_expected_callback(self, name, expected_callback):
+        assert _mod._route_command(_Cmd(name)) is expected_callback
 
     def test_excludes_mode2_freeze_frame_twins(self):
         # python-obd adds a DTC_-prefixed mode-2 twin for every supported
@@ -838,7 +822,7 @@ class TestQueuePoint:
     def test_tags_every_point_with_vin(self):
         _mod._vin = "1FATESTVIN0000009"
         _mod._queue_point(_mod.Point("rpm").field("value", 1))
-        assert _mod.pending_points[0]._tags == {"vin": "1FATESTVIN0000009"}
+        assert "vin=1FATESTVIN0000009" in _mod.pending_points[0].to_line_protocol()
 
 
 class TestConnectionHealthy:
@@ -861,3 +845,55 @@ class TestConnectionHealthy:
         conn.is_connected.return_value = True
         _mod._last_append_monotonic = _mod.monotonic() - (_mod.STALE_DATA_TIMEOUT_S + 1)
         assert _mod._connection_healthy(conn) is False
+
+
+class TestMainLoop:
+    def setup_method(self):
+        _reset()
+
+    def test_one_iteration_registers_watches_skips_elm_and_exits(
+        self, monkeypatch, caplog
+    ):
+        """Drive a single hot-loop iteration of main(): the no-car retry loop,
+        supported-command watch registration, the ELM_VOLTAGE skip on
+        (AttributeError, KeyError), and the watchdog sys.exit(1)."""
+        cmd = _Cmd("RPM")
+        connection = MagicMock()
+        # 1st status -> no car (enter retry loop); then Car Connected for the
+        # loop re-check and the debug log after the loop.
+        connection.status.side_effect = [
+            "No car connected", "Car Connected", "Car Connected",
+        ]
+        connection.supported_commands = [cmd]
+
+        def watch(command, callback=None):
+            # Only the ELM_VOLTAGE registration fails; PID watches succeed.
+            if command is _mod.obd.commands.ELM_VOLTAGE:
+                raise KeyError("no voltage command")
+
+        connection.watch.side_effect = watch
+
+        with patch.object(_mod.Spool, "from_config", return_value=MagicMock()), \
+                patch.object(_mod._influx, "connect"), \
+                patch.object(_mod, "_configure_obd_logging"), \
+                patch.object(_mod, "connect", return_value=connection) as mock_connect, \
+                patch.object(_mod, "_resolve_vin", return_value="TESTVIN0000000001"), \
+                patch.object(_mod, "_query_fuel_type_once"), \
+                patch.object(_mod, "_pump") as mock_pump, \
+                patch.object(_mod, "_connection_healthy", return_value=False), \
+                patch.object(_mod, "sleep"), \
+                caplog.at_level(logging.WARNING, logger="telem"):
+            with pytest.raises(SystemExit) as exc:
+                _mod.main()
+
+        assert exc.value.code == 1
+        # No-car retry ran once: initial connect + one reconnect.
+        assert mock_connect.call_count == 2
+        connection.close.assert_called_once()
+        # Supported PID registered with its routed callback.
+        connection.watch.assert_any_call(cmd, callback=_mod.new_value)
+        # ELM_VOLTAGE registration raised KeyError and was skipped with a warning.
+        assert any("voltage monitoring" in r.message for r in caplog.records)
+        # One hot-loop cycle ran (pump) before the watchdog exit.
+        connection.start.assert_called_once()
+        mock_pump.assert_called_once()


### PR DESCRIPTION
## Summary

A test-suite audit found the suite lopsided: dense one-assertion/duplicate coverage in the large modules, but hollow coverage of the daemon **runtime loops** and error branches. This PR rebalances it — cutting redundancy and brittleness while adding coverage where it was actually missing.

| | Before | After |
|---|---|---|
| Tests passing | 662 | **696** |
| Coverage | 89% | **97%** |

Coverage holes closed: `pisugar_monitor` 67→93%, `race_diagnose` 66→96%, `telem` 86→99%, `_spool` 89→99%, `races` 95→100%, `_config` 97→99%.

## Changes

- **Parametrize** include/omit and single-substring clusters across the laps, telem, influx, and backfill tests — dozens of one-assertion tests collapsed into tables with no coverage lost.
- **Remove implementation coupling** — positional `call_args.args[N]` assertions on patched *pure* helpers now let the helper run and assert on the emitted line protocol; `Point._fields`/`._tags` internals replaced with the public `to_line_protocol()`.
- **Delete dead/framework tests** — an empty test class, enum-exists checks, argparse-default assertions, and constant-echo duplicates.
- **Cover previously-untested runtime paths** — pisugar `main()` poll loop incl. the 401 re-auth path; telem `main()` watch+pump loop and watchdog exit; race_diagnose `diagnose_api`/`diagnose_influx`; backfill `main()` dispatch, mutual-exclusivity guard, and interrupt exits; `_config._typed` type errors; `_spool` OSError paths.
- **Fix a latent bug in `print_rankings`** — the empty-name guard tested the dict *key* instead of the value (`item != ''` was always true), so empty names were never filtered. `list_of_names` is unused by callers, so there's no runtime behavior change, but the guard is now correct and tested.

Net test count is roughly flat — the redundancy removed was reinvested into the coverage gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ranking output to skip blank contributor names.
  * Better CLI error messages for unknown commands and upstream HTTP errors.
  * More resilient monitoring and backfill behavior when network or read errors occur.
  * Improved handling of config validation, token resolution, and telemetry/race data edge cases.
  * Spool and telemetry workflows now handle write, cleanup, and replay failures more safely.

* **Tests**
  * Expanded and streamlined automated coverage across CLI, config, env, Influx, race, spool, and telemetry flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->