### PR TITLE
docs: add missing docstrings across helper modules

### DIFF
--- a/src/lemongrass/_config.py
+++ b/src/lemongrass/_config.py
@@ -76,6 +76,8 @@ class ConfigError(Exception):
 
 @dataclass(frozen=True)
 class Buckets:
+    """InfluxDB bucket names for each class of lemongrass measurement."""
+
     laps: str = 'laps'
     races: str = 'races'
     sessions: str = 'race_sessions'
@@ -85,6 +87,8 @@ class Buckets:
 
 @dataclass(frozen=True)
 class InfluxConfig:
+    """InfluxDB connection settings, bucket names, and the token env-var name."""
+
     url: str = 'https://influxdb.focism.com'
     org: str = 'focism'
     token_env: str = 'INFLUX_TELEMETRY_TOKEN'
@@ -93,22 +97,30 @@ class InfluxConfig:
 
 @dataclass(frozen=True)
 class BackfillConfig:
+    """Race-history backfill: event search terms and the default start date."""
+
     search_terms: tuple = ('Real Hoopties', 'GP du Lac', 'Halloween Hoop')
     default_start_date: str = '2017-01-01'
 
 
 @dataclass(frozen=True)
 class RacesConfig:
+    """Settings for the ``races`` command group."""
+
     backfill: BackfillConfig = field(default_factory=BackfillConfig)
 
 
 @dataclass(frozen=True)
 class RaceMonitorConfig:
+    """RaceMonitor API settings: the name of the token-pool env var."""
+
     tokens_env: str = 'RACEMONITOR_TOKENS'
 
 
 @dataclass(frozen=True)
 class ObdConfig:
+    """OBD-II serial-port settings for the telemetry reader."""
+
     port: str = '/dev/obd'
     baudrate: int = 0
     debug: bool = False
@@ -116,12 +128,16 @@ class ObdConfig:
 
 @dataclass(frozen=True)
 class SpoolConfig:
+    """On-disk telemetry spool: directory and total size cap."""
+
     dir: str = '/data/telem-spool'
     max_size: int = 1024 ** 3
 
 
 @dataclass(frozen=True)
 class TelemConfig:
+    """Telemetry settings: car VIN plus nested OBD and spool config."""
+
     vin: str = ''
     obd: ObdConfig = field(default_factory=ObdConfig)
     spool: SpoolConfig = field(default_factory=SpoolConfig)
@@ -129,6 +145,8 @@ class TelemConfig:
 
 @dataclass(frozen=True)
 class PisugarConfig:
+    """PiSugar battery-monitor connection settings."""
+
     host: str = ''
     api_url: str = 'http://localhost:8421'
     config_path: str = '/etc/pisugar-server/config.json'
@@ -136,6 +154,8 @@ class PisugarConfig:
 
 @dataclass(frozen=True)
 class Config:
+    """Top-level lemongrass configuration aggregating all sections."""
+
     influx: InfluxConfig = field(default_factory=InfluxConfig)
     races: RacesConfig = field(default_factory=RacesConfig)
     racemonitor: RaceMonitorConfig = field(default_factory=RaceMonitorConfig)
@@ -156,6 +176,11 @@ def load_config():
 
 
 def _read_file():
+    """Read and parse the TOML file named by LEMONGRASS_CONFIG.
+
+    Returns an empty dict when the var is unset. Raises ConfigError if the file
+    cannot be read or is not valid UTF-8 TOML.
+    """
     path = os.environ.get('LEMONGRASS_CONFIG')
     if not path:
         return {}
@@ -171,6 +196,10 @@ def _read_file():
 
 
 def _reject_unknown(d, allowed, where):
+    """Raise ConfigError if ``d`` is not a table or has keys outside ``allowed``.
+
+    ``where`` names the table in the error message (e.g. 'influx.buckets').
+    """
     if not isinstance(d, dict):
         raise ConfigError(f"[{where}] must be a table, not {type(d).__name__}")
     extra = set(d) - allowed
@@ -179,6 +208,11 @@ def _reject_unknown(d, allowed, where):
 
 
 def _typed(d, key, default, kind, where):
