### PR TITLE
feat(race-backfill): interactive race selection with live search-term refinement

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -76,6 +76,15 @@ Config is validated on load and fails loud rather than silently misbehaving:
 | `pisugar.api_url` | string | `http://localhost:8421` | pisugar-server base URL |
 | `pisugar.config_path` | string | `/etc/pisugar-server/config.json` | pisugar credentials file |
 
+## Interactive search-term refinement
+
+When `race-backfill` runs in a terminal it opens an interactive checklist of the matched
+races; search terms added or removed there apply to that run only. On confirm, if the
+terms changed, it offers to write the updated `races.backfill.search_terms` back to the
+file named by `LEMONGRASS_CONFIG` — the rest of the file, including comments, is
+preserved. Without `LEMONGRASS_CONFIG` set (or if the save fails), it prints the TOML
+snippet to paste in by hand instead of writing any file.
+
 ## Examples
 
 Override only the bucket names (e.g. a shared InfluxDB):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ dependencies = [
     "obd~=0.7",
     "pandas~=3.0",
     "race-monitor>=1.0,<2.0",
+    "textual~=8.2",
+    "tomlkit~=0.15",
     "urllib3>=2",
 ]
 
@@ -50,10 +52,15 @@ select = ["E", "F", "W", "D1", "I", "B", "UP", "RUF", "N", "C4", "SIM"]
 "tests/**" = ["D1", "SIM117"]
 
 [dependency-groups]
-dev = ["pytest>=8", "ruff>=0.14,<1.0"]
+dev = [
+    "pytest>=8",
+    "pytest-asyncio>=1.4.0",
+    "ruff>=0.14,<1.0",
+]
 
 [tool.pytest.ini_options]
 addopts = "-m 'not integration'"
+asyncio_default_fixture_loop_scope = "function"
 markers = [
     "integration: real OBD path against the ELM327 emulator (emulator must be installed; excluded from the default run)",
 ]

--- a/src/lemongrass/_backfill_tui.py
+++ b/src/lemongrass/_backfill_tui.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import ClassVar
 
+from race_monitor import RaceMonitorError
+from textual import work
 from textual.app import App
 from textual.binding import Binding, BindingType
 from textual.containers import Horizontal, Vertical
@@ -134,6 +136,7 @@ class BackfillApp(App):
         Binding('enter', 'confirm', 'Confirm', priority=True),
         Binding('a', 'select_all', 'All'),
         Binding('i', 'invert', 'Invert'),
+        Binding('d', 'remove_term', 'Remove term'),
         Binding('escape', 'cancel', 'Cancel'),
         Binding('q', 'cancel', 'Cancel', show=False),
         Binding('ctrl+c', 'cancel', 'Cancel', show=False, priority=True),
@@ -215,9 +218,46 @@ class BackfillApp(App):
         """Exit without a selection."""
         self.exit(None)
 
+    def action_remove_term(self):
+        """Remove the term highlighted in the terms pane."""
+        terms_view = self.query_one('#terms', ListView)
+        if terms_view.index is None or not self.model.terms:
+            return
+        self.model.remove_term(self.model.terms[terms_view.index])
+        self._refresh_all()
+
+    def on_input_submitted(self, event):
+        """Fallback submit path if the priority enter binding is bypassed."""
+        self._submit_term(event.value)
+
     def _submit_term(self, value):
-        """Add a search term (implemented in the term-management task)."""
-        raise NotImplementedError
+        """Add a term: from the session cache if present, else a live search."""
+        term = value.strip()
+        self.query_one('#new-term', Input).value = ''
+        if not term or term in self.model.terms:
+            return
+        if self.model.has_cached(term):
+            self.model.add_term(term)
+            self._refresh_all()
+            return
+        self.notify(f'searching "{term}"…')
+        self._search_term(term)
+
+    @work(thread=True)
+    def _search_term(self, term):
+        """Fetch a term's results off the UI thread (rate limit may block ~10s)."""
+        try:
+            resp = self.client.results.search_results(term)
+        except RaceMonitorError as exc:
+            self.call_from_thread(
+                self.notify, f'search "{term}" failed: {exc}', severity='error')
+            return
+        self.call_from_thread(self._merge_results, term, resp.get('Races', []))
+
+    def _merge_results(self, term, results):
+        """Merge a completed term search into the model and rebuild the panes."""
+        self.model.add_term(term, results)
+        self._refresh_all()
 
 
 def refine_races(client, terms, races_by_term, start_epoc):

--- a/src/lemongrass/_backfill_tui.py
+++ b/src/lemongrass/_backfill_tui.py
@@ -8,6 +8,14 @@ behavior is unit-testable without Textual.
 """
 
 from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import ClassVar
+
+from textual.app import App
+from textual.binding import Binding, BindingType
+from textual.containers import Horizontal, Vertical
+from textual.widgets import Footer, Input, Label, ListItem, ListView, SelectionList
+from textual.widgets.selection_list import Selection
 
 
 @dataclass(frozen=True)
@@ -101,3 +109,128 @@ class RaceListModel:
     def terms_changed(self):
         """True if the active terms differ from the session's initial terms."""
         return tuple(self.terms) != self._initial_terms
+
+
+def _race_label(race):
+    """One checklist row: 'YYYY-MM-DD  Name  (#id)'."""
+    day = datetime.fromtimestamp(race['StartDateEpoc'], tz=UTC).strftime('%Y-%m-%d')
+    return f"{day}  {race['Name']}  (#{race['ID']})"
+
+
+class BackfillApp(App):
+    """Two-pane refinement UI; exit value is a RefineResult, or None on cancel.
+
+    All state changes are delegated to the RaceListModel; widgets are rebuilt
+    from the model after every mutation, so the model stays the single source
+    of truth.
+    """
+
+    CSS = """
+    #terms-pane { width: 36; }
+    #terms-pane, #races-pane { border: round $primary; padding: 0 1; }
+    """
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding('enter', 'confirm', 'Confirm', priority=True),
+        Binding('a', 'select_all', 'All'),
+        Binding('i', 'invert', 'Invert'),
+        Binding('escape', 'cancel', 'Cancel'),
+        Binding('q', 'cancel', 'Cancel', show=False),
+        Binding('ctrl+c', 'cancel', 'Cancel', show=False, priority=True),
+    ]
+
+    def __init__(self, client, model):
+        """client is the shared RaceMonitorClient; model a seeded RaceListModel."""
+        super().__init__()
+        self.client = client
+        self.model = model
+
+    def compose(self):
+        """Lay out the terms pane, races checklist, and footer."""
+        with Horizontal():
+            with Vertical(id='terms-pane'):
+                yield Label('Search terms')
+                yield ListView(id='terms')
+                yield Input(placeholder='add search term…', id='new-term')
+            with Vertical(id='races-pane'):
+                yield Label(id='count')
+                yield SelectionList(id='races')
+        yield Footer()
+
+    def on_mount(self):
+        """Populate both panes from the model and focus the checklist."""
+        self._refresh_all()
+        self.query_one('#races', SelectionList).focus()
+
+    def _refresh_all(self):
+        """Rebuild both panes from the model."""
+        terms_view = self.query_one('#terms', ListView)
+        terms_view.clear()
+        for term in self.model.terms:
+            terms_view.append(ListItem(Label(term)))
+        races_view = self.query_one('#races', SelectionList)
+        races_view.clear_options()
+        for race in self.model.races():
+            races_view.add_option(Selection(
+                _race_label(race), race['ID'], race['ID'] in self.model.checked))
+        self._update_count()
+
+    def _update_count(self):
+        """Refresh the 'N of M selected' header above the checklist."""
+        total = len(self.model.races())
+        self.query_one('#count', Label).update(
+            f'Races — {len(self.model.checked)} of {total} selected')
+
+    def on_selection_list_selection_toggled(self, event):
+        """Mirror a checkbox toggle into the model."""
+        self.model.toggle(event.selection.value)
+        self._update_count()
+
+    def action_select_all(self):
+        """Check every visible race."""
+        self.model.set_all(True)
+        self._refresh_all()
+
+    def action_invert(self):
+        """Invert every visible race's checked state."""
+        self.model.invert()
+        self._refresh_all()
+
+    def action_confirm(self):
+        """Exit with the confirmed selection.
+
+        enter is a priority binding so it wins over the SelectionList; when the
+        term Input is focused it submits the typed term instead of confirming
+        (the Input would otherwise swallow the key).
+        """
+        term_input = self.query_one('#new-term', Input)
+        if self.focused is term_input:
+            self._submit_term(term_input.value)
+            return
+        self.exit(RefineResult(races=self.model.selected(),
+                               terms=tuple(self.model.terms),
+                               terms_changed=self.model.terms_changed))
+
+    def action_cancel(self):
+        """Exit without a selection."""
+        self.exit(None)
+
+    def _submit_term(self, value):
+        """Add a search term (implemented in the term-management task)."""
+        raise NotImplementedError
+
+
+def refine_races(client, terms, races_by_term, start_epoc):
+    """Run the refinement app; return a RefineResult, or None if cancelled.
+
+    client is the already-open RaceMonitorClient from the initial search (its
+    rate-limiter window is shared with in-app term searches). races_by_term is
+    the per-term output of search_races_by_term(); start_epoc filters in-app
+    search results the same way --start-date filtered the initial ones.
+    """
+    model = RaceListModel(terms, races_by_term, start_epoc)
+    app = BackfillApp(client, model)
+    try:
+        return app.run()
+    except KeyboardInterrupt:
+        return None

--- a/src/lemongrass/_backfill_tui.py
+++ b/src/lemongrass/_backfill_tui.py
@@ -1,0 +1,103 @@
+"""Interactive refinement of the race-backfill selection.
+
+refine_races() (added with the Textual app) is the public entry point: it shows
+discovered races in a two-pane TUI — search terms on the left, a race checklist
+on the right — and returns the confirmed selection. RaceListModel below holds
+every piece of state and all merge/dedup logic, with no UI imports, so the
+behavior is unit-testable without Textual.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RefineResult:
+    """Confirmed outcome of a refinement session.
+
+    races is the checked subset (date-sorted race dicts); terms the final
+    search terms in display order; terms_changed whether they differ from the
+    terms the session started with.
+    """
+
+    races: list
+    terms: tuple
+    terms_changed: bool
+
+
+class RaceListModel:
+    """State for the refinement UI: active terms, cached results, checked IDs.
+
+    The per-term cache outlives term removal, so re-adding a removed term costs
+    no API call. races() derives the visible list on demand: dedup by race ID
+    across active terms, filter to StartDateEpoc >= start_epoc, sort by date.
+    """
+
+    def __init__(self, terms, races_by_term, start_epoc):
+        """Seed with the initial terms and their (already fetched) results."""
+        self.start_epoc = start_epoc
+        self._initial_terms = tuple(terms)
+        self.terms = list(terms)
+        self._cache = {term: list(races_by_term.get(term, [])) for term in terms}
+        self.checked = {race['ID'] for race in self.races()}
+
+    def races(self):
+        """Return visible races: deduped, date-filtered, date-sorted."""
+        seen = {}
+        for term in self.terms:
+            for race in self._cache.get(term, []):
+                if race['StartDateEpoc'] >= self.start_epoc:
+                    seen[race['ID']] = race
+        return sorted(seen.values(), key=lambda r: r['StartDateEpoc'])
+
+    def has_cached(self, term):
+        """True if term already has session-cached search results."""
+        return term in self._cache
+
+    def add_term(self, term, results=None):
+        """Activate a term; newly visible races become checked.
+
+        results is the term's raw search-result list, required unless the term
+        is already cached from earlier in the session. Blank and already-active
+        terms are ignored.
+        """
+        term = term.strip()
+        if not term or term in self.terms:
+            return
+        if results is not None:
+            self._cache[term] = list(results)
+        elif term not in self._cache:
+            raise ValueError(f"no cached results for {term!r}; pass results")
+        before = {race['ID'] for race in self.races()}
+        self.terms.append(term)
+        self.checked |= {race['ID'] for race in self.races()} - before
+
+    def remove_term(self, term):
+        """Deactivate a term; races matched only by it drop from the list."""
+        if term not in self.terms:
+            return
+        self.terms.remove(term)
+        self.checked &= {race['ID'] for race in self.races()}
+
+    def toggle(self, race_id):
+        """Flip one race's checked state."""
+        if race_id in self.checked:
+            self.checked.discard(race_id)
+        else:
+            self.checked.add(race_id)
+
+    def set_all(self, checked):
+        """Check (True) or uncheck (False) every visible race."""
+        self.checked = {r['ID'] for r in self.races()} if checked else set()
+
+    def invert(self):
+        """Invert the checked state of every visible race."""
+        self.checked = {r['ID'] for r in self.races()} - self.checked
+
+    def selected(self):
+        """Return the checked races, date-sorted."""
+        return [race for race in self.races() if race['ID'] in self.checked]
+
+    @property
+    def terms_changed(self):
+        """True if the active terms differ from the session's initial terms."""
+        return tuple(self.terms) != self._initial_terms

--- a/src/lemongrass/_backfill_tui.py
+++ b/src/lemongrass/_backfill_tui.py
@@ -18,6 +18,7 @@ from textual.binding import Binding, BindingType
 from textual.containers import Horizontal, Vertical
 from textual.widgets import Footer, Input, Label, ListItem, ListView, SelectionList
 from textual.widgets.selection_list import Selection
+from textual.worker import get_current_worker
 
 
 @dataclass(frozen=True)
@@ -245,12 +246,21 @@ class BackfillApp(App):
 
     @work(thread=True)
     def _search_term(self, term):
-        """Fetch a term's results off the UI thread (rate limit may block ~10s)."""
+        """Fetch a term's results off the UI thread (rate limit may block ~10s).
+
+        If the app exits while the request is in flight, this worker is cancelled;
+        skip call_from_thread in that case since the event loop is already closed.
+        """
+        worker = get_current_worker()
         try:
             resp = self.client.results.search_results(term)
         except RaceMonitorError as exc:
+            if worker.is_cancelled:
+                return
             self.call_from_thread(
                 self.notify, f'search "{term}" failed: {exc}', severity='error')
+            return
+        if worker.is_cancelled:
             return
         self.call_from_thread(self._merge_results, term, resp.get('Races', []))
 