+    """Return ``d[key]`` validated as ``kind``, or ``default`` if absent.
+
+    ``kind`` is str, int, bool, or tuple (a TOML list of strings, returned as a
+    tuple). Raises ConfigError on a type mismatch, tagging it with ``where``.
+    """
     if key not in d:
         return default
     v = d[key]
@@ -196,6 +230,7 @@ def _typed(d, key, default, kind, where):
 
 
 def _build_config(data):
+    """Validate the top-level table and build a Config from its sections."""
     _reject_unknown(data, {'influx', 'races', 'racemonitor', 'telem', 'pisugar'},
                     'top level')
     return Config(
@@ -208,6 +243,7 @@ def _build_config(data):
 
 
 def _build_influx(d):
+    """Build InfluxConfig, including nested Buckets, from the [influx] table."""
     _reject_unknown(d, {'url', 'org', 'token_env', 'buckets'}, 'influx')
     b = d.get('buckets', {})
     _reject_unknown(b, {'laps', 'races', 'sessions', 'telem', 'pisugar'},
@@ -228,6 +264,7 @@ def _build_influx(d):
 
 
 def _build_races(d):
+    """Build RacesConfig, including nested BackfillConfig, from the [races] table."""
     _reject_unknown(d, {'backfill'}, 'races')
     bf = d.get('backfill', {})
     _reject_unknown(bf, {'search_terms', 'default_start_date'}, 'races.backfill')
@@ -241,6 +278,7 @@ def _build_races(d):
 
 
 def _build_racemonitor(d):
+    """Build RaceMonitorConfig from the [racemonitor] table."""
     _reject_unknown(d, {'tokens_env'}, 'racemonitor')
     dflt = RaceMonitorConfig()
     return RaceMonitorConfig(
@@ -248,6 +286,10 @@ def _build_racemonitor(d):
 
 
 def _build_telem(d):
+    """Build TelemConfig, including nested ObdConfig and SpoolConfig, from [telem].
+
+    spool.max_size accepts a human-readable size string (parsed via parse_size).
+    """
     _reject_unknown(d, {'vin', 'obd', 'spool'}, 'telem')
     obd_d, spool_d = d.get('obd', {}), d.get('spool', {})
     _reject_unknown(obd_d, {'port', 'baudrate', 'debug'}, 'telem.obd')
@@ -274,6 +316,7 @@ def _build_telem(d):
 
 
 def _build_pisugar(d):
+    """Build PisugarConfig from the [pisugar] table."""
     _reject_unknown(d, {'host', 'api_url', 'config_path'}, 'pisugar')
     dflt = PisugarConfig()
     return PisugarConfig(

--- a/src/lemongrass/_env.py
+++ b/src/lemongrass/_env.py
@@ -5,11 +5,17 @@ _LEGACY_TOKEN_VAR = 'RACEMONITOR_TOKEN'
 
 
 def _pool_var() -> str:
+    """Return the configured name of the RaceMonitor token-pool env var."""
     from lemongrass import _config
     return _config.load_config().racemonitor.tokens_env
 
 
 def _legacy_applies(pool_var: str) -> bool:
+    """Whether the legacy RACEMONITOR_TOKEN fallback applies for ``pool_var``.
+
+    True only when the default pool var is in use, so a deployment that names
+    its own pool var does not pick up a stale singular leftover.
+    """
     # The legacy singular var is honored only alongside the default pool var; a
     # deployment that names its own pool var must not pick up a stale leftover.
     from lemongrass import _config

--- a/src/lemongrass/_spool.py
+++ b/src/lemongrass/_spool.py
@@ -28,6 +28,9 @@ class Spool:
     def __init__(
         self, directory, max_bytes=DEFAULT_MAX_BYTES, rotate_bytes=ROTATE_BYTES
     ):
+        """Open a spool at ``directory``, capped at ``max_bytes`` total and
+        rotating to a new file every ``rotate_bytes``. Durability is disabled
+        (``self.enabled`` False) if the directory cannot be created."""
         self.dir = Path(directory)
         self.max_bytes = max_bytes
         self.rotate_bytes = rotate_bytes
@@ -35,11 +38,13 @@ class Spool:
 
     @classmethod
     def from_config(cls):
+        """Build a Spool from the telem.spool section of the loaded config."""
         from lemongrass import _config
         spool = _config.load_config().telem.spool
         return cls(spool.dir, max_bytes=spool.max_size)
 
     def _ensure_dir(self):
+        """Create the spool directory; return True if usable, False (and log) if not."""
         try:
             self.dir.mkdir(parents=True, exist_ok=True)
             return True
@@ -52,11 +57,17 @@ class Spool:
             return False
 
     def _files(self):
+        """Return the live (.lp) spool files, oldest first (empty if disabled)."""
         if not self.enabled:
             return []
         return sorted(self.dir.glob(f'*{_SUFFIX}'))
 
     def _next_seq(self):
+        """Return the next file sequence number, one past the highest existing.
+
+        Considers BOTH live (.lp) and quarantined (.bad) files so the counter
+        never resets and collides with a lingering quarantined file.
+        """
         # Derive the next sequence from BOTH live (.lp) and quarantined (.bad)
         # files: once every .lp drains, a lingering .bad must not let the
         # counter reset to 1 and collide with (rename would clobber) or
@@ -68,6 +79,8 @@ class Spool:
         return (max(seqs) + 1) if seqs else 1
 
     def _append_path(self):
+        """Path to append to: the newest file if under the rotate threshold,
+        otherwise a freshly sequenced file."""
         files = self._files()
         if files and files[-1].stat().st_size < self.rotate_bytes:
             return files[-1]
@@ -114,6 +127,11 @@ class Spool:
         return True
 
     def _enforce_cap(self):
+        """Evict the oldest files until total size is within ``max_bytes``.
+
+        Counts both live (.lp) and quarantined (.bad) files toward the cap and
+        always keeps at least one file. Eviction counts are logged.
+        """
         # Count both live (.lp) and quarantined (.bad) files toward the cap: a
         # recurring stream of poison/unreadable files must not accumulate .bad
         # files past telem.spool.max_size on a constrained device. Both suffixes

--- a/src/lemongrass/laps.py
+++ b/src/lemongrass/laps.py
@@ -1065,6 +1065,7 @@ def existing_lap_counts(ctx):
     some laps predate the current schema (written by an older laps.py).
     """
     def _count(field_filter):
+        """Count lap points for the tracked car matching ``field_filter``."""
         tables = ctx.query_api.query(
             f'from(bucket: "{_influx.BUCKET_LAPS}")\n'
             f'  |> range(start: {EPOCH_START})\n'
@@ -1088,6 +1089,7 @@ def existing_lap_counts_fieldwide(ctx):
     the full field. Used by old_race when running in fieldwide mode.
     """
     def _count(field_filter):
+        """Count lap points across all cars in the race matching ``field_filter``."""
         tables = ctx.query_api.query(
             f'from(bucket: "{_influx.BUCKET_LAPS}")\n'
             f'  |> range(start: {EPOCH_START})\n'
@@ -1143,6 +1145,7 @@ def existing_standings_counts_fieldwide(ctx):
     standings are fresh before skipping a race whose laps are already complete.
     """
     def _count(field_filter):
+        """Count standings points across all cars in the race matching ``field_filter``."""
         tables = ctx.query_api.query(
             f'from(bucket: "{_influx.BUCKET_LAPS}")\n'
             f'  |> range(start: {EPOCH_START})\n'


### PR DESCRIPTION
Raises docstring coverage from **78.5% (113/144)** to **100% (144/144)**, addressing CodeRabbit's recurring low-coverage flag.

The gap was concentrated in four modules:

| File | Before → After | Added |
|------|----------------|-------|
| `_config.py` | 21% → 100% | 10 config dataclasses + 9 `_build_*`/validation helpers |
| `_spool.py` | 46% → 100% | `__init__`, `from_config`, 5 private methods |
| `_env.py` | 60% → 100% | `_pool_var`, `_legacy_applies` |
| `laps.py` | 93% → 100% | 3 nested `_count` query closures |

Docstrings only — no behavior changes. `ruff check` passes and the config/env/spool test modules stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)