--- a/src/lemongrass/race_backfill.py
+++ b/src/lemongrass/race_backfill.py
@@ -32,6 +32,12 @@ Usage:
     # RaceMonitor (faster than --force when only the schema tag changed)
     lemongrass race-backfill --upgrade-stored
 
+    When run in a terminal, race-backfill (including --dry-run and --validate)
+    opens an interactive checklist of the matched races: toggle races with
+    space, add/remove search terms live, then Enter to proceed with the
+    selection (everything starts selected, so Enter alone keeps the old
+    behavior). Non-terminal runs (cron, pipes) skip the UI entirely.
+
 Required environment variables:
     RACEMONITOR_TOKENS     — comma-separated RaceMonitor API tokens (preferred)
     RACEMONITOR_TOKEN      — single RaceMonitor API token (fallback)
@@ -380,6 +386,10 @@ def run_upgrade_stored(query_api, dry_run=False, force=False):
     return failures
 
 
+def _maybe_save_terms(result):
+    """Offer to persist changed search terms (implemented with the save flow)."""
+
+
 def main():
     """Entry point: parse args, discover races, then backfill or validate."""
     # The `lemongrass` console script dispatches here by import (cli.main ->
@@ -414,8 +424,23 @@ def main():
 
     try:
         with RaceMonitorClient(api_token=tokens) as client:
-            races = find_matching_races(client, start_epoc)
+            races_by_term = search_races_by_term(
+                client, LEMONS_SEARCH_TERMS, start_epoc)
+            races = merge_races(races_by_term)
             logging.info("Found %d matching races", len(races))
+
+            if sys.stdin.isatty() and sys.stdout.isatty():
+                # Imported lazily: non-interactive runs (cron, pipes) never pay
+                # the textual import.
+                from lemongrass._backfill_tui import refine_races
+                result = refine_races(
+                    client, LEMONS_SEARCH_TERMS, races_by_term, start_epoc)
+                if result is None:
+                    logging.info("Cancelled, nothing done.")
+                    sys.exit(0)
+                logging.info("Selected %d of %d races", len(result.races), len(races))
+                races = result.races
+                _maybe_save_terms(result)
 
             if args.validate:
                 race_ids = [str(r['ID']) for r in races]

--- a/src/lemongrass/race_backfill.py
+++ b/src/lemongrass/race_backfill.py
@@ -47,9 +47,11 @@ Required environment variables:
 
 import argparse
 import logging
+import os
 import sys
 from datetime import UTC, date, datetime, timedelta
 
+import tomlkit
 from race_monitor import RaceMonitorClient, RaceMonitorError
 
 from lemongrass import _config, _env, _influx
@@ -386,8 +388,59 @@ def run_upgrade_stored(query_api, dry_run=False, force=False):
     return failures
 
 
+def _save_search_terms(path, terms):
+    """Rewrite races.backfill.search_terms in the TOML file at path.
+
+    tomlkit preserves the rest of the document — comments, formatting, and
+    unrelated keys. Returns True on success; logs a warning and returns False
+    on any read/parse/write failure.
+    """
+    try:
+        with open(path, encoding='utf-8') as f:
+            doc = tomlkit.parse(f.read())
+        if 'races' not in doc:
+            doc['races'] = tomlkit.table()
+        if 'backfill' not in doc['races']:
+            doc['races']['backfill'] = tomlkit.table()
+        doc['races']['backfill']['search_terms'] = list(terms)
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(tomlkit.dumps(doc))
+        return True
+    except (OSError, tomlkit.exceptions.TOMLKitError) as exc:
+        logging.warning("could not save search terms to %s: %s", path, exc)
+        return False
+
+
+def _print_terms_snippet(terms):
+    """Print the TOML snippet that persists terms, for manual pasting."""
+    quoted = ", ".join(f'"{t}"' for t in terms)
+    print("To persist these search terms, add to the TOML file named by "
+          "LEMONGRASS_CONFIG:\n\n"
+          "[races.backfill]\n"
+          f"search_terms = [{quoted}]\n")
+
+
 def _maybe_save_terms(result):
-    """Offer to persist changed search terms (implemented with the save flow)."""
+    """Offer to persist changed search terms after an interactive confirm.
+
+    With LEMONGRASS_CONFIG set, a y/N prompt gates a format-preserving rewrite
+    of races.backfill.search_terms; a failed save falls back to printing the
+    snippet. Without it no file is written — config loading has no default
+    path, so a written file would be silently ignored — and the snippet is
+    printed instead. Never blocks the run.
+    """
+    if not result.terms_changed:
+        return
+    path = os.environ.get('LEMONGRASS_CONFIG')
+    if not path:
+        _print_terms_snippet(result.terms)
+        return
+    try:
+        answer = input(f"Save updated search terms to {path}? [y/N] ")
+    except EOFError:
+        return
+    if answer.strip().lower() in ('y', 'yes') and not _save_search_terms(path, result.terms):
+        _print_terms_snippet(result.terms)
 
 
 def main():

--- a/src/lemongrass/race_backfill.py
+++ b/src/lemongrass/race_backfill.py
@@ -46,9 +46,11 @@ Required environment variables:
 """
 
 import argparse
+import contextlib
 import logging
 import os
 import sys
+import tempfile
 from datetime import UTC, date, datetime, timedelta
 
 import tomlkit
@@ -403,8 +405,18 @@ def _save_search_terms(path, terms):
         if 'backfill' not in doc['races']:
             doc['races']['backfill'] = tomlkit.table()
         doc['races']['backfill']['search_terms'] = list(terms)
-        with open(path, 'w', encoding='utf-8') as f:
-            f.write(tomlkit.dumps(doc))
+        # Write-then-rename so a crash mid-write can't truncate the config.
+        fd, tmp_path = tempfile.mkstemp(dir=os.path.dirname(path) or '.',
+                                        suffix='.tmp')
+        try:
+            with os.fdopen(fd, 'w', encoding='utf-8') as f:
+                f.write(tomlkit.dumps(doc))
+            os.chmod(tmp_path, os.stat(path).st_mode)
+            os.replace(tmp_path, path)
+        except OSError:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_path)
+            raise
         return True
     except (OSError, tomlkit.exceptions.TOMLKitError) as exc:
         logging.warning("could not save search terms to %s: %s", path, exc)
@@ -413,11 +425,11 @@ def _save_search_terms(path, terms):
 
 def _print_terms_snippet(terms):
     """Print the TOML snippet that persists terms, for manual pasting."""
-    quoted = ", ".join(f'"{t}"' for t in terms)
+    array = tomlkit.item(list(terms)).as_string()
     print("To persist these search terms, add to the TOML file named by "
           "LEMONGRASS_CONFIG:\n\n"
           "[races.backfill]\n"
-          f"search_terms = [{quoted}]\n")
+          f"search_terms = {array}\n")
 
 
 def _maybe_save_terms(result):

--- a/src/lemongrass/race_backfill.py
+++ b/src/lemongrass/race_backfill.py
@@ -90,18 +90,37 @@ def _build_parser():
     return parser
 
 
+def search_races_by_term(client, terms, start_epoc):
+    """Search RaceMonitor once per term; return {term: [race, ...]}.
+
+    Each list is filtered to races starting at or after start_epoc but is NOT
+    deduplicated across terms, preserving which term matched which race (the
+    interactive refinement UI needs that attribution to drop a term's races
+    when the term is removed).
+    """
+    by_term = {}
+    for term in terms:
+        resp = client.results.search_results(term)
+        by_term[term] = [race for race in resp.get('Races', [])
+                         if race['StartDateEpoc'] >= start_epoc]
+    return by_term
+
+
+def merge_races(races_by_term):
+    """Merge per-term search results: dedup by race ID, sort by start date."""
+    seen = {}
+    for races in races_by_term.values():
+        for race in races:
+            seen[race['ID']] = race
+    return sorted(seen.values(), key=lambda r: r['StartDateEpoc'])
+
+
 def find_matching_races(client, start_epoc):
     """Search for matching Lemons races at or after start_epoc.
 
     Makes one API call per search term and deduplicates by race ID.
     """
-    seen = {}
-    for term in LEMONS_SEARCH_TERMS:
-        resp = client.results.search_results(term)
-        for race in resp.get('Races', []):
-            if race['StartDateEpoc'] >= start_epoc:
-                seen[race['ID']] = race
-    return sorted(seen.values(), key=lambda r: r['StartDateEpoc'])
+    return merge_races(search_races_by_term(client, LEMONS_SEARCH_TERMS, start_epoc))
 
 
 def validate_backfill(race_ids, query_api):

--- a/tests/test_backfill_tui.py
+++ b/tests/test_backfill_tui.py
@@ -1,6 +1,8 @@
 from unittest.mock import MagicMock
 
 import pytest
+from race_monitor import RaceMonitorError
+from textual.widgets import Input, ListView, SelectionList
 
 from lemongrass._backfill_tui import BackfillApp, RaceListModel
 
@@ -150,3 +152,94 @@ class TestBackfillAppCore:
         async with app.run_test() as pilot:
             await pilot.press('escape')
         assert app.return_value is None
+
+
+class TestBackfillAppTerms:
+    async def _type_term(self, pilot, app, term):
+        app.query_one('#new-term', Input).focus()
+        await pilot.pause()
+        for ch in term:
+            await pilot.press(ch)
+        await pilot.press('enter')
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+    @pytest.mark.asyncio
+    async def test_add_term_searches_and_merges_prechecked(self):
+        client = MagicMock()
+        client.results.search_results.return_value = {
+            'Races': [_race(3, 'three', 300)]}
+        app = _app({'t1': [_race(1, 'one', 100)]}, client=client)
+        async with app.run_test() as pilot:
+            await self._type_term(pilot, app, 'gp')
+            app.query_one('#races', SelectionList).focus()
+            await pilot.pause()
+            await pilot.press('enter')
+        client.results.search_results.assert_called_once_with('gp')
+        result = app.return_value
+        assert [r['ID'] for r in result.races] == [1, 3]
+        assert result.terms == ('t1', 'gp')
+        assert result.terms_changed is True
+
+    @pytest.mark.asyncio
+    async def test_add_term_filters_new_results_by_start_epoc(self):
+        client = MagicMock()
+        client.results.search_results.return_value = {
+            'Races': [_race(3, 'too-old', 50)]}
+        app = _app({'t1': [_race(1, 'one', 150)]}, start_epoc=100, client=client)
+        async with app.run_test() as pilot:
+            await self._type_term(pilot, app, 'gp')
+            app.query_one('#races', SelectionList).focus()
+            await pilot.pause()
+            await pilot.press('enter')
+        assert [r['ID'] for r in app.return_value.races] == [1]
+
+    @pytest.mark.asyncio
+    async def test_search_failure_notifies_and_does_not_add_term(self):
+        client = MagicMock()
+        client.results.search_results.side_effect = RaceMonitorError('boom')
+        app = _app({'t1': [_race(1, 'one', 100)]}, client=client)
+        async with app.run_test() as pilot:
+            await self._type_term(pilot, app, 'gp')
+        assert app.model.terms == ['t1']
+
+    @pytest.mark.asyncio
+    async def test_remove_term_key_drops_its_races(self):
+        app = _app({'t1': [_race(1, 'one', 100)], 't2': [_race(2, 'two', 200)]},
+                   terms=('t1', 't2'))
+        async with app.run_test() as pilot:
+            app.query_one('#terms', ListView).focus()
+            await pilot.pause()
+            # this Textual patch version starts with no highlighted row, so two
+            # presses are needed to reach index 1 ('t2')
+            await pilot.press('down')
+            await pilot.press('down')  # highlight 't2'
+            await pilot.press('d')
+            app.query_one('#races', SelectionList).focus()
+            await pilot.pause()
+            await pilot.press('enter')
+        result = app.return_value
+        assert [r['ID'] for r in result.races] == [1]
+        assert result.terms == ('t1',)
+
+    @pytest.mark.asyncio
+    async def test_readding_removed_term_hits_cache_not_client(self):
+        client = MagicMock()
+        client.results.search_results.return_value = {
+            'Races': [_race(2, 'two', 200)]}
+        app = _app({'t1': [_race(1, 'one', 100)]}, client=client)
+        async with app.run_test() as pilot:
+            await self._type_term(pilot, app, 'gp')     # live search (1 call)
+            app.query_one('#terms', ListView).focus()
+            await pilot.pause()
+            # this Textual patch version starts with no highlighted row, so two
+            # presses are needed to reach index 1 ('gp')
+            await pilot.press('down')
+            await pilot.press('down')
+            await pilot.press('d')                       # remove 'gp'
+            await self._type_term(pilot, app, 'gp')     # re-add: cache hit
+            app.query_one('#races', SelectionList).focus()
+            await pilot.pause()
+            await pilot.press('enter')
+        assert client.results.search_results.call_count == 1
+        assert [r['ID'] for r in app.return_value.races] == [1, 2]

--- a/tests/test_backfill_tui.py
+++ b/tests/test_backfill_tui.py
@@ -1,0 +1,96 @@
+from lemongrass._backfill_tui import RaceListModel
+
+
+def _race(id, name, start_epoc):
+    return {'ID': id, 'Name': name, 'StartDateEpoc': start_epoc}
+
+
+def _model(races_by_term=None, terms=('t1',), start_epoc=0):
+    return RaceListModel(terms, races_by_term or {}, start_epoc)
+
+
+class TestRaceListModel:
+    def test_all_races_checked_initially(self):
+        m = _model({'t1': [_race(1, 'one', 100), _race(2, 'two', 200)]})
+        assert m.checked == {1, 2}
+
+    def test_races_deduped_across_terms_and_date_sorted(self):
+        shared = _race(2, 'shared', 200)
+        m = _model({'t1': [shared, _race(3, 'three', 300)],
+                    't2': [shared, _race(1, 'one', 100)]},
+                   terms=('t1', 't2'))
+        assert [r['ID'] for r in m.races()] == [1, 2, 3]
+
+    def test_races_filtered_by_start_epoc(self):
+        m = _model({'t1': [_race(1, 'old', 50), _race(2, 'new', 150)]},
+                   start_epoc=100)
+        assert [r['ID'] for r in m.races()] == [2]
+        assert m.checked == {2}
+
+    def test_toggle_unchecks_then_rechecks(self):
+        m = _model({'t1': [_race(1, 'one', 100)]})
+        m.toggle(1)
+        assert m.checked == set()
+        m.toggle(1)
+        assert m.checked == {1}
+
+    def test_set_all_and_invert(self):
+        m = _model({'t1': [_race(1, 'one', 100), _race(2, 'two', 200)]})
+        m.set_all(False)
+        assert m.checked == set()
+        m.toggle(1)
+        m.invert()
+        assert m.checked == {2}
+        m.set_all(True)
+        assert m.checked == {1, 2}
+
+    def test_add_term_merges_prechecked_preserving_existing_state(self):
+        m = _model({'t1': [_race(1, 'one', 100), _race(2, 'two', 200)]})
+        m.toggle(1)  # user unchecked race 1
+        m.add_term('t2', [_race(2, 'two', 200), _race(3, 'three', 300)])
+        assert [r['ID'] for r in m.races()] == [1, 2, 3]
+        assert m.checked == {2, 3}  # 1 stays unchecked, new 3 pre-checked
+
+    def test_add_term_filters_by_start_epoc(self):
+        m = _model({'t1': [_race(1, 'one', 150)]}, start_epoc=100)
+        m.add_term('t2', [_race(2, 'old', 50)])
+        assert [r['ID'] for r in m.races()] == [1]
+
+    def test_add_blank_or_duplicate_term_is_noop(self):
+        m = _model({'t1': [_race(1, 'one', 100)]})
+        m.add_term('  ', [])
+        m.add_term('t1', [_race(9, 'dup', 900)])
+        assert m.terms == ['t1']
+        assert [r['ID'] for r in m.races()] == [1]
+
+    def test_remove_term_drops_only_races_matched_solely_by_that_term(self):
+        shared = _race(2, 'shared', 200)
+        m = _model({'t1': [_race(1, 'one', 100), shared],
+                    't2': [shared, _race(3, 'three', 300)]},
+                   terms=('t1', 't2'))
+        m.remove_term('t2')
+        assert [r['ID'] for r in m.races()] == [1, 2]
+        assert m.checked == {1, 2}
+
+    def test_readd_removed_term_uses_cache(self):
+        m = _model({'t1': [_race(1, 'one', 100)]})
+        m.add_term('t2', [_race(2, 'two', 200)])
+        m.remove_term('t2')
+        assert m.has_cached('t2')
+        m.add_term('t2')  # no results arg: served from session cache
+        assert [r['ID'] for r in m.races()] == [1, 2]
+        assert m.checked == {1, 2}  # reappearing race is pre-checked again
+
+    def test_terms_changed_tracks_difference_from_initial(self):
+        m = _model({'t1': [], 't2': []}, terms=('t1', 't2'))
+        assert m.terms_changed is False
+        m.remove_term('t2')
+        assert m.terms_changed is True
+        m.add_term('t2')
+        assert m.terms_changed is False  # back to the initial tuple
+
+    def test_selected_returns_checked_races_date_sorted(self):
+        m = _model({'t1': [_race(2, 'two', 200), _race(1, 'one', 100),
+                           _race(3, 'three', 300)]})
+        m.toggle(2)
+        assert [r['ID'] for r in m.selected()] == [1, 3]

--- a/tests/test_backfill_tui.py
+++ b/tests/test_backfill_tui.py
@@ -1,4 +1,8 @@
-from lemongrass._backfill_tui import RaceListModel
+from unittest.mock import MagicMock
+
+import pytest
+
+from lemongrass._backfill_tui import BackfillApp, RaceListModel
 
 
 def _race(id, name, start_epoc):
@@ -7,6 +11,11 @@ def _race(id, name, start_epoc):
 
 def _model(races_by_term=None, terms=('t1',), start_epoc=0):
     return RaceListModel(terms, races_by_term or {}, start_epoc)
+
+
+def _app(races_by_term=None, terms=('t1',), start_epoc=0, client=None):
+    model = RaceListModel(terms, races_by_term or {}, start_epoc)
+    return BackfillApp(client or MagicMock(), model)
 
 
 class TestRaceListModel:
@@ -94,3 +103,50 @@ class TestRaceListModel:
                            _race(3, 'three', 300)]})
         m.toggle(2)
         assert [r['ID'] for r in m.selected()] == [1, 3]
+
+
+class TestBackfillAppCore:
+    @pytest.mark.asyncio
+    async def test_enter_confirms_all_races_by_default(self):
+        app = _app({'t1': [_race(1, 'one', 100), _race(2, 'two', 200)]})
+        async with app.run_test() as pilot:
+            await pilot.press('enter')
+        result = app.return_value
+        assert [r['ID'] for r in result.races] == [1, 2]
+        assert result.terms == ('t1',)
+        assert result.terms_changed is False
+
+    @pytest.mark.asyncio
+    async def test_space_toggles_highlighted_race(self):
+        app = _app({'t1': [_race(1, 'one', 100), _race(2, 'two', 200)]})
+        async with app.run_test() as pilot:
+            # this Textual patch version needs an explicit move to highlight row 0
+            await pilot.press('down')
+            await pilot.press('space')  # checklist is focused; row 1 highlighted
+            await pilot.press('enter')
+        assert [r['ID'] for r in app.return_value.races] == [2]
+
+    @pytest.mark.asyncio
+    async def test_select_all_and_invert_keys(self):
+        app = _app({'t1': [_race(1, 'one', 100), _race(2, 'two', 200)]})
+        async with app.run_test() as pilot:
+            await pilot.press('i')  # invert: all -> none
+            # this Textual patch version needs an explicit move to highlight row 0
+            await pilot.press('down')
+            await pilot.press('space')  # check row 1
+            await pilot.press('enter')
+        assert [r['ID'] for r in app.return_value.races] == [1]
+
+    @pytest.mark.asyncio
+    async def test_q_cancels_with_none(self):
+        app = _app({'t1': [_race(1, 'one', 100)]})
+        async with app.run_test() as pilot:
+            await pilot.press('q')
+        assert app.return_value is None
+
+    @pytest.mark.asyncio
+    async def test_escape_cancels_with_none(self):
+        app = _app({'t1': [_race(1, 'one', 100)]})
+        async with app.run_test() as pilot:
+            await pilot.press('escape')
+        assert app.return_value is None

--- a/tests/test_race_backfill.py
+++ b/tests/test_race_backfill.py
@@ -5,6 +5,7 @@ import sys
 from contextlib import contextmanager
 from datetime import UTC, datetime
 from types import SimpleNamespace
+from typing import ClassVar
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -703,6 +704,70 @@ class TestMainTokenResolution:
         mock_rm_cls.assert_called_once_with(api_token=['TOKEN1', 'TOKEN2'])
 
 
+class TestMainInteractive:
+    RACES: ClassVar[list] = [_make_race(1, 'one', EPOC_2022), _make_race(2, 'two', EPOC_2023)]
+
+    @contextmanager
+    def _main_harness(self, tty, refine_result='unset'):
+        """Run main() with discovery stubbed; yields (run_backfill, refine) mocks."""
+        client = MagicMock()
+        client.__enter__ = MagicMock(return_value=client)
+        client.__exit__ = MagicMock(return_value=False)
+        by_term = {t: list(self.RACES) for t in _mod.LEMONS_SEARCH_TERMS}
+        with patch.object(_mod, 'RaceMonitorClient', return_value=client), \
+             patch.object(_mod, 'resolve_tokens', return_value=['tok']), \
+             patch.object(_mod, 'search_races_by_term', return_value=by_term), \
+             patch.object(_mod, 'run_backfill', return_value=[]) as backfill, \
+             patch.object(_mod.sys.stdin, 'isatty', return_value=tty), \
+             patch.object(_mod.sys.stdout, 'isatty', return_value=tty), \
+             patch('lemongrass._backfill_tui.refine_races') as refine:
+            if refine_result != 'unset':
+                refine.return_value = refine_result
+            yield backfill, refine
+
+    def test_non_tty_skips_tui_and_backfills_all(self):
+        with self._main_harness(tty=False) as (backfill, refine):
+            with patch.object(sys, 'argv', ['race-backfill']):
+                _mod.main()
+        refine.assert_not_called()
+        races = backfill.call_args.args[0]
+        assert [r['ID'] for r in races] == [1, 2]
+
+    def test_tty_cancel_exits_zero_without_backfill(self):
+        with self._main_harness(tty=True, refine_result=None) as (backfill, _):
+            with patch.object(sys, 'argv', ['race-backfill']):
+                with pytest.raises(SystemExit) as exc:
+                    _mod.main()
+        assert exc.value.code == 0
+        backfill.assert_not_called()
+
+    def test_tty_confirm_backfills_selected_subset(self):
+        from lemongrass._backfill_tui import RefineResult
+        subset = RefineResult(races=[self.RACES[1]],
+                              terms=tuple(_mod.LEMONS_SEARCH_TERMS),
+                              terms_changed=False)
+        with self._main_harness(tty=True, refine_result=subset) as (backfill, refine):
+            with patch.object(sys, 'argv', ['race-backfill']):
+                _mod.main()
+        refine.assert_called_once()
+        races = backfill.call_args.args[0]
+        assert [r['ID'] for r in races] == [2]
+
+    def test_tty_validate_uses_selected_subset(self):
+        from lemongrass._backfill_tui import RefineResult
+        subset = RefineResult(races=[self.RACES[0]],
+                              terms=tuple(_mod.LEMONS_SEARCH_TERMS),
+                              terms_changed=False)
+        with self._main_harness(tty=True, refine_result=subset):
+            with patch.object(_mod, 'validate_backfill', return_value=True) as val, \
+                 patch.object(_mod._influx, 'connect', MagicMock()):
+                with patch.object(sys, 'argv', ['race-backfill', '--validate']):
+                    with pytest.raises(SystemExit) as exc:
+                        _mod.main()
+        assert exc.value.code == 0
+        assert val.call_args.args[0] == ['1']
+
+
 class TestMain:
     """main() control flow: dispatch, exit codes, and interrupt handling."""
 
@@ -781,7 +846,7 @@ class TestMain:
             with patch.object(sys, 'argv', ['race-backfill']):
                 with patch('lemongrass.race_backfill.RaceMonitorClient') as mk_rm:
                     mk_rm.return_value.__enter__.return_value = MagicMock()
-                    with patch.object(_mod, 'find_matching_races',
+                    with patch.object(_mod, 'search_races_by_term',
                                       side_effect=KeyboardInterrupt()):
                         with pytest.raises(SystemExit) as exc:
                             _mod.main()

--- a/tests/test_race_backfill.py
+++ b/tests/test_race_backfill.py
@@ -2,6 +2,7 @@ import importlib
 import logging
 import os
 import sys
+import tomllib
 from contextlib import contextmanager
 from datetime import UTC, datetime
 from types import SimpleNamespace
@@ -926,3 +927,90 @@ def test_backfill_defaults_come_from_config(monkeypatch, tmp_path):
     finally:
         monkeypatch.delenv("LEMONGRASS_CONFIG", raising=False)
         importlib.reload(race_backfill)  # restore default module state
+
+
+def _refine_result(terms=('a', 'b'), changed=True):
+    from lemongrass._backfill_tui import RefineResult
+    return RefineResult(races=[], terms=tuple(terms), terms_changed=changed)
+
+
+class TestSaveSearchTerms:
+    def test_updates_terms_preserving_comments_and_other_keys(self, tmp_path):
+        cfg = tmp_path / 'lemongrass.toml'
+        cfg.write_text('# my config\n'
+                       '[races.backfill]\n'
+                       'search_terms = ["old"]\n'
+                       '\n'
+                       '[influx]\n'
+                       'url = "http://example"\n')
+        assert _mod._save_search_terms(str(cfg), ('a', 'b')) is True
+        text = cfg.read_text()
+        assert '# my config' in text
+        data = tomllib.loads(text)
+        assert data['races']['backfill']['search_terms'] == ['a', 'b']
+        assert data['influx']['url'] == 'http://example'
+
+    def test_creates_missing_tables(self, tmp_path):
+        cfg = tmp_path / 'lemongrass.toml'
+        cfg.write_text('[influx]\nurl = "http://example"\n')
+        assert _mod._save_search_terms(str(cfg), ('a',)) is True
+        data = tomllib.loads(cfg.read_text())
+        assert data['races']['backfill']['search_terms'] == ['a']
+
+    def test_returns_false_on_unreadable_path(self, tmp_path, caplog):
+        missing = tmp_path / 'nope' / 'lemongrass.toml'
+        with caplog.at_level(logging.WARNING):
+            assert _mod._save_search_terms(str(missing), ('a',)) is False
+        assert any('could not save' in r.message for r in caplog.records)
+
+
+class TestMaybeSaveTerms:
+    def test_unchanged_terms_never_prompt(self, monkeypatch, capsys):
+        monkeypatch.setenv('LEMONGRASS_CONFIG', '/some/path.toml')
+        monkeypatch.setattr('builtins.input',
+                            lambda *_: pytest.fail('should not prompt'))
+        _mod._maybe_save_terms(_refine_result(changed=False))
+        assert capsys.readouterr().out == ''
+
+    def test_no_config_prints_snippet_without_prompt(self, monkeypatch, capsys):
+        monkeypatch.delenv('LEMONGRASS_CONFIG', raising=False)
+        monkeypatch.setattr('builtins.input',
+                            lambda *_: pytest.fail('should not prompt'))
+        _mod._maybe_save_terms(_refine_result(terms=('a', 'b')))
+        out = capsys.readouterr().out
+        assert '[races.backfill]' in out
+        assert 'search_terms = ["a", "b"]' in out
+
+    def test_yes_saves_to_config_path(self, monkeypatch, tmp_path):
+        cfg = tmp_path / 'lemongrass.toml'
+        cfg.write_text('')
+        monkeypatch.setenv('LEMONGRASS_CONFIG', str(cfg))
+        monkeypatch.setattr('builtins.input', lambda *_: 'y')
+        _mod._maybe_save_terms(_refine_result(terms=('a',)))
+        data = tomllib.loads(cfg.read_text())
+        assert data['races']['backfill']['search_terms'] == ['a']
+
+    def test_default_answer_is_no(self, monkeypatch, tmp_path):
+        cfg = tmp_path / 'lemongrass.toml'
+        cfg.write_text('')
+        monkeypatch.setenv('LEMONGRASS_CONFIG', str(cfg))
+        monkeypatch.setattr('builtins.input', lambda *_: '')
+        _mod._maybe_save_terms(_refine_result())
+        assert cfg.read_text() == ''
+
+    def test_eof_on_prompt_treated_as_no(self, monkeypatch, tmp_path):
+        cfg = tmp_path / 'lemongrass.toml'
+        cfg.write_text('')
+        monkeypatch.setenv('LEMONGRASS_CONFIG', str(cfg))
+
+        def _eof(*_):
+            raise EOFError
+        monkeypatch.setattr('builtins.input', _eof)
+        _mod._maybe_save_terms(_refine_result())
+        assert cfg.read_text() == ''
+
+    def test_failed_save_falls_back_to_snippet(self, monkeypatch, tmp_path, capsys):
+        monkeypatch.setenv('LEMONGRASS_CONFIG', str(tmp_path / 'nope' / 'x.toml'))
+        monkeypatch.setattr('builtins.input', lambda *_: 'y')
+        _mod._maybe_save_terms(_refine_result(terms=('a',)))
+        assert '[races.backfill]' in capsys.readouterr().out

--- a/tests/test_race_backfill.py
+++ b/tests/test_race_backfill.py
@@ -699,7 +699,7 @@ class TestMainTokenResolution:
             with patch.object(sys, 'argv', ['race-backfill']):
                 with patch('lemongrass.race_backfill.RaceMonitorClient') as mock_rm_cls:
                     mock_rm_cls.return_value.__enter__.return_value = MagicMock()
-                    with patch.object(_mod, 'find_matching_races', return_value=[]):
+                    with patch.object(_mod, 'search_races_by_term', return_value={'term': []}):
                         with patch.object(_mod, 'run_backfill', return_value=[]):
                             _mod.main()
         mock_rm_cls.assert_called_once_with(api_token=['TOKEN1', 'TOKEN2'])
@@ -812,8 +812,9 @@ class TestMain:
             with patch.object(sys, 'argv', ['race-backfill', '--validate']):
                 with patch('lemongrass.race_backfill.RaceMonitorClient') as mk_rm:
                     mk_rm.return_value.__enter__.return_value = MagicMock()
-                    with patch.object(_mod, 'find_matching_races',
-                                      return_value=[_make_race(101, 'R', EPOC_2022)]):
+                    with patch.object(
+                            _mod, 'search_races_by_term',
+                            return_value={'term': [_make_race(101, 'R', EPOC_2022)]}):
                         with patch('lemongrass._influx.connect') as mk_connect:
                             mk_connect.return_value.__enter__.return_value = MagicMock()
                             with patch.object(_mod, 'validate_backfill',
@@ -825,6 +826,7 @@ class TestMain:
     def test_validate_dispatches_and_exits_0_when_ok(self):
         exc, mk_val = self._run_validate_main(ok=True)
         mk_val.assert_called_once()
+        assert mk_val.call_args.args[0] == ['101']
         assert exc.value.code == 0
 
     def test_validate_exits_1_when_not_ok(self):
@@ -836,7 +838,7 @@ class TestMain:
             with patch.object(sys, 'argv', ['race-backfill']):
                 with patch('lemongrass.race_backfill.RaceMonitorClient') as mk_rm:
                     mk_rm.return_value.__enter__.return_value = MagicMock()
-                    with patch.object(_mod, 'find_matching_races', return_value=[]):
+                    with patch.object(_mod, 'search_races_by_term', return_value={'term': []}):
                         with patch.object(_mod, 'run_backfill', return_value=['101']):
                             with pytest.raises(SystemExit) as exc:
                                 _mod.main()
@@ -880,7 +882,8 @@ class TestMainConfiguresLogging:
                 with patch.object(sys, 'argv', ['race-backfill']):
                     with patch('lemongrass.race_backfill.RaceMonitorClient') as mock_rm_cls:
                         mock_rm_cls.return_value.__enter__.return_value = MagicMock()
-                        with patch.object(_mod, 'find_matching_races', return_value=[]):
+                        with patch.object(_mod, 'search_races_by_term',
+                                          return_value={'term': []}):
                             with patch.object(_mod, 'run_backfill', return_value=[]):
                                 _mod.main()
             assert root.level == logging.INFO

--- a/tests/test_race_backfill.py
+++ b/tests/test_race_backfill.py
@@ -966,6 +966,34 @@ class TestSaveSearchTerms:
             assert _mod._save_search_terms(str(missing), ('a',)) is False
         assert any('could not save' in r.message for r in caplog.records)
 
+    def test_failed_write_leaves_original_intact_and_no_temp_files(
+            self, tmp_path, monkeypatch, caplog):
+        cfg = tmp_path / 'lemongrass.toml'
+        original = '[races.backfill]\nsearch_terms = ["old"]\n'
+        cfg.write_text(original)
+
+        def _boom(*_):
+            raise OSError('disk full')
+        monkeypatch.setattr(os, 'replace', _boom)
+        with caplog.at_level(logging.WARNING):
+            assert _mod._save_search_terms(str(cfg), ('a',)) is False
+        assert cfg.read_text() == original
+        assert list(tmp_path.iterdir()) == [cfg]
+
+    def test_preserves_file_mode(self, tmp_path):
+        cfg = tmp_path / 'lemongrass.toml'
+        cfg.write_text('')
+        os.chmod(cfg, 0o644)
+        assert _mod._save_search_terms(str(cfg), ('a',)) is True
+        assert os.stat(cfg).st_mode & 0o777 == 0o644
+
+    def test_bare_filename_saves_relative_to_cwd(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / 'lemongrass.toml').write_text('')
+        assert _mod._save_search_terms('lemongrass.toml', ('a',)) is True
+        data = tomllib.loads((tmp_path / 'lemongrass.toml').read_text())
+        assert data['races']['backfill']['search_terms'] == ['a']
+
 
 class TestMaybeSaveTerms:
     def test_unchanged_terms_never_prompt(self, monkeypatch, capsys):
@@ -983,6 +1011,15 @@ class TestMaybeSaveTerms:
         out = capsys.readouterr().out
         assert '[races.backfill]' in out
         assert 'search_terms = ["a", "b"]' in out
+
+    def test_snippet_escapes_toml_special_characters(self, monkeypatch, capsys):
+        monkeypatch.delenv('LEMONGRASS_CONFIG', raising=False)
+        terms = ('say "hi"', 'back\\slash')
+        _mod._maybe_save_terms(_refine_result(terms=terms))
+        out = capsys.readouterr().out
+        snippet = out[out.index('[races.backfill]'):]
+        data = tomllib.loads(snippet)
+        assert data['races']['backfill']['search_terms'] == list(terms)
 
     def test_yes_saves_to_config_path(self, monkeypatch, tmp_path):
         cfg = tmp_path / 'lemongrass.toml'

--- a/tests/test_race_backfill.py
+++ b/tests/test_race_backfill.py
@@ -108,6 +108,46 @@ class TestFindMatchingRaces:
         assert [r['ID'] for r in races] == [1, 2]
 
 
+class TestSearchRacesByTerm:
+    def _client(self, responses_by_term):
+        client = MagicMock()
+        client.results.search_results.side_effect = lambda term: {
+            'Races': responses_by_term.get(term, [])
+        }
+        return client
+
+    def test_one_search_call_per_term_in_order(self):
+        client = self._client({})
+        _mod.search_races_by_term(client, ('alpha', 'beta'), start_epoc=EPOC_2021)
+        called = [c.args[0] for c in client.results.search_results.call_args_list]
+        assert called == ['alpha', 'beta']
+
+    def test_filters_races_before_start_epoc(self):
+        client = self._client({'alpha': [_make_race(1, 'old', EPOC_2020),
+                                         _make_race(2, 'new', EPOC_2022)]})
+        by_term = _mod.search_races_by_term(client, ('alpha',), start_epoc=EPOC_2021)
+        assert [r['ID'] for r in by_term['alpha']] == [2]
+
+    def test_keeps_per_term_attribution_without_dedup(self):
+        shared = _make_race(2, 'shared', EPOC_2022)
+        client = self._client({'alpha': [shared], 'beta': [shared]})
+        by_term = _mod.search_races_by_term(client, ('alpha', 'beta'),
+                                            start_epoc=EPOC_2021)
+        assert by_term['alpha'] == [shared]
+        assert by_term['beta'] == [shared]
+
+
+class TestMergeRaces:
+    def test_dedups_by_id_and_sorts_by_start_date(self):
+        by_term = {
+            'alpha': [_make_race(2, 'later', EPOC_2022),
+                      _make_race(1, 'early', EPOC_2021)],
+            'beta': [_make_race(2, 'later', EPOC_2022)],
+        }
+        merged = _mod.merge_races(by_term)
+        assert [r['ID'] for r in merged] == [1, 2]
+
+
 class TestRunBackfill:
     def _races(self):
         return [

--- a/uv.lock
+++ b/uv.lock
@@ -147,12 +147,15 @@ dependencies = [
     { name = "obd" },
     { name = "pandas" },
     { name = "race-monitor" },
+    { name = "textual" },
+    { name = "tomlkit" },
     { name = "urllib3" },
 ]
 
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 
@@ -162,13 +165,66 @@ requires-dist = [
     { name = "obd", specifier = "~=0.7" },
     { name = "pandas", specifier = "~=3.0" },
     { name = "race-monitor", specifier = ">=1.0,<2.0" },
+    { name = "textual", specifier = "~=8.2" },
+    { name = "tomlkit", specifier = "~=0.15" },
     { name = "urllib3", specifier = ">=2" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=8" },
+    { name = "pytest-asyncio", specifier = ">=1.4.0" },
     { name = "ruff", specifier = ">=0.14,<1.0" },
+]
+
+[[package]]
+name = "linkify-it-py"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -465,6 +521,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -502,6 +571,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.20"
 source = { registry = "https://pypi.org/simple" }
@@ -536,6 +618,32 @@ wheels = [
 ]
 
 [[package]]
+name = "textual"
+version = "8.2.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/21/39a76b01bd5eea82a04baaca7580e105d8c59450df03998345bb2cfb307b/textual-8.2.8.tar.gz", hash = "sha256:3f106a9fbc73e39dd266c9712432087de78a6d644084c7c241d6a25c3169115b", size = 1860502, upload-time = "2026-06-30T06:51:24.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/be/35261223d9416a0751cdff1c7b4a6f881387218a12d439fe22fefebc8c04/textual-8.2.8-py3-none-any.whl", hash = "sha256:267375fd402dc8d981457212efa71f0e3365fd17bba144ba9bb3ed7563cb374a", size = 731418, upload-time = "2026-06-30T06:51:26.364Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/db/03eaf4331631ef6b27d6e3c9b68c54dc6f0d63d87201fed600cc409307fd/tomlkit-0.15.0.tar.gz", hash = "sha256:7d1a9ecba3086638211b13814ea79c90dd54dd11993564376f3aa92271f5c7a3", size = 161875, upload-time = "2026-05-10T07:38:22.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl", hash = "sha256:4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738", size = 41328, upload-time = "2026-05-10T07:38:23.517Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -551,6 +659,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

When `lemongrass race-backfill` runs in a terminal, it now opens an interactive two-pane TUI (Textual) between race discovery and the backfill itself: the matched races appear as a checklist (all pre-selected), and search terms can be added or removed live before confirming which races to process.

- **Race checklist** (right pane): one row per race (`date  name  #id`), space toggles, `a` selects all, `i` inverts, live "N of M selected" count. `Enter` confirms — so a plain Enter keeps the old backfill-everything behavior. `q`/`Esc`/Ctrl-C cancels (exit 0, nothing written).
- **Search terms** (left pane): terms from `races.backfill.search_terms` seed the list. Typing a new term runs a live RaceMonitor search on the shared client (same rate-limiter window as discovery) in a background worker; results merge in pre-checked, preserving existing selections. `d` removes a term, dropping races matched only by it. Per-term results are session-cached, so re-adding a removed term costs no API call. The `--start-date` filter applies to in-TUI results too.
- **Term persistence**: on confirm with changed terms, offers a y/N prompt to rewrite `races.backfill.search_terms` in the file named by `LEMONGRASS_CONFIG` — tomlkit preserves comments, formatting, and unrelated keys, and the write is atomic (temp file + rename, keeping the original file mode) so a crash mid-save can't truncate the config. Without `LEMONGRASS_CONFIG`, it prints a paste-able TOML snippet (tomlkit-escaped, so terms containing quotes or backslashes stay valid) instead of writing a file (config loading has no default path). A failed save warns, prints the snippet, and never blocks the run.
- **Scope**: the TUI wraps the discovery paths (default backfill, `--dry-run`, `--validate` — each operates on the refined selection). Non-TTY runs (cron, pipes) skip the TUI entirely and never import textual; `--upgrade-stored` is unchanged.

Internally, `find_matching_races()` is split into `search_races_by_term()` + `merge_races()` (preserving per-term attribution the term-removal logic needs; the original function remains as a thin wrapper), and all selection/merge state lives in a UI-free `RaceListModel` so the behavior is unit-testable without Textual.

New dependencies: `textual~=8.2`, `tomlkit~=0.15` (runtime), `pytest-asyncio` (dev).

## Test plan

- `RaceListModel` unit tests: dedup/date-sort/filter, check-state preservation across term add/remove, session cache, select-all/invert.
- Textual pilot tests (headless): toggle/confirm/cancel flows, live term search (mocked client), search-failure notification, remove-term, cache re-add without a client call, worker-cancel guard.
- `main()` wiring tests: non-TTY skips the TUI and backfills all races; TTY cancel exits 0 without backfilling; TTY confirm backfills/validates only the selected subset.
- Save-flow tests: comment/key preservation via real file round-trips, missing-table creation, crash-safety (failed write leaves the original intact, no temp files left), file-mode preservation, bare-filename paths, snippet escaping, default-no/EOF-no prompt semantics, failed-save snippet fallback.
- Full suite: 739 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